### PR TITLE
Add chip recommendation indicators to /best_team_scenarios output

### DIFF
--- a/src/commandsHandler/bestTeamScenariosHandler.js
+++ b/src/commandsHandler/bestTeamScenariosHandler.js
@@ -20,6 +20,50 @@ function formatNumber(value) {
   return Number(Number(value || 0).toFixed(2)).toFixed(2);
 }
 
+function getChipRecommendationDot(chip, diff) {
+  if (!Number.isFinite(diff)) {
+    return '';
+  }
+
+  if (chip === WILDCARD_CHIP) {
+    if (diff >= 30) {
+      return ' 🟢';
+    }
+
+    if (diff >= 20) {
+      return ' 🟡';
+    }
+
+    return '';
+  }
+
+  if (chip === LIMITLESS_CHIP) {
+    if (diff >= 120) {
+      return ' 🟢';
+    }
+
+    if (diff >= 100) {
+      return ' 🟡';
+    }
+
+    return '';
+  }
+
+  if (chip === EXTRA_BOOST_CHIP) {
+    if (diff >= 70) {
+      return ' 🟢';
+    }
+
+    if (diff >= 50) {
+      return ' 🟡';
+    }
+
+    return '';
+  }
+
+  return '';
+}
+
 function getTopBestTeamForScenario(
   cachedJsonData,
   selectedChip,
@@ -110,7 +154,7 @@ async function handleBestTeamScenariosMessage(bot, chatId) {
 
   const sections = ppmScenarios.map((ppm) => {
     const sectionTitle = `*${formatNumber(ppm)} ${t('points per million', chatId)}*`;
-    const lines = chipScenarios.map((scenario) => {
+    const scenarioResults = chipScenarios.map((scenario) => {
       const topTeam = getTopBestTeamForScenario(
         cachedJsonData,
         scenario.chip,
@@ -118,14 +162,26 @@ async function handleBestTeamScenariosMessage(bot, chatId) {
         safeRemainingRaceCount,
       );
 
+      return { scenario, topTeam };
+    });
+
+    const baselineScore = scenarioResults[0]?.topTeam?.projected_points;
+
+    const lines = scenarioResults.map(({ scenario, topTeam }) => {
       if (!topTeam) {
         return `• *${scenario.label}* — ${t('Unavailable', chatId)}`;
       }
 
+      const recommendationDot = getChipRecommendationDot(
+        scenario.chip,
+        topTeam.projected_points - baselineScore,
+      );
+
       return (
         `• *${scenario.label}* — ` +
         `${formatNumber(topTeam.projected_points)} ${t('pts', chatId)} | ` +
-        `Δ ${formatNumber(topTeam.expected_price_change)}`
+        `Δ ${formatNumber(topTeam.expected_price_change)}` +
+        recommendationDot
       );
     });
 
@@ -144,4 +200,5 @@ async function handleBestTeamScenariosMessage(bot, chatId) {
 module.exports = {
   handleBestTeamScenariosMessage,
   getTopBestTeamForScenario,
+  getChipRecommendationDot,
 };

--- a/src/commandsHandler/bestTeamScenariosHandler.test.js
+++ b/src/commandsHandler/bestTeamScenariosHandler.test.js
@@ -72,12 +72,22 @@ describe('handleBestTeamScenariosMessage', () => {
     selectedChipCache[KILZI_CHAT_ID] = { [TEAM_ID]: 'WITHOUT_CHIP' };
     remainingRaceCountCache[sharedKey] = 10;
 
-    calculateBestTeams.mockImplementation((_, chip, ppm) => [
-      {
-        projected_points: 300 + ppm,
-        expected_price_change: chip === LIMITLESS_CHIP ? 0.4 : 0.8,
-      },
-    ]);
+    calculateBestTeams.mockImplementation((_, chip, ppm) => {
+      const baseline = 300 + ppm;
+      const scoreByChip = {
+        WITHOUT_CHIP: baseline,
+        [LIMITLESS_CHIP]: baseline + 120,
+        [EXTRA_BOOST_CHIP]: baseline + 50,
+        [WILDCARD_CHIP]: baseline + 20,
+      };
+
+      return [
+        {
+          projected_points: scoreByChip[chip],
+          expected_price_change: chip === LIMITLESS_CHIP ? 0.4 : 0.8,
+        },
+      ];
+    });
 
     await handleBestTeamScenariosMessage(botMock, KILZI_CHAT_ID);
 
@@ -105,9 +115,9 @@ describe('handleBestTeamScenariosMessage', () => {
     expect(sentMessage).toContain('*1.65 points per million*');
     expect(sentMessage).toContain('*2.00 points per million*');
     expect(sentMessage).toContain('• *Without Chip* — 300.00 pts | Δ 0.80');
-    expect(sentMessage).toContain('• *Limitless* — 300.00 pts | Δ 0.40');
-    expect(sentMessage).toContain('• *Extra Boost* — 300.00 pts | Δ 0.80');
-    expect(sentMessage).toContain('• *Wildcard* — 300.00 pts | Δ 0.80');
+    expect(sentMessage).toContain('• *Limitless* — 420.00 pts | Δ 0.40 🟢');
+    expect(sentMessage).toContain('• *Extra Boost* — 350.00 pts | Δ 0.80 🟡');
+    expect(sentMessage).toContain('• *Wildcard* — 320.00 pts | Δ 0.80 🟡');
   });
 
   it('should continue when remaining race count is unavailable', async () => {


### PR DESCRIPTION
### Motivation
- Provide a visual recommendation hint for which chip to use by comparing each chip's top-team score to the "Without Chip" baseline inside each points-per-million block.
- Surface those recommendations inline in the compact `/best_team_scenarios` message so users can quickly spot strong chip choices.

### Description
- Added `getChipRecommendationDot` helper that returns `🟢` / `🟡` (or empty) based on per-chip thresholds and a computed score delta. (see `src/commandsHandler/bestTeamScenariosHandler.js`).
- Compute the baseline per ppm block from the first scenario (the "Without Chip" line) and calculate `Diff = chip.projected_points - baseline` before formatting each line, appending the emoji at the very end of the line when applicable. (updated rendering logic in `handleBestTeamScenariosMessage`).
- Updated unit test behavior and expectations to validate dynamic diffs and emoji placement by adjusting the `calculateBestTeams` mock and assertions. (changes in `src/commandsHandler/bestTeamScenariosHandler.test.js`).
- Exported the recommendation helper (`getChipRecommendationDot`) for readability and testability.

### Testing
- Ran the handler unit test with `npm test -- src/commandsHandler/bestTeamScenariosHandler.test.js`, which passed. 
- Ran the full test suite (pre-commit hook invoked `jest --coverage`) and all tests passed (`50 suites, 446 tests`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9a608a78483268a943afff49ae070)