### PR TITLE
Centralize user messaging helper

### DIFF
--- a/src/callbackQueryHandler.js
+++ b/src/callbackQueryHandler.js
@@ -22,7 +22,7 @@ const {
   COMMAND_BEST_TEAMS,
 } = require('./constants');
 
-const { sendLogMessage } = require('./utils');
+const { sendLogMessage, sendMessageToUser } = require('./utils');
 const { handleMenuCallback } = require('./commandsHandler/menuHandler');
 const { t, setLanguage, getLanguageName } = require('./i18n');
 
@@ -78,18 +78,17 @@ async function handlePhotoCallback(bot, query) {
     await storeInCache(bot, chatId, type, extractedData);
     delete bestTeamsCache[chatId];
 
-    await bot
-      .sendMessage(chatId, getPrintableCache(chatId, type), {
-        parse_mode: 'Markdown',
-      })
+    await sendMessageToUser(bot, chatId, getPrintableCache(chatId, type), {
+      parse_mode: 'Markdown',
+    })
       .catch((err) => console.error('Error sending extracted data:', err));
   } catch (err) {
     console.error('Error extracting data from photo:', err);
-    await bot
-      .sendMessage(
-        chatId,
-        t('An error occurred while extracting data from the photo.', chatId)
-      )
+    await sendMessageToUser(
+      bot,
+      chatId,
+      t('An error occurred while extracting data from the photo.', chatId)
+    )
       .catch((err) =>
         console.error('Error sending extraction error message:', err)
       );

--- a/src/callbackQueryHandler.test.js
+++ b/src/callbackQueryHandler.test.js
@@ -18,6 +18,9 @@ const { t, getLanguage, languageCache, getLanguageName } = require('./i18n');
 
 jest.mock('./utils', () => ({
   sendLogMessage: jest.fn().mockResolvedValue(undefined),
+  sendMessageToUser: jest.fn((bot, chatId, msg, opts) =>
+    opts !== undefined ? bot.sendMessage(chatId, msg, opts) : bot.sendMessage(chatId, msg)
+  ),
 }));
 
 jest.mock('openai', () => ({

--- a/src/commandsHandler/askHandler.js
+++ b/src/commandsHandler/askHandler.js
@@ -1,7 +1,7 @@
 const { AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY, AZURE_OPEN_AI_MODEL } = process.env;
 const { AzureOpenAI } = require('openai');
 const { t } = require('../i18n');
-const { sendLogMessage } = require('../utils');
+const { sendLogMessage, sendMessageToUser } = require('../utils');
 const { handleNumberMessage } = require('./numberInputHandler');
 const { executeCommand } = require('./commandHandlers');
 
@@ -21,7 +21,8 @@ async function handleAskCommand(bot, msg) {
   const text = msg.text.trim();
 
   if (!text) {
-    await bot.sendMessage(
+    await sendMessageToUser(
+      bot,
       chatId,
       t('Please provide a question.', chatId)
     );
@@ -40,7 +41,7 @@ async function handleAskCommand(bot, msg) {
     });
   } catch (error) {
     await sendLogMessage(bot, `AzureOpenAI error: ${error.message}`);
-    await bot.sendMessage(chatId, t('Error executing command', chatId));
+    await sendMessageToUser(bot, chatId, t('Error executing command', chatId));
 
     return;
   }
@@ -57,7 +58,7 @@ async function handleAskCommand(bot, msg) {
       bot,
       `Failed to parse AI response: ${completion.choices[0].message.content}`
     );
-    await bot.sendMessage(chatId, t('Error executing command', chatId));
+    await sendMessageToUser(bot, chatId, t('Error executing command', chatId));
 
     return;
   }

--- a/src/commandsHandler/bestTeamsHandler.js
+++ b/src/commandsHandler/bestTeamsHandler.js
@@ -9,6 +9,7 @@ const {
   sharedKey,
 } = require('../cache');
 const { t } = require('../i18n');
+const { sendMessageToUser } = require('../utils');
 
 async function handleBestTeamsMessage(bot, chatId) {
   // Try to fetch cached data for this chat
@@ -18,11 +19,11 @@ async function handleBestTeamsMessage(bot, chatId) {
   const currentTeam = currentTeamCache[chatId];
 
   if (!drivers || !constructors || !currentTeam) {
-    await bot
-      .sendMessage(
-        chatId,
-        t('Missing cached data. Please send images or JSON data for drivers, constructors, and current team first.', chatId)
-      )
+    await sendMessageToUser(
+      bot,
+      chatId,
+      t('Missing cached data. Please send images or JSON data for drivers, constructors, and current team first.', chatId)
+    )
       .catch((err) =>
         console.error('Error sending cache unavailable message:', err)
       );
@@ -97,15 +98,14 @@ async function handleBestTeamsMessage(bot, chatId) {
     })
     .join('\n\n');
 
-  await bot
-    .sendMessage(chatId, messageMarkdown, { parse_mode: 'Markdown' })
+  await sendMessageToUser(bot, chatId, messageMarkdown, { parse_mode: 'Markdown' })
     .catch((err) => console.error('Error sending JSON reply:', err));
 
-  await bot
-    .sendMessage(
-      chatId,
-      t('Please send a number to get the required changes to that team.', chatId)
-    )
+  await sendMessageToUser(
+    bot,
+    chatId,
+    t('Please send a number to get the required changes to that team.', chatId)
+  )
     .catch((err) =>
       console.error('Error sending number request message:', err)
     );

--- a/src/commandsHandler/bestTeamsHandler.test.js
+++ b/src/commandsHandler/bestTeamsHandler.test.js
@@ -4,6 +4,11 @@ const mockValidateJsonData = jest.fn().mockReturnValue(true);
 
 jest.mock('../utils', () => ({
   validateJsonData: mockValidateJsonData,
+  sendMessageToUser: jest.fn((bot, chatId, msg, opts) =>
+    opts !== undefined
+      ? bot.sendMessage(chatId, msg, opts)
+      : bot.sendMessage(chatId, msg)
+  ),
 }));
 
 const { calculateBestTeams } = require('../bestTeamsCalculator');

--- a/src/commandsHandler/billingStatsHandler.js
+++ b/src/commandsHandler/billingStatsHandler.js
@@ -1,5 +1,5 @@
 const { getMonthlyBillingStats } = require('../azureBillingService');
-const { sendLogMessage, isAdminMessage } = require('../utils/utils');
+const { sendLogMessage, isAdminMessage, sendMessageToUser } = require('../utils/utils');
 const { t } = require('../i18n');
 
 /**
@@ -11,7 +11,8 @@ async function handleBillingStats(bot, msg) {
   const chatId = msg.chat.id;
 
   if (!isAdminMessage(msg)) {
-    await bot.sendMessage(
+    await sendMessageToUser(
+      bot,
       chatId,
       t('Sorry, only admins can access billing statistics.', chatId)
     );
@@ -27,8 +28,7 @@ async function handleBillingStats(bot, msg) {
     const billingMessage = formatBillingMessage(billingData, chatId);
 
     // Send the formatted billing statistics
-    await bot
-      .sendMessage(chatId, billingMessage, { parse_mode: 'Markdown' })
+    await sendMessageToUser(bot, chatId, billingMessage, { parse_mode: 'Markdown' })
       .catch((err) =>
         console.error('Error sending billing stats message:', err)
       );
@@ -36,17 +36,17 @@ async function handleBillingStats(bot, msg) {
     console.error('Error in handleBillingStats:', error);
     await sendLogMessage(bot, `Error fetching billing stats: ${error.message}`);
 
-    await bot
-      .sendMessage(
+    await sendMessageToUser(
+      bot,
+      chatId,
+      t(
+        '❌ Error fetching billing statistics: {ERROR}\n\nPlease check your Azure configuration and permissions.',
         chatId,
-        t(
-          '❌ Error fetching billing statistics: {ERROR}\n\nPlease check your Azure configuration and permissions.',
-          chatId,
-          {
-            ERROR: error.message,
-          }
-        )
+        {
+          ERROR: error.message,
+        }
       )
+    )
       .catch((err) =>
         console.error('Error sending billing error message:', err)
       );

--- a/src/commandsHandler/billingStatsHandler.test.js
+++ b/src/commandsHandler/billingStatsHandler.test.js
@@ -4,7 +4,13 @@ const { sendLogMessage, isAdminMessage } = require('../utils/utils');
 
 // Mock the dependencies
 jest.mock('../azureBillingService');
-jest.mock('../utils/utils');
+jest.mock('../utils/utils', () => ({
+  sendMessageToUser: jest.fn((bot, chatId, msg, opts) =>
+    opts !== undefined ? bot.sendMessage(chatId, msg, opts) : bot.sendMessage(chatId, msg)
+  ),
+  sendLogMessage: jest.fn(),
+  isAdminMessage: jest.fn(),
+}));
 
 describe('billingStatsHandler', () => {
   let mockBot;

--- a/src/commandsHandler/chipsHandler.js
+++ b/src/commandsHandler/chipsHandler.js
@@ -6,13 +6,14 @@ const {
   WITHOUT_CHIP,
 } = require('../constants');
 const { t } = require('../i18n');
+const { sendMessageToUser } = require('../utils');
 
 async function handleChipsMessage(bot, msg) {
   const chatId = msg.chat.id;
   const messageId = msg.message_id;
 
   // Reply with inline buttons
-  await bot.sendMessage(chatId, t('which chip do you want to use?', chatId), {
+  await sendMessageToUser(bot, chatId, t('which chip do you want to use?', chatId), {
     reply_to_message_id: messageId,
     reply_markup: {
       inline_keyboard: [

--- a/src/commandsHandler/chipsHandler.test.js
+++ b/src/commandsHandler/chipsHandler.test.js
@@ -136,7 +136,7 @@ describe('handleChipsMessage', () => {
     expect(sentMessage[2].reply_to_message_id).toBe(originalMessageId);
   });
 
-  it('should propagate sendMessage errors', async () => {
+  it('should handle sendMessage errors gracefully', async () => {
     const msgMock = {
       chat: { id: KILZI_CHAT_ID },
       message_id: 123,
@@ -145,12 +145,9 @@ describe('handleChipsMessage', () => {
 
     botMock.sendMessage.mockRejectedValueOnce(new Error('Network error'));
 
-    // Should propagate the error since there's no error handling
-    await expect(handleChipsMessage(botMock, msgMock)).rejects.toThrow(
-      'Network error'
-    );
+    await handleChipsMessage(botMock, msgMock);
 
-    expect(botMock.sendMessage).toHaveBeenCalledTimes(1);
+    expect(botMock.sendMessage).toHaveBeenCalledTimes(2);
   });
 
   it('should work with different chat IDs and message IDs', async () => {

--- a/src/commandsHandler/currentTeamInfoHandler.js
+++ b/src/commandsHandler/currentTeamInfoHandler.js
@@ -6,6 +6,7 @@ const {
   sharedKey,
 } = require('../cache');
 const { t } = require('../i18n');
+const { sendMessageToUser } = require('../utils');
 
 async function calcCurrentTeamInfo(bot, chatId) {
   const drivers = driversCache[chatId] || driversCache[sharedKey];
@@ -14,14 +15,14 @@ async function calcCurrentTeamInfo(bot, chatId) {
   const currentTeam = currentTeamCache[chatId];
 
   if (!drivers || !constructors || !currentTeam) {
-    await bot
-      .sendMessage(
-        chatId,
-        t(
-          'Missing cached data. Please send images or JSON data for drivers, constructors, and current team first.',
-          chatId
-        )
+    await sendMessageToUser(
+      bot,
+      chatId,
+      t(
+        'Missing cached data. Please send images or JSON data for drivers, constructors, and current team first.',
+        chatId
       )
+    )
       .catch((err) =>
         console.error('Error sending cache unavailable message:', err)
       );
@@ -39,8 +40,7 @@ async function calcCurrentTeamInfo(bot, chatId) {
     `*${t('Expected Points', chatId)}:* ${teamInfo.teamExpectedPoints.toFixed(2)}\n` +
     `*${t('Expected Price Change', chatId)}:* ${teamInfo.teamPriceChange.toFixed(2)}`;
 
-  await bot
-    .sendMessage(chatId, message, { parse_mode: 'Markdown' })
+  await sendMessageToUser(bot, chatId, message, { parse_mode: 'Markdown' })
     .catch((err) =>
       console.error('Error sending current team info message:', err)
     );

--- a/src/commandsHandler/currentTeamInfoHandler.test.js
+++ b/src/commandsHandler/currentTeamInfoHandler.test.js
@@ -4,6 +4,9 @@ const mockCalculateTeamInfo = jest.fn();
 
 jest.mock('../utils', () => ({
   calculateTeamInfo: mockCalculateTeamInfo,
+  sendMessageToUser: jest.fn((bot, chatId, msg, opts) =>
+    opts !== undefined ? bot.sendMessage(chatId, msg, opts) : bot.sendMessage(chatId, msg)
+  ),
 }));
 
 const {

--- a/src/commandsHandler/getBotfatherCommandsHandler.js
+++ b/src/commandsHandler/getBotfatherCommandsHandler.js
@@ -1,4 +1,4 @@
-const { isAdminMessage } = require('../utils');
+const { isAdminMessage, sendMessageToUser } = require('../utils');
 const { USER_COMMANDS_CONFIG } = require('../constants');
 const { t } = require('../i18n');
 
@@ -6,7 +6,8 @@ async function handleGetBotfatherCommands(bot, msg) {
   const chatId = msg.chat.id;
 
   if (!isAdminMessage(msg)) {
-    await bot.sendMessage(
+    await sendMessageToUser(
+      bot,
       chatId,
       t('Sorry, only admins can get BotFather commands.', chatId)
     );
@@ -18,8 +19,7 @@ async function handleGetBotfatherCommands(bot, msg) {
     (cmd) => `${cmd.constant.substring(1)} - ${cmd.description}`
   ).join('\n');
 
-  await bot
-    .sendMessage(chatId, botFatherCommands)
+  await sendMessageToUser(bot, chatId, botFatherCommands)
     .catch((err) =>
       console.error('Error sending BotFather commands message:', err)
     );

--- a/src/commandsHandler/getBotfatherCommandsHandler.test.js
+++ b/src/commandsHandler/getBotfatherCommandsHandler.test.js
@@ -4,6 +4,9 @@ const mockIsAdminMessage = jest.fn().mockReturnValue(true);
 
 jest.mock('../utils', () => ({
   isAdminMessage: mockIsAdminMessage,
+  sendMessageToUser: jest.fn((bot, chatId, msg, opts) =>
+    opts !== undefined ? bot.sendMessage(chatId, msg, opts) : bot.sendMessage(chatId, msg)
+  ),
 }));
 
 const { handleGetBotfatherCommands } = require('./getBotfatherCommandsHandler');

--- a/src/commandsHandler/getCurrentSimulationHandler.js
+++ b/src/commandsHandler/getCurrentSimulationHandler.js
@@ -1,4 +1,4 @@
-const { isAdminMessage, formatDateTime } = require('../utils');
+const { isAdminMessage, formatDateTime, sendMessageToUser } = require('../utils');
 const {
   driversCache,
   constructorsCache,
@@ -19,7 +19,8 @@ async function handleGetCurrentSimulation(bot, msg) {
 
   // Check if user has data in their cache
   if (drivers || constructors) {
-    await bot.sendMessage(
+    await sendMessageToUser(
+      bot,
       chatId,
       t('You currently have data in your cache. To use data from a simulation, please run {CMD} first.', chatId, { CMD: COMMAND_RESET_CACHE })
     );
@@ -29,7 +30,8 @@ async function handleGetCurrentSimulation(bot, msg) {
 
   const simulationInfo = simulationInfoCache[sharedKey];
   if (!simulationInfo) {
-    await bot.sendMessage(
+    await sendMessageToUser(
+      bot,
       chatId,
       t('No simulation data is currently loaded. Please use {CMD} to load simulation data.', chatId, { CMD: COMMAND_LOAD_SIMULATION })
     );
@@ -39,7 +41,7 @@ async function handleGetCurrentSimulation(bot, msg) {
 
   const printableCache = getPrintableCache(sharedKey);
 
-  await bot.sendMessage(chatId, printableCache, { parse_mode: 'Markdown' });
+  await sendMessageToUser(bot, chatId, printableCache, { parse_mode: 'Markdown' });
   let timeText = t('Unknown', chatId);
   if (simulationInfo.lastUpdate) {
     try {
@@ -52,7 +54,8 @@ async function handleGetCurrentSimulation(bot, msg) {
   }
   const lastUpdateText = t('Last updated: {TIME}', chatId, { TIME: timeText });
 
-  await bot.sendMessage(
+  await sendMessageToUser(
+    bot,
     chatId,
     t('Current simulation: {NAME}\n{UPDATE}', chatId, {
       NAME: simulationInfo.name,
@@ -61,7 +64,8 @@ async function handleGetCurrentSimulation(bot, msg) {
   );
 
   if (isAdminMessage(msg)) {
-    await bot.sendMessage(
+    await sendMessageToUser(
+      bot,
       chatId,
       t(
         '💡 Tip: If the simulation seems outdated, you can run {CMD} to update the current simulation.',

--- a/src/commandsHandler/getCurrentSimulationHandler.test.js
+++ b/src/commandsHandler/getCurrentSimulationHandler.test.js
@@ -13,6 +13,9 @@ const mockFormatDateTime = jest.fn().mockReturnValue({
 jest.mock('../utils', () => ({
   isAdminMessage: mockIsAdminMessage,
   formatDateTime: mockFormatDateTime,
+  sendMessageToUser: jest.fn((bot, chatId, msg, opts) =>
+    opts !== undefined ? bot.sendMessage(chatId, msg, opts) : bot.sendMessage(chatId, msg)
+  ),
 }));
 
 const {

--- a/src/commandsHandler/helpHandler.js
+++ b/src/commandsHandler/helpHandler.js
@@ -1,4 +1,4 @@
-const { isAdminMessage } = require('../utils');
+const { isAdminMessage, sendMessageToUser } = require('../utils');
 const { MENU_CATEGORIES, COMMAND_BEST_TEAMS } = require('../constants');
 const { t } = require('../i18n');
 
@@ -19,8 +19,7 @@ async function displayHelpMessage(bot, msg) {
   // Add other messages section
   helpMessage += buildOtherMessagesSection(chatId);
 
-  await bot
-    .sendMessage(chatId, helpMessage, { parse_mode: 'Markdown' })
+  await sendMessageToUser(bot, chatId, helpMessage, { parse_mode: 'Markdown' })
     .catch((err) => console.error('Error sending help message:', err));
 
   return;

--- a/src/commandsHandler/helpHandler.test.js
+++ b/src/commandsHandler/helpHandler.test.js
@@ -9,6 +9,9 @@ const mockIsAdminMessage = jest.fn().mockReturnValue(false);
 
 jest.mock('../utils', () => ({
   isAdminMessage: mockIsAdminMessage,
+  sendMessageToUser: jest.fn((bot, chatId, msg, opts) =>
+    opts !== undefined ? bot.sendMessage(chatId, msg, opts) : bot.sendMessage(chatId, msg)
+  ),
 }));
 
 const { displayHelpMessage } = require('./helpHandler');

--- a/src/commandsHandler/jsonInputHandler.test.js
+++ b/src/commandsHandler/jsonInputHandler.test.js
@@ -4,6 +4,9 @@ const mockValidateJsonData = jest.fn().mockReturnValue(true);
 
 jest.mock('../utils', () => ({
   validateJsonData: mockValidateJsonData,
+  sendMessageToUser: jest.fn((bot, chatId, msg, opts) =>
+    opts !== undefined ? bot.sendMessage(chatId, msg, opts) : bot.sendMessage(chatId, msg)
+  ),
 }));
 
 const azureStorageService = require('../azureStorageService');

--- a/src/commandsHandler/loadSimulationHandler.js
+++ b/src/commandsHandler/loadSimulationHandler.js
@@ -1,4 +1,4 @@
-const { isAdminMessage } = require('../utils');
+const { isAdminMessage, sendMessageToUser } = require('../utils');
 const { loadSimulationData } = require('../cacheInitializer');
 const { t } = require('../i18n');
 
@@ -6,19 +6,21 @@ async function handleLoadSimulation(bot, msg) {
   const chatId = msg.chat.id;
 
   if (!isAdminMessage(msg)) {
-    await bot.sendMessage(chatId, t('Sorry, only admins can use this command.', chatId));
+    await sendMessageToUser(bot, chatId, t('Sorry, only admins can use this command.', chatId));
 
     return;
   }
 
   try {
     await loadSimulationData(bot);
-    await bot.sendMessage(
+    await sendMessageToUser(
+      bot,
       chatId,
       t('Simulation data fetched and cached successfully.', chatId)
     );
   } catch (error) {
-    await bot.sendMessage(
+    await sendMessageToUser(
+      bot,
       chatId,
       t('Failed to load simulation data: {ERROR}', chatId, { ERROR: error.message })
     );

--- a/src/commandsHandler/loadSimulationHandler.test.js
+++ b/src/commandsHandler/loadSimulationHandler.test.js
@@ -5,6 +5,9 @@ const mockLoadSimulationData = jest.fn().mockResolvedValue();
 
 jest.mock('../utils', () => ({
   isAdminMessage: mockIsAdminMessage,
+  sendMessageToUser: jest.fn((bot, chatId, msg, opts) =>
+    opts !== undefined ? bot.sendMessage(chatId, msg, opts) : bot.sendMessage(chatId, msg)
+  ),
 }));
 
 jest.mock('../cacheInitializer', () => ({

--- a/src/commandsHandler/menuHandler.js
+++ b/src/commandsHandler/menuHandler.js
@@ -1,4 +1,4 @@
-const { isAdminMessage } = require('../utils');
+const { isAdminMessage, sendMessageToUser } = require('../utils');
 const {
   MENU_CATEGORIES,
   MENU_ACTIONS,
@@ -18,13 +18,12 @@ async function displayMenuMessage(bot, msg) {
   const message = buildMainMenuMessage(chatId);
   const keyboard = buildMainMenuKeyboard(isAdmin, chatId);
 
-  await bot
-    .sendMessage(chatId, message, {
-      parse_mode: 'Markdown',
-      reply_markup: {
-        inline_keyboard: keyboard,
-      },
-    })
+  await sendMessageToUser(bot, chatId, message, {
+    parse_mode: 'Markdown',
+    reply_markup: {
+      inline_keyboard: keyboard,
+    },
+  })
     .catch((err) => console.error('Error sending menu message:', err));
 }
 

--- a/src/commandsHandler/menuHandler.test.js
+++ b/src/commandsHandler/menuHandler.test.js
@@ -4,6 +4,9 @@ const { MENU_CALLBACK_TYPE, MENU_ACTIONS } = require('../constants');
 // Mock the utils function
 jest.mock('../utils', () => ({
   isAdminMessage: jest.fn(),
+  sendMessageToUser: jest.fn((bot, chatId, msg, opts) =>
+    opts !== undefined ? bot.sendMessage(chatId, msg, opts) : bot.sendMessage(chatId, msg)
+  ),
 }));
 
 // Mock all command handlers individually

--- a/src/commandsHandler/nextRaceInfoHandler.js
+++ b/src/commandsHandler/nextRaceInfoHandler.js
@@ -1,4 +1,4 @@
-const { sendLogMessage } = require('../utils');
+const { sendLogMessage, sendMessageToUser } = require('../utils');
 const { formatDateTime } = require('../utils/utils');
 const { getWeatherForecast } = require('../utils/weatherApi');
 const { MAX_TELEGRAM_MESSAGE_LENGTH } = require('../constants');
@@ -13,14 +13,13 @@ async function handleNextRaceInfoCommand(bot, chatId) {
   const nextRaceInfo = nextRaceInfoCache[sharedKey];
 
   if (!nextRaceInfo) {
-    await bot
-      .sendMessage(
-        chatId,
-        t('Next race information is currently unavailable.', chatId)
-      )
-      .catch((err) =>
-        console.error('Error sending next race info unavailable message:', err)
-      );
+    await sendMessageToUser(
+      bot,
+      chatId,
+      t('Next race information is currently unavailable.', chatId)
+    ).catch((err) =>
+      console.error('Error sending next race info unavailable message:', err)
+    );
 
     return;
   }
@@ -220,25 +219,26 @@ async function handleNextRaceInfoCommand(bot, chatId) {
     message.length + trackHistoryMessage.length >
     MAX_TELEGRAM_MESSAGE_LENGTH
   ) {
-    await bot
-      .sendMessage(chatId, message, { parse_mode: 'Markdown' })
+    await sendMessageToUser(bot, chatId, message, { parse_mode: 'Markdown' })
       .catch((err) =>
         console.error('Error sending next race info message:', err)
       );
 
-    await bot
-      .sendMessage(chatId, trackHistoryMessage, { parse_mode: 'Markdown' })
+    await sendMessageToUser(bot, chatId, trackHistoryMessage, { parse_mode: 'Markdown' })
       .catch((err) =>
         console.error('Error sending track history message:', err)
       );
   } else {
-    await bot
-      .sendMessage(chatId, message + trackHistoryMessage, {
+    await sendMessageToUser(
+      bot,
+      chatId,
+      message + trackHistoryMessage,
+      {
         parse_mode: 'Markdown',
-      })
-      .catch((err) =>
-        console.error('Error sending next race info message:', err)
-      );
+      }
+    ).catch((err) =>
+      console.error('Error sending next race info message:', err)
+    );
   }
 }
 

--- a/src/commandsHandler/nextRaceInfoHandler.test.js
+++ b/src/commandsHandler/nextRaceInfoHandler.test.js
@@ -4,6 +4,9 @@ const mockSendLogMessage = jest.fn();
 
 jest.mock('../utils', () => ({
   sendLogMessage: mockSendLogMessage,
+  sendMessageToUser: jest.fn((bot, chatId, msg, opts) =>
+    opts !== undefined ? bot.sendMessage(chatId, msg, opts) : bot.sendMessage(chatId, msg)
+  ),
 }));
 
 jest.mock('../utils/utils', () => {

--- a/src/commandsHandler/numberInputHandler.js
+++ b/src/commandsHandler/numberInputHandler.js
@@ -8,6 +8,7 @@ const {
 } = require('../cache');
 const { COMMAND_BEST_TEAMS } = require('../constants');
 const { t } = require('../i18n');
+const { sendMessageToUser } = require('../utils');
 
 // Handles the case when the message text is a number
 async function handleNumberMessage(bot, chatId, textTrimmed) {
@@ -24,13 +25,13 @@ async function handleNumberMessage(bot, chatId, textTrimmed) {
         selectedTeam.transfers_needed === 0 &&
         !selectedTeam.extra_drs_driver // if the user uses the extra drs chip we need to show the changes
       ) {
-        await bot
-          .sendMessage(
-            chatId,
-            t('You are already at team {TEAM}. No changes needed.', chatId, {
-              TEAM: teamRowRequested,
-            })
-          )
+        await sendMessageToUser(
+          bot,
+          chatId,
+          t('You are already at team {TEAM}. No changes needed.', chatId, {
+            TEAM: teamRowRequested,
+          })
+        )
           .catch((err) =>
             console.error('Error sending no changes message:', err)
           );
@@ -69,27 +70,26 @@ async function handleNumberMessage(bot, chatId, textTrimmed) {
         chatId
       );
 
-      await bot
-        .sendMessage(chatId, changesToTeamMessage, { parse_mode: 'Markdown' })
+      await sendMessageToUser(bot, chatId, changesToTeamMessage, { parse_mode: 'Markdown' })
         .catch((err) =>
           console.error('Error sending changes to team message:', err)
         );
     } else {
-      await bot
-        .sendMessage(
-          chatId,
-          t('No team found for number {NUM}.', chatId, { NUM: teamRowRequested })
-        )
+      await sendMessageToUser(
+        bot,
+        chatId,
+        t('No team found for number {NUM}.', chatId, { NUM: teamRowRequested })
+      )
         .catch((err) =>
           console.error('Error sending team not found message:', err)
         );
     }
   } else {
-    await bot
-      .sendMessage(
-        chatId,
-        t('No cached teams available. Please send full JSON data or images first and then run the {CMD} command.', chatId, { CMD: COMMAND_BEST_TEAMS })
-      )
+    await sendMessageToUser(
+      bot,
+      chatId,
+      t('No cached teams available. Please send full JSON data or images first and then run the {CMD} command.', chatId, { CMD: COMMAND_BEST_TEAMS })
+    )
       .catch((err) =>
         console.error('Error sending cache unavailable message:', err)
       );

--- a/src/commandsHandler/printCacheHandler.js
+++ b/src/commandsHandler/printCacheHandler.js
@@ -1,34 +1,32 @@
 const { getPrintableCache, selectedChipCache } = require('../cache');
 const { t } = require('../i18n');
+const { sendMessageToUser } = require('../utils');
 
 async function sendPrintableCache(chatId, bot) {
   const printableCache = getPrintableCache(chatId);
   const selectedChip = selectedChipCache[chatId];
 
   if (printableCache) {
-    await bot
-      .sendMessage(chatId, printableCache, { parse_mode: 'Markdown' })
+    await sendMessageToUser(bot, chatId, printableCache, { parse_mode: 'Markdown' })
       .catch((err) => console.error('Error sending drivers cache:', err));
   } else {
-    await bot
-      .sendMessage(
-        chatId,
-        t('Drivers cache is empty. Please send drivers image or valid JSON data.', chatId)
-      )
+    await sendMessageToUser(
+      bot,
+      chatId,
+      t('Drivers cache is empty. Please send drivers image or valid JSON data.', chatId)
+    )
       .catch((err) =>
         console.error('Error sending empty drivers cache message:', err)
       );
   }
 
   if (selectedChip) {
-    await bot
-      .sendMessage(chatId, t('Selected Chip: {CHIP}', chatId, { CHIP: selectedChip }))
+    await sendMessageToUser(bot, chatId, t('Selected Chip: {CHIP}', chatId, { CHIP: selectedChip }))
       .catch((err) =>
         console.error('Error sending selected chip message:', err)
       );
   } else {
-    await bot
-      .sendMessage(chatId, t('No chip selected.', chatId))
+    await sendMessageToUser(bot, chatId, t('No chip selected.', chatId))
       .catch((err) => console.error('Error sending no chip message:', err));
   }
 

--- a/src/commandsHandler/printCacheHandler.test.js
+++ b/src/commandsHandler/printCacheHandler.test.js
@@ -111,7 +111,7 @@ describe('sendPrintableCache', () => {
 
     await sendPrintableCache(KILZI_CHAT_ID, botMock);
 
-    expect(botMock.sendMessage).toHaveBeenCalledTimes(2);
+    expect(botMock.sendMessage).toHaveBeenCalledTimes(3);
     // Second call should still succeed
     expect(botMock.sendMessage).toHaveBeenLastCalledWith(
       KILZI_CHAT_ID,

--- a/src/commandsHandler/resetCacheHandler.js
+++ b/src/commandsHandler/resetCacheHandler.js
@@ -7,6 +7,7 @@ const {
   selectedChipCache,
 } = require('../cache');
 const { t } = require('../i18n');
+const { sendMessageToUser } = require('../utils');
 
 async function resetCacheForChat(chatId, bot) {
   delete driversCache[chatId];
@@ -16,8 +17,7 @@ async function resetCacheForChat(chatId, bot) {
   delete bestTeamsCache[chatId];
   delete selectedChipCache[chatId];
 
-  await bot
-    .sendMessage(chatId, t('Cache has been reset for your chat.', chatId))
+  await sendMessageToUser(bot, chatId, t('Cache has been reset for your chat.', chatId))
     .catch((err) => console.error('Error sending cache reset message:', err));
 
   return;

--- a/src/commandsHandler/scrapingTriggerHandler.js
+++ b/src/commandsHandler/scrapingTriggerHandler.js
@@ -1,20 +1,21 @@
-const { triggerScraping, isAdminMessage } = require('../utils');
+const { triggerScraping, isAdminMessage, sendMessageToUser } = require('../utils');
 const { t } = require('../i18n');
 
 async function handleScrapingTrigger(bot, msg) {
   const chatId = msg.chat.id;
 
   if (!isAdminMessage(msg)) {
-    await bot.sendMessage(chatId, t('Sorry, only admins can trigger scraping.', chatId));
+    await sendMessageToUser(bot, chatId, t('Sorry, only admins can trigger scraping.', chatId));
 
     return;
   }
 
   const result = await triggerScraping(bot);
   if (result.success) {
-    await bot.sendMessage(chatId, t('Web scraping triggered successfully.', chatId));
+    await sendMessageToUser(bot, chatId, t('Web scraping triggered successfully.', chatId));
   } else {
-    await bot.sendMessage(
+    await sendMessageToUser(
+      bot,
       chatId,
       t('Failed to trigger web scraping: {ERROR}', chatId, { ERROR: result.error })
     );

--- a/src/commandsHandler/scrapingTriggerHandler.test.js
+++ b/src/commandsHandler/scrapingTriggerHandler.test.js
@@ -6,6 +6,9 @@ const mockTriggerScraping = jest.fn();
 jest.mock('../utils', () => ({
   isAdminMessage: mockIsAdminMessage,
   triggerScraping: mockTriggerScraping,
+  sendMessageToUser: jest.fn((bot, chatId, msg, opts) =>
+    opts !== undefined ? bot.sendMessage(chatId, msg, opts) : bot.sendMessage(chatId, msg)
+  ),
 }));
 
 const { handleScrapingTrigger } = require('./scrapingTriggerHandler');

--- a/src/commandsHandler/setLanguageHandler.js
+++ b/src/commandsHandler/setLanguageHandler.js
@@ -1,6 +1,7 @@
 const { t, setLanguage, getSupportedLanguages, getLanguageName } = require('../i18n');
 const { LANG_CALLBACK_TYPE } = require('../constants');
 const azureStorageService = require('../azureStorageService');
+const { sendMessageToUser } = require('../utils');
 
 async function handleSetLanguage(bot, msg) {
   const chatId = msg.chat.id;
@@ -15,11 +16,10 @@ async function handleSetLanguage(bot, msg) {
       },
     ]);
 
-    await bot
-      .sendMessage(chatId, t('Please select a language:', chatId), {
-        reply_to_message_id: msg.message_id,
-        reply_markup: { inline_keyboard: keyboard },
-      })
+    await sendMessageToUser(bot, chatId, t('Please select a language:', chatId), {
+      reply_to_message_id: msg.message_id,
+      reply_markup: { inline_keyboard: keyboard },
+    })
       .catch((err) => console.error('Error sending language menu:', err));
 
     return;
@@ -27,19 +27,19 @@ async function handleSetLanguage(bot, msg) {
 
   if (setLanguage(lang, chatId)) {
     await azureStorageService.saveUserSettings(bot, chatId, { lang });
-    await bot
-      .sendMessage(
-        chatId,
-        t('Language changed to {LANG}.', chatId, { LANG: getLanguageName(lang, chatId) })
-      )
+    await sendMessageToUser(
+      bot,
+      chatId,
+      t('Language changed to {LANG}.', chatId, { LANG: getLanguageName(lang, chatId) })
+    )
       .catch((err) => console.error('Error sending language changed message:', err));
   } else {
     const langs = getSupportedLanguages().join(', ');
-    await bot
-      .sendMessage(
-        chatId,
-        t('Invalid language. Supported languages: {LANGS}', chatId, { LANGS: langs })
-      )
+    await sendMessageToUser(
+      bot,
+      chatId,
+      t('Invalid language. Supported languages: {LANGS}', chatId, { LANGS: langs })
+    )
       .catch((err) => console.error('Error sending invalid language message:', err));
   }
 }

--- a/src/commandsHandler/versionHandler.js
+++ b/src/commandsHandler/versionHandler.js
@@ -1,11 +1,11 @@
-const { isAdminMessage } = require('../utils');
+const { isAdminMessage, sendMessageToUser } = require('../utils');
 const { t } = require('../i18n');
 
 async function handleVersionCommand(bot, msg) {
   const chatId = msg.chat.id;
 
   if (!isAdminMessage(msg)) {
-    await bot.sendMessage(chatId, t('Sorry, only admins can use this command.', chatId));
+    await sendMessageToUser(bot, chatId, t('Sorry, only admins can use this command.', chatId));
 
     return;
   }
@@ -21,7 +21,7 @@ async function handleVersionCommand(bot, msg) {
     }
   );
 
-  await bot.sendMessage(chatId, versionInfo);
+  await sendMessageToUser(bot, chatId, versionInfo);
 }
 
 module.exports = { handleVersionCommand };

--- a/src/commandsHandler/versionHandler.test.js
+++ b/src/commandsHandler/versionHandler.test.js
@@ -4,6 +4,9 @@ const mockIsAdminMessage = jest.fn().mockReturnValue(true);
 
 jest.mock('../utils', () => ({
   isAdminMessage: mockIsAdminMessage,
+  sendMessageToUser: jest.fn((bot, chatId, msg, opts) =>
+    opts !== undefined ? bot.sendMessage(chatId, msg, opts) : bot.sendMessage(chatId, msg)
+  ),
 }));
 
 const { handleVersionCommand } = require('./versionHandler');

--- a/src/messageHandler.js
+++ b/src/messageHandler.js
@@ -5,6 +5,7 @@ const {
 } = require('./utils/utils');
 const { handleTextMessage } = require('./textMessageHandler');
 const { handlePhotoMessage } = require('./photoMessageHandler');
+const { sendMessageToUser } = require('./utils');
 const { t } = require('./i18n');
 
 exports.handleMessage = async function (bot, msg) {
@@ -43,8 +44,11 @@ exports.handleMessage = async function (bot, msg) {
   );
 
   // For unsupported message types
-  await bot
-    .sendMessage(chatId, t('Sorry, I only support text and image messages.', chatId))
+  await sendMessageToUser(
+    bot,
+    chatId,
+    t('Sorry, I only support text and image messages.', chatId)
+  )
     .catch((err) =>
       console.error('Error sending unsupported type reply:', err)
     );

--- a/src/messageHandler.test.js
+++ b/src/messageHandler.test.js
@@ -6,6 +6,9 @@ jest.mock('./utils/utils', () => ({
   getChatName: jest.fn().mockReturnValue('Unknown'),
   sendLogMessage: jest.fn(),
   isAdminMessage: mockIsAdmin,
+  sendMessageToUser: jest.fn((bot, chatId, msg, opts) =>
+    opts !== undefined ? bot.sendMessage(chatId, msg, opts) : bot.sendMessage(chatId, msg)
+  ),
 }));
 
 const { handleMessage } = require('./messageHandler');

--- a/src/photoMessageHandler.js
+++ b/src/photoMessageHandler.js
@@ -6,6 +6,7 @@ const {
   PHOTO_CALLBACK_TYPE,
 } = require('./constants');
 const { t } = require('./i18n');
+const { sendMessageToUser } = require('./utils');
 
 exports.handlePhotoMessage = async function (bot, msg) {
   const chatId = msg.chat.id;
@@ -25,7 +26,7 @@ exports.handlePhotoMessage = async function (bot, msg) {
   };
 
   // Reply with inline buttons
-  await bot.sendMessage(chatId, t('What type is this photo?', chatId), {
+  await sendMessageToUser(bot, chatId, t('What type is this photo?', chatId), {
     reply_to_message_id: messageId,
     reply_markup: {
       inline_keyboard: [

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -14,14 +14,18 @@ const {
 } = require('../prompts');
 const { t, getLocale } = require('../i18n');
 
-exports.sendMessage = async function (bot, chatId, message) {
+exports.sendMessage = async function (bot, chatId, message, options) {
   if (!chatId) {
     console.error('Chat ID is not set');
 
     return;
   }
 
-  await bot.sendMessage(chatId, message);
+  if (options !== undefined) {
+    await bot.sendMessage(chatId, message, options);
+  } else {
+    await bot.sendMessage(chatId, message);
+  }
 };
 
 exports.sendLogMessage = async function (bot, logMessage) {
@@ -64,9 +68,9 @@ exports.sendMessageToAdmins = async function (bot, message) {
   }
 };
 
-exports.sendMessageToUser = async function (bot, chatId, message) {
+exports.sendMessageToUser = async function (bot, chatId, message, options) {
   try {
-    await exports.sendMessage(bot, chatId, message);
+    await exports.sendMessage(bot, chatId, message, options);
   } catch (error) {
     console.error(error);
     await exports.sendLogMessage(


### PR DESCRIPTION
## Summary
- forward all bot messages through `sendMessageToUser`
- refactor handlers and tests to use the helper
- keep option parameters intact

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883639f33e48326bef196db978a0c4e