### PR TITLE
Add contact us command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -130,6 +130,7 @@ Commands are organized into logical categories for better usability:
   - **🔧 Utilities**: Cache management and data operations
   - **👤 Admin Commands**: Administrative tools (admin only)
   - **❓ Help**: Direct access to help information
+  - **✉️ Contact Us**: Send a message to the bot admins
 
 ### Help Command
 
@@ -143,6 +144,7 @@ All users can access these commands:
 
 - **`/help`** - Show help message with commands organized by categories
 - **`/menu`** - Show interactive menu with organized command categories
+- **`/contact_us`** - Send a message to the bot admins
 
 #### Team Management
 

--- a/src/commandsHandler/contactUsHandler.js
+++ b/src/commandsHandler/contactUsHandler.js
@@ -1,0 +1,42 @@
+const { sendMessageToAdmins, getChatName } = require('../utils');
+
+// Track pending contact requests by chatId -> messageId
+const awaitingContactMessages = {};
+
+async function handleContactUsCommand(bot, msg) {
+  const chatId = msg.chat.id;
+  const sent = await bot.sendMessage(chatId, 'Please write your message for the admins:', {
+    reply_markup: { force_reply: true },
+  });
+
+  awaitingContactMessages[chatId] = sent.message_id;
+}
+
+async function processContactUsResponse(bot, msg) {
+  const chatId = msg.chat.id;
+  const expectedId = awaitingContactMessages[chatId];
+
+  if (
+    expectedId &&
+    msg.reply_to_message &&
+    msg.reply_to_message.message_id === expectedId
+  ) {
+    const chatName = getChatName(msg);
+    await sendMessageToAdmins(
+      bot,
+      `Contact from ${chatName} (${chatId}):\n${msg.text}`
+    );
+    await bot.sendMessage(chatId, 'Your message was sent to the admins. Thank you!');
+    delete awaitingContactMessages[chatId];
+
+    return true;
+  }
+
+  return false;
+}
+
+module.exports = {
+  handleContactUsCommand,
+  processContactUsResponse,
+  awaitingContactMessages,
+};

--- a/src/commandsHandler/contactUsHandler.test.js
+++ b/src/commandsHandler/contactUsHandler.test.js
@@ -1,0 +1,59 @@
+const {
+  handleContactUsCommand,
+  processContactUsResponse,
+  awaitingContactMessages,
+} = require('./contactUsHandler');
+const { sendMessageToAdmins, getChatName } = require('../utils');
+
+jest.mock('../utils', () => ({
+  sendMessageToAdmins: jest.fn(),
+  getChatName: jest.fn().mockReturnValue('User'),
+}));
+
+describe('contactUsHandler', () => {
+  const botMock = { sendMessage: jest.fn().mockResolvedValue({ message_id: 1 }) };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.keys(awaitingContactMessages).forEach((key) => delete awaitingContactMessages[key]);
+  });
+
+  it('handleContactUsCommand sends prompt and stores message id', async () => {
+    const msg = { chat: { id: 123 } };
+
+    await handleContactUsCommand(botMock, msg);
+
+    expect(botMock.sendMessage).toHaveBeenCalledWith(123, expect.any(String), {
+      reply_markup: { force_reply: true },
+    });
+    expect(awaitingContactMessages[123]).toBe(1);
+  });
+
+  it('processContactUsResponse forwards message when reply matches', async () => {
+    awaitingContactMessages[123] = 1;
+    const msg = { chat: { id: 123 }, text: 'hi', reply_to_message: { message_id: 1 } };
+
+    const res = await processContactUsResponse(botMock, msg);
+
+    expect(res).toBe(true);
+    expect(sendMessageToAdmins).toHaveBeenCalledWith(
+      botMock,
+      expect.stringContaining('hi')
+    );
+    expect(botMock.sendMessage).toHaveBeenCalledWith(
+      123,
+      expect.any(String)
+    );
+    expect(awaitingContactMessages[123]).toBeUndefined();
+  });
+
+  it('processContactUsResponse returns false for non matching reply', async () => {
+    awaitingContactMessages[123] = 2;
+    const msg = { chat: { id: 123 }, text: 'no', reply_to_message: { message_id: 1 } };
+
+    const res = await processContactUsResponse(botMock, msg);
+
+    expect(res).toBe(false);
+    expect(sendMessageToAdmins).not.toHaveBeenCalled();
+  });
+});

--- a/src/commandsHandler/index.js
+++ b/src/commandsHandler/index.js
@@ -14,6 +14,10 @@ const { resetCacheForChat } = require('./resetCacheHandler');
 const { handleScrapingTrigger } = require('./scrapingTriggerHandler');
 const { handleBillingStats } = require('./billingStatsHandler');
 const { displayMenuMessage } = require('./menuHandler');
+const {
+  handleContactUsCommand,
+  processContactUsResponse,
+} = require('./contactUsHandler');
 
 module.exports = {
   handleBestTeamsMessage,
@@ -31,4 +35,6 @@ module.exports = {
   handleScrapingTrigger,
   handleBillingStats,
   displayMenuMessage,
+  handleContactUsCommand,
+  processContactUsResponse,
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -28,6 +28,7 @@ exports.COMMAND_GET_BOTFATHER_COMMANDS = '/get_botfather_commands';
 exports.COMMAND_NEXT_RACE_INFO = '/next_race_info';
 exports.COMMAND_BILLING_STATS = '/billing_stats';
 exports.COMMAND_MENU = '/menu';
+exports.COMMAND_CONTACT_US = '/contact_us';
 
 // Menu configuration for interactive menu command
 exports.MENU_CATEGORIES = {
@@ -46,6 +47,11 @@ exports.MENU_CATEGORIES = {
         constant: exports.COMMAND_MENU,
         title: '📱 Menu',
         description: 'Show interactive menu with all available commands.',
+      },
+      {
+        constant: exports.COMMAND_CONTACT_US,
+        title: '✉️ Contact Us',
+        description: 'Send a message to the bot admins.',
       },
     ],
   },

--- a/src/messageHandler.js
+++ b/src/messageHandler.js
@@ -5,16 +5,33 @@ const {
 } = require('./utils/utils');
 const { handleTextMessage } = require('./textMessageHandler');
 const { handlePhotoMessage } = require('./photoMessageHandler');
+const {
+  handleContactUsCommand,
+  processContactUsResponse,
+} = require('./commandsHandler/contactUsHandler');
+const { COMMAND_CONTACT_US } = require('./constants');
 
 exports.handleMessage = async function (bot, msg) {
   const chatId = msg.chat.id;
   const chatName = getChatName(msg);
 
   if (!isAdminMessage(msg)) {
-    await sendLogMessage(
-      bot,
-      `Message from unknown chat: ${chatName} (${chatId})`
-    );
+    if (msg.text === COMMAND_CONTACT_US) {
+      await handleContactUsCommand(bot, msg);
+
+      return;
+    }
+
+    const handled = msg.text
+      ? await processContactUsResponse(bot, msg)
+      : false;
+
+    if (!handled) {
+      await sendLogMessage(
+        bot,
+        `Message from unknown chat: ${chatName} (${chatId})`
+      );
+    }
 
     return;
   }

--- a/src/messageHandler.test.js
+++ b/src/messageHandler.test.js
@@ -8,6 +8,13 @@ jest.mock('./utils/utils', () => ({
   isAdminMessage: mockIsAdmin,
 }));
 
+const mockHandleContactUsCommand = jest.fn();
+const mockProcessContactUsResponse = jest.fn();
+jest.mock('./commandsHandler/contactUsHandler', () => ({
+  handleContactUsCommand: mockHandleContactUsCommand,
+  processContactUsResponse: mockProcessContactUsResponse,
+}));
+
 const { handleMessage } = require('./messageHandler');
 const { sendLogMessage } = require('./utils/utils');
 
@@ -56,6 +63,31 @@ describe('handleMessage', () => {
       botMock,
       'Message from unknown chat: Unknown (123456)'
     );
+  });
+
+  it('should handle /contact_us command from unknown sender', async () => {
+    const msgMock = {
+      chat: { id: 123456 },
+      text: '/contact_us',
+    };
+
+    await handleMessage(botMock, msgMock);
+
+    expect(mockHandleContactUsCommand).toHaveBeenCalledWith(botMock, msgMock);
+    expect(sendLogMessage).not.toHaveBeenCalled();
+  });
+
+  it('should process contact reply when from unknown sender', async () => {
+    const msgMock = {
+      chat: { id: 123456 },
+      text: 'hi there',
+    };
+    mockProcessContactUsResponse.mockResolvedValue(true);
+
+    await handleMessage(botMock, msgMock);
+
+    expect(mockProcessContactUsResponse).toHaveBeenCalledWith(botMock, msgMock);
+    expect(sendLogMessage).not.toHaveBeenCalled();
   });
 
   it('when got unsupported message', async () => {

--- a/src/textMessageHandler.js
+++ b/src/textMessageHandler.js
@@ -15,6 +15,7 @@ const {
   handleNextRaceInfoCommand,
   handleBillingStats,
   displayMenuMessage,
+  handleContactUsCommand,
 } = require('./commandsHandler');
 
 // Import constants
@@ -32,6 +33,7 @@ const {
   COMMAND_NEXT_RACE_INFO,
   COMMAND_BILLING_STATS,
   COMMAND_MENU,
+  COMMAND_CONTACT_US,
 } = require('./constants');
 
 exports.handleTextMessage = async function (bot, msg) {
@@ -72,6 +74,8 @@ exports.handleTextMessage = async function (bot, msg) {
       return await handleBillingStats(bot, msg);
     case msg.text === COMMAND_MENU:
       return await displayMenuMessage(bot, msg);
+    case msg.text === COMMAND_CONTACT_US:
+      return await handleContactUsCommand(bot, msg);
     default:
       handleJsonMessage(bot, msg, chatId);
       break;

--- a/src/textMessageHandler.test.js
+++ b/src/textMessageHandler.test.js
@@ -11,6 +11,7 @@ const {
   COMMAND_GET_BOTFATHER_COMMANDS,
   COMMAND_NEXT_RACE_INFO,
   COMMAND_CHIPS,
+  COMMAND_CONTACT_US,
 } = require('./constants');
 
 // Mock all command handlers
@@ -41,6 +42,7 @@ const {
 const {
   handleNextRaceInfoCommand,
 } = require('./commandsHandler/nextRaceInfoHandler');
+const { handleContactUsCommand } = require('./commandsHandler/contactUsHandler');
 
 jest.mock('./commandsHandler/numberInputHandler');
 jest.mock('./commandsHandler/jsonInputHandler');
@@ -55,6 +57,7 @@ jest.mock('./commandsHandler/loadSimulationHandler');
 jest.mock('./commandsHandler/scrapingTriggerHandler');
 jest.mock('./commandsHandler/getBotfatherCommandsHandler');
 jest.mock('./commandsHandler/nextRaceInfoHandler');
+jest.mock('./commandsHandler/contactUsHandler');
 
 const { handleTextMessage } = require('./textMessageHandler');
 
@@ -219,6 +222,18 @@ describe('handleTextMessage', () => {
         botMock,
         KILZI_CHAT_ID
       );
+      expect(handleJsonMessage).not.toHaveBeenCalled();
+    });
+
+    it('should route /contact_us command to handleContactUsCommand', async () => {
+      const msgMock = {
+        chat: { id: KILZI_CHAT_ID },
+        text: COMMAND_CONTACT_US,
+      };
+
+      await handleTextMessage(botMock, msgMock);
+
+      expect(handleContactUsCommand).toHaveBeenCalledWith(botMock, msgMock);
       expect(handleJsonMessage).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary
- add /contact_us command constant and help docs
- implement contact message handler and export it
- integrate contact command in message routing
- support contact command in text routing
- update README with new command
- add tests for new functionality

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a30dc8b008326ab0ca4c3378419ea