### PR TITLE
Add /deadline countdown command with refresh callback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ This repository contains a Telegram bot that helps manage F1 Fantasy teams. The 
 - `/set_best_team_ranking`
 - `/select_team`, `/print_cache`, `/reset_cache`
 - `/next_race_info`, `/next_races`, `/next_race_weather`
+- `/deadline` _(countdown to next race with inline refresh button)_
 - `/get_current_simulation`
 - `/load_simulation`
 - `/menu`, `/help`, `/lang`
@@ -411,6 +412,14 @@ Blob naming includes the team ID:
 | `COMMAND_SELECT_TEAM`       | `'/select_team'` | Command string for team selection.                                |
 | `TEAM_CALLBACK_TYPE`        | `'TEAM'`         | Callback type for `/select_team` inline keyboard.                 |
 | `TEAM_ASSIGN_CALLBACK_TYPE` | `'TEAM_ASSIGN'`  | Callback type for asking user which team a screenshot belongs to. |
+
+### Deadline Countdown
+
+- `/deadline` sends a next-race countdown using Jolpi schedule data and includes a single inline button:
+  - text: `🔄 Refresh`
+  - callback data: `refresh_f1_countdown`
+- Refresh is handled in `src/callbackQueryHandler.js`: it always answers the callback query first, recalculates countdown from current time, and then attempts `editMessageText`.
+- `editMessageText` errors with Telegram `"message is not modified"` are intentionally swallowed; other edit failures are logged concisely without crashing.
 
 ### Key Files
 

--- a/src/callbackQueryHandler.js
+++ b/src/callbackQueryHandler.js
@@ -19,6 +19,12 @@ const {
   TEAM_ASSIGN_CALLBACK_TYPE,
   BEST_TEAM_WEIGHTS_CALLBACK_TYPE,
 } = require('./constants');
+const {
+  REFRESH_F1_COUNTDOWN_CALLBACK,
+  buildDeadlineMessage,
+  buildRefreshKeyboard,
+  getNextRaceForCountdown,
+} = require('./commandsHandler/deadlineHandler');
 
 const {
   sendLogMessage,
@@ -46,10 +52,51 @@ exports.handleCallbackQuery = async function (bot, query) {
       return await handleTeamAssignCallback(bot, query);
     case BEST_TEAM_WEIGHTS_CALLBACK_TYPE:
       return await handleBestTeamRankingCallback(bot, query);
+    case REFRESH_F1_COUNTDOWN_CALLBACK:
+      return await handleDeadlineRefreshCallback(bot, query);
     default:
       await sendLogMessage(bot, `Unknown callback type: ${callbackType}`);
   }
 };
+
+async function handleDeadlineRefreshCallback(bot, query) {
+  const chatId = query.message.chat.id;
+  const messageId = query.message.message_id;
+
+  await bot.answerCallbackQuery(query.id);
+
+  try {
+    const nextRace = await getNextRaceForCountdown();
+    if (!nextRace) {
+      console.error('No upcoming race found while refreshing deadline countdown.');
+
+      return;
+    }
+
+    const messageText = buildDeadlineMessage(
+      nextRace.raceName,
+      nextRace.raceDate,
+      chatId,
+    );
+
+    try {
+      await bot.editMessageText(messageText, {
+        chat_id: chatId,
+        message_id: messageId,
+        parse_mode: 'Markdown',
+        ...buildRefreshKeyboard(),
+      });
+    } catch (error) {
+      if (error?.message?.includes('message is not modified')) {
+        return;
+      }
+
+      console.error('Error editing deadline countdown message:', error.message);
+    }
+  } catch (error) {
+    console.error('Error refreshing deadline countdown:', error.message);
+  }
+}
 
 async function handleChipCallback(bot, query) {
   const chatId = query.message.chat.id;

--- a/src/callbackQueryHandler.test.js
+++ b/src/callbackQueryHandler.test.js
@@ -12,6 +12,12 @@ const azureStorageService = require('./azureStorageService');
 const { updateUserAttributes } = require('./userRegistryService');
 const { setLanguage } = require('./i18n');
 const { selectChip } = require('./commandsHandler/selectChipHandlers');
+const {
+  REFRESH_F1_COUNTDOWN_CALLBACK,
+  getNextRaceForCountdown,
+  buildDeadlineMessage,
+  buildRefreshKeyboard,
+} = require('./commandsHandler/deadlineHandler');
 
 jest.mock('./utils', () => ({
   sendLogMessage: jest.fn().mockResolvedValue(undefined),
@@ -47,6 +53,15 @@ jest.mock('./cache', () => ({
   normalizeBestTeamBudgetChangePointsPerMillion: jest.fn(() => ({})),
   clearSelectedBestTeam: jest.fn(() => ({})),
   serializeSelectedBestTeamByTeam: jest.fn(() => null),
+}));
+
+jest.mock('./commandsHandler/deadlineHandler', () => ({
+  REFRESH_F1_COUNTDOWN_CALLBACK: 'refresh_f1_countdown',
+  getNextRaceForCountdown: jest.fn(),
+  buildDeadlineMessage: jest.fn(() => 'deadline text'),
+  buildRefreshKeyboard: jest.fn(() => ({
+    reply_markup: { inline_keyboard: [[{ text: '🔄 Refresh', callback_data: 'refresh_f1_countdown' }]] },
+  })),
 }));
 
 describe('handleCallbackQuery', () => {
@@ -167,5 +182,36 @@ describe('handleCallbackQuery', () => {
 
     expect(updateUserAttributes).toHaveBeenCalled();
     expect(bot.answerCallbackQuery).toHaveBeenCalledWith('q6');
+  });
+
+  it('should handle deadline refresh callback and swallow not modified error', async () => {
+    getNextRaceForCountdown.mockResolvedValueOnce({
+      raceName: 'Monaco Grand Prix',
+      raceDate: new Date('2026-05-25T13:00:00Z'),
+    });
+    bot.editMessageText.mockRejectedValueOnce(
+      new Error('400: Bad Request: message is not modified'),
+    );
+
+    const query = {
+      id: 'q7',
+      data: REFRESH_F1_COUNTDOWN_CALLBACK,
+      message: { chat: { id: 123 }, message_id: 456 },
+    };
+
+    await handleCallbackQuery(bot, query);
+
+    expect(bot.answerCallbackQuery).toHaveBeenCalledWith('q7');
+    expect(buildDeadlineMessage).toHaveBeenCalledWith(
+      'Monaco Grand Prix',
+      new Date('2026-05-25T13:00:00Z'),
+      123,
+    );
+    expect(bot.editMessageText).toHaveBeenCalledWith('deadline text', {
+      chat_id: 123,
+      message_id: 456,
+      parse_mode: 'Markdown',
+      ...buildRefreshKeyboard(),
+    });
   });
 });

--- a/src/commandsHandler/commandHandlers.js
+++ b/src/commandsHandler/commandHandlers.js
@@ -131,8 +131,7 @@ async function executeCommand(bot, msg, command) {
     command === COMMAND_CURRENT_TEAM_INFO ||
     command === COMMAND_NEXT_RACE_INFO ||
     command === COMMAND_NEXT_RACES ||
-    command === COMMAND_NEXT_RACE_WEATHER ||
-    command === COMMAND_DEADLINE
+    command === COMMAND_NEXT_RACE_WEATHER
   ) {
     await handler(bot, chatId);
   } else {

--- a/src/commandsHandler/commandHandlers.js
+++ b/src/commandsHandler/commandHandlers.js
@@ -13,6 +13,7 @@ const {
   COMMAND_NEXT_RACE_INFO,
   COMMAND_NEXT_RACES,
   COMMAND_NEXT_RACE_WEATHER,
+  COMMAND_DEADLINE,
   COMMAND_BILLING_STATS,
   COMMAND_VERSION,
   COMMAND_MENU,
@@ -46,6 +47,7 @@ const { handleLoadSimulation } = require('./loadSimulationHandler');
 const { handleNextRaceInfoCommand } = require('./nextRaceInfoHandler');
 const { handleNextRaceWeatherCommand } = require('./nextRaceWeatherHandler');
 const { handleNextRacesCommand } = require('./nextRacesHandler');
+const { handleDeadlineCommand } = require('./deadlineHandler');
 const { sendPrintableCache } = require('./printCacheHandler');
 const { resetCacheForChat } = require('./resetCacheHandler');
 const { handleScrapingTrigger } = require('./scrapingTriggerHandler');
@@ -91,6 +93,7 @@ const COMMAND_HANDLERS = {
   [COMMAND_NEXT_RACE_INFO]: handleNextRaceInfoCommand,
   [COMMAND_NEXT_RACES]: handleNextRacesCommand,
   [COMMAND_NEXT_RACE_WEATHER]: handleNextRaceWeatherCommand,
+  [COMMAND_DEADLINE]: handleDeadlineCommand,
   [COMMAND_BILLING_STATS]: handleBillingStats,
   [COMMAND_VERSION]: handleVersionCommand,
   [COMMAND_MENU]: displayMenuMessage,
@@ -128,7 +131,8 @@ async function executeCommand(bot, msg, command) {
     command === COMMAND_CURRENT_TEAM_INFO ||
     command === COMMAND_NEXT_RACE_INFO ||
     command === COMMAND_NEXT_RACES ||
-    command === COMMAND_NEXT_RACE_WEATHER
+    command === COMMAND_NEXT_RACE_WEATHER ||
+    command === COMMAND_DEADLINE
   ) {
     await handler(bot, chatId);
   } else {

--- a/src/commandsHandler/commandHandlers.test.js
+++ b/src/commandsHandler/commandHandlers.test.js
@@ -1,0 +1,29 @@
+const { executeCommand } = require('./commandHandlers');
+const { COMMAND_DEADLINE } = require('../constants');
+
+jest.mock('./deadlineHandler', () => ({
+  handleDeadlineCommand: jest.fn().mockResolvedValue(undefined),
+}));
+
+const { handleDeadlineCommand } = require('./deadlineHandler');
+
+describe('executeCommand', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('routes /deadline through msg-shaped handler signature for menu/ask execution', async () => {
+    const bot = {};
+    const msg = { chat: { id: 321 }, text: '/menu' };
+
+    await executeCommand(bot, msg, COMMAND_DEADLINE);
+
+    expect(handleDeadlineCommand).toHaveBeenCalledWith(
+      bot,
+      expect.objectContaining({
+        chat: { id: 321 },
+        text: COMMAND_DEADLINE,
+      }),
+    );
+  });
+});

--- a/src/commandsHandler/deadlineHandler.js
+++ b/src/commandsHandler/deadlineHandler.js
@@ -1,0 +1,110 @@
+const { t } = require('../i18n');
+const {
+  buildDate,
+  fetchCurrentSeasonRaces,
+  findNextRace,
+} = require('../raceScheduleService');
+
+const REFRESH_F1_COUNTDOWN_CALLBACK = 'refresh_f1_countdown';
+
+function buildRefreshKeyboard() {
+  return {
+    reply_markup: {
+      inline_keyboard: [
+        [
+          {
+            text: t('🔄 Refresh'),
+            callback_data: REFRESH_F1_COUNTDOWN_CALLBACK,
+          },
+        ],
+      ],
+    },
+  };
+}
+
+function formatCountdownParts(targetDate) {
+  const diffMs = Math.max(0, targetDate - new Date());
+  const totalSeconds = Math.floor(diffMs / 1000);
+
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  return { days, hours, minutes, seconds };
+}
+
+function buildDeadlineMessage(raceName, raceDate, chatId) {
+  const { days, hours, minutes, seconds } = formatCountdownParts(raceDate);
+
+  return `${t('🏎️ **{RACE_NAME}** starts in:', chatId, {
+    RACE_NAME: raceName,
+  })}\n${t('⏳ {DAYS} days, {HOURS} hours, {MINUTES} minutes, {SECONDS} seconds.', chatId, {
+    DAYS: days,
+    HOURS: hours,
+    MINUTES: minutes,
+    SECONDS: seconds,
+  })}`;
+}
+
+async function getNextRaceForCountdown() {
+  const data = await fetchCurrentSeasonRaces();
+  const races = data?.MRData?.RaceTable?.Races || [];
+  const nextRace = findNextRace(races);
+
+  if (!nextRace) {
+    return null;
+  }
+
+  const raceDate = buildDate(nextRace.date, nextRace.time);
+  if (!raceDate) {
+    return null;
+  }
+
+  return {
+    raceName: nextRace.raceName,
+    raceDate,
+  };
+}
+
+async function handleDeadlineCommand(bot, msg) {
+  const chatId = msg.chat.id;
+
+  try {
+    const nextRace = await getNextRaceForCountdown();
+
+    if (!nextRace) {
+      await bot.sendMessage(
+        chatId,
+        t('No upcoming race found.', chatId),
+      );
+
+      return;
+    }
+
+    const messageText = buildDeadlineMessage(
+      nextRace.raceName,
+      nextRace.raceDate,
+      chatId,
+    );
+
+    await bot.sendMessage(chatId, messageText, {
+      parse_mode: 'Markdown',
+      ...buildRefreshKeyboard(),
+    });
+  } catch (error) {
+    console.error('Error handling deadline command:', error);
+    await bot.sendMessage(
+      chatId,
+      t('Failed to fetch race schedule. Please try again later.', chatId),
+    );
+  }
+}
+
+module.exports = {
+  REFRESH_F1_COUNTDOWN_CALLBACK,
+  buildDeadlineMessage,
+  buildRefreshKeyboard,
+  getNextRaceForCountdown,
+  handleDeadlineCommand,
+};

--- a/src/commandsHandler/deadlineHandler.test.js
+++ b/src/commandsHandler/deadlineHandler.test.js
@@ -1,0 +1,81 @@
+const {
+  buildDate,
+  fetchCurrentSeasonRaces,
+} = require('../raceScheduleService');
+const {
+  handleDeadlineCommand,
+  buildDeadlineMessage,
+  REFRESH_F1_COUNTDOWN_CALLBACK,
+} = require('./deadlineHandler');
+
+jest.mock('../raceScheduleService', () => ({
+  buildDate: jest.fn(),
+  fetchCurrentSeasonRaces: jest.fn(),
+  findNextRace: jest.fn(),
+}));
+
+const { findNextRace } = require('../raceScheduleService');
+
+describe('deadlineHandler', () => {
+  const botMock = {
+    sendMessage: jest.fn().mockResolvedValue(undefined),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should format deadline message with countdown', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-04-01T00:00:00Z'));
+
+    const message = buildDeadlineMessage(
+      'Monaco Grand Prix',
+      new Date('2026-04-02T01:02:03Z'),
+      123,
+    );
+
+    expect(message).toBe(
+      '🏎️ **Monaco Grand Prix** starts in:\n⏳ 1 days, 1 hours, 2 minutes, 3 seconds.',
+    );
+
+    jest.useRealTimers();
+  });
+
+  it('should send countdown with refresh button', async () => {
+    fetchCurrentSeasonRaces.mockResolvedValueOnce({
+      MRData: { RaceTable: { Races: [{ raceName: 'Monaco GP' }] } },
+    });
+    findNextRace.mockReturnValueOnce({
+      raceName: 'Monaco GP',
+      date: '2026-05-25',
+      time: '13:00:00Z',
+    });
+    buildDate.mockReturnValueOnce(new Date('2026-05-25T13:00:00Z'));
+
+    await handleDeadlineCommand(botMock, { chat: { id: 123 } });
+
+    expect(botMock.sendMessage).toHaveBeenCalledWith(
+      123,
+      expect.stringContaining('🏎️ **Monaco GP** starts in:'),
+      {
+        parse_mode: 'Markdown',
+        reply_markup: {
+          inline_keyboard: [
+            [{ text: '🔄 Refresh', callback_data: REFRESH_F1_COUNTDOWN_CALLBACK }],
+          ],
+        },
+      },
+    );
+  });
+
+  it('should send fallback when no upcoming race exists', async () => {
+    fetchCurrentSeasonRaces.mockResolvedValueOnce({
+      MRData: { RaceTable: { Races: [] } },
+    });
+    findNextRace.mockReturnValueOnce(null);
+
+    await handleDeadlineCommand(botMock, { chat: { id: 123 } });
+
+    expect(botMock.sendMessage).toHaveBeenCalledWith(123, 'No upcoming race found.');
+  });
+});

--- a/src/commandsHandler/index.js
+++ b/src/commandsHandler/index.js
@@ -10,6 +10,7 @@ const { handleJsonMessage } = require('./jsonInputHandler');
 const { handleLoadSimulation } = require('./loadSimulationHandler');
 const { handleNextRaceInfoCommand } = require('./nextRaceInfoHandler');
 const { handleNextRaceWeatherCommand } = require('./nextRaceWeatherHandler');
+const { handleDeadlineCommand } = require('./deadlineHandler');
 const { handleNextRacesCommand } = require('./nextRacesHandler');
 const { handleNumberMessage } = require('./numberInputHandler');
 const { sendPrintableCache } = require('./printCacheHandler');
@@ -54,6 +55,7 @@ module.exports = {
   handleLoadSimulation,
   handleNextRaceInfoCommand,
   handleNextRaceWeatherCommand,
+  handleDeadlineCommand,
   handleNextRacesCommand,
   handleNumberMessage,
   sendPrintableCache,

--- a/src/constants.js
+++ b/src/constants.js
@@ -47,6 +47,7 @@ exports.COMMAND_GET_BOTFATHER_COMMANDS = '/get_botfather_commands';
 exports.COMMAND_NEXT_RACE_INFO = '/next_race_info';
 exports.COMMAND_NEXT_RACES = '/next_races';
 exports.COMMAND_NEXT_RACE_WEATHER = '/next_race_weather';
+exports.COMMAND_DEADLINE = '/deadline';
 exports.COMMAND_BILLING_STATS = '/billing_stats';
 exports.COMMAND_VERSION = '/version';
 exports.COMMAND_MENU = '/menu';
@@ -160,6 +161,11 @@ exports.MENU_CATEGORIES = {
         constant: exports.COMMAND_NEXT_RACE_WEATHER,
         title: '🌦️ Next Race Weather',
         description: 'Get detailed weather forecast for the next race',
+      },
+      {
+        constant: exports.COMMAND_DEADLINE,
+        title: '⏳ Deadline Countdown',
+        description: 'Show countdown to the next race with a refresh button',
       },
       {
         constant: exports.COMMAND_GET_CURRENT_SIMULATION,

--- a/src/raceScheduleService.js
+++ b/src/raceScheduleService.js
@@ -40,6 +40,25 @@ function filterUpcomingRaces(races) {
   });
 }
 
+function findNextRace(races) {
+  const upcomingRaces = filterUpcomingRaces(races);
+
+  if (upcomingRaces.length === 0) {
+    return null;
+  }
+
+  return [...upcomingRaces].sort((a, b) => {
+    const raceDateA = buildDate(a.date, a.time);
+    const raceDateB = buildDate(b.date, b.time);
+
+    if (!raceDateA || !raceDateB) {
+      return 0;
+    }
+
+    return raceDateA - raceDateB;
+  })[0];
+}
+
 async function fetchRemainingRaceCount() {
   const data = await fetchCurrentSeasonRaces();
   const races = data?.MRData?.RaceTable?.Races || [];
@@ -51,5 +70,6 @@ module.exports = {
   buildDate,
   fetchCurrentSeasonRaces,
   filterUpcomingRaces,
+  findNextRace,
   fetchRemainingRaceCount,
 };

--- a/src/raceScheduleService.test.js
+++ b/src/raceScheduleService.test.js
@@ -2,6 +2,7 @@ const {
   buildDate,
   fetchCurrentSeasonRaces,
   filterUpcomingRaces,
+  findNextRace,
   fetchRemainingRaceCount,
 } = require('./raceScheduleService');
 
@@ -96,6 +97,18 @@ describe('raceScheduleService', () => {
     });
 
     await expect(fetchRemainingRaceCount()).resolves.toBe(3);
+  });
+
+  it('should return the nearest upcoming race', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2025-05-01T12:00:00Z'));
+
+    const races = [
+      { raceName: 'British Grand Prix', date: '2025-07-06', time: '14:00:00Z' },
+      { raceName: 'Monaco Grand Prix', date: '2025-05-25', time: '13:00:00Z' },
+      { raceName: 'Canadian Grand Prix', date: '2025-06-15', time: '18:00:00Z' },
+    ];
+
+    expect(findNextRace(races)).toEqual(races[1]);
   });
 
   it('should parse dates with and without a trailing Z', () => {

--- a/src/textMessageHandler.js
+++ b/src/textMessageHandler.js
@@ -16,6 +16,7 @@ const {
   handleNextRaceInfoCommand,
   handleNextRacesCommand,
   handleNextRaceWeatherCommand,
+  handleDeadlineCommand,
   handleBillingStats,
   displayMenuMessage,
   handleVersionCommand,
@@ -54,6 +55,7 @@ const {
   COMMAND_NEXT_RACE_INFO,
   COMMAND_NEXT_RACES,
   COMMAND_NEXT_RACE_WEATHER,
+  COMMAND_DEADLINE,
   COMMAND_BILLING_STATS,
   COMMAND_VERSION,
   COMMAND_MENU,
@@ -126,6 +128,8 @@ exports.handleTextMessage = async function (bot, msg) {
       return await handleNextRacesCommand(bot, chatId);
     case msg.text === COMMAND_NEXT_RACE_WEATHER:
       return await handleNextRaceWeatherCommand(bot, chatId);
+    case msg.text === COMMAND_DEADLINE:
+      return await handleDeadlineCommand(bot, msg);
     case msg.text === COMMAND_BILLING_STATS:
       return await handleBillingStats(bot, msg);
     case msg.text === COMMAND_VERSION:

--- a/src/textMessageHandler.test.js
+++ b/src/textMessageHandler.test.js
@@ -13,6 +13,7 @@ const {
   COMMAND_NEXT_RACE_INFO,
   COMMAND_NEXT_RACES,
   COMMAND_NEXT_RACE_WEATHER,
+  COMMAND_DEADLINE,
   COMMAND_CHIPS,
   COMMAND_SET_LANGUAGE,
   COMMAND_FLOW,
@@ -67,6 +68,7 @@ const {
   handleNextRacesCommand,
 } = require('./commandsHandler/nextRacesHandler');
 const { handleNextRaceWeatherCommand } = require('./commandsHandler/nextRaceWeatherHandler');
+const { handleDeadlineCommand } = require('./commandsHandler/deadlineHandler');
 const { displayMenuMessage } = require('./commandsHandler/menuHandler');
 const { handleSetLanguage } = require('./commandsHandler/setLanguageHandler');
 const { handleFlowCommand } = require('./commandsHandler/flowHandler');
@@ -108,6 +110,7 @@ jest.mock('./commandsHandler/getBotfatherCommandsHandler');
 jest.mock('./commandsHandler/nextRaceInfoHandler');
 jest.mock('./commandsHandler/nextRacesHandler');
 jest.mock('./commandsHandler/nextRaceWeatherHandler');
+jest.mock('./commandsHandler/deadlineHandler');
 jest.mock('./commandsHandler/menuHandler');
 jest.mock('./commandsHandler/setLanguageHandler');
 jest.mock('./commandsHandler/flowHandler');
@@ -238,6 +241,18 @@ describe('handleTextMessage', () => {
       await handleTextMessage(botMock, msgMock);
 
       expect(sendPrintableCache).toHaveBeenCalledWith(KILZI_CHAT_ID, botMock);
+      expect(handleJsonMessage).not.toHaveBeenCalled();
+    });
+
+    it('should route /deadline command to handleDeadlineCommand', async () => {
+      const msgMock = {
+        chat: { id: KILZI_CHAT_ID },
+        text: COMMAND_DEADLINE,
+      };
+
+      await handleTextMessage(botMock, msgMock);
+
+      expect(handleDeadlineCommand).toHaveBeenCalledWith(botMock, msgMock);
       expect(handleJsonMessage).not.toHaveBeenCalled();
     });
 

--- a/src/translations.js
+++ b/src/translations.js
@@ -42,6 +42,13 @@ const translations = {
       'לא נמצאו מרוצים קרובים לעונה זו.',
     'Unable to fetch upcoming races. Please try again later.':
       'לא ניתן להביא את המרוצים הקרובים. נסה שוב מאוחר יותר.',
+    '🏎️ **{RACE_NAME}** starts in:': '🏎️ **{RACE_NAME}** מתחיל בעוד:',
+    '⏳ {DAYS} days, {HOURS} hours, {MINUTES} minutes, {SECONDS} seconds.':
+      '⏳ {DAYS} ימים, {HOURS} שעות, {MINUTES} דקות, {SECONDS} שניות.',
+    'No upcoming race found.': 'לא נמצא מרוץ קרוב.',
+    'Failed to fetch race schedule. Please try again later.':
+      'לא ניתן להביא את לוח הזמנים של המרוצים. נסה שוב מאוחר יותר.',
+    '🔄 Refresh': '🔄 רענון',
     'Upcoming Races': 'מרוצים קרובים',
     'Upcoming Races (continued)': 'מרוצים קרובים (המשך)',
     'Summary: {RACES_SUMMARY}, {SPRINT_SUMMARY}':
@@ -248,6 +255,9 @@ const translations = {
     '🗓️ Upcoming Races': '🗓️ מרוצים קרובים',
     'View schedule details for the remaining races this season':
       'צפה בפרטי לוח הזמנים של המרוצים שנותרו בעונה',
+    '⏳ Deadline Countdown': '⏳ ספירה לאחור לדדליין',
+    'Show countdown to the next race with a refresh button':
+      'הצג ספירה לאחור למרוץ הבא עם כפתור רענון',
     '📈 Current Simulation': '📈 סימולציה נוכחית',
     'Show the current simulation data and name':
       'הצג את נתוני הסימולציה הנוכחית ואת שמה',


### PR DESCRIPTION
### Motivation
- Provide a simple command-only countdown to the next F1 race with an inline refresh button so users can update the remaining time without sending a new command.  
- Reuse the existing Jolpi-backed schedule service and repo i18n conventions while keeping the refresh path resilient to Telegram `message is not modified` errors.  

### Description
- Added a new command handler `src/commandsHandler/deadlineHandler.js` that finds the next race, computes `days/hours/minutes/seconds`, builds the Markdown message (`🏎️ **{RACE_NAME}** starts in:` / `⏳ X days, Y hours, Z minutes, W seconds.`) and sends it with a single inline button (`🔄 Refresh` / `refresh_f1_countdown`).  
- Extended the schedule service with `findNextRace` in `src/raceScheduleService.js` and implemented `getNextRaceForCountdown` to reuse existing fetch/filter logic.  
- Wired the command through the codebase: added `COMMAND_DEADLINE` in `src/constants.js`, registered the handler in `src/commandsHandler/index.js` and `src/commandsHandler/commandHandlers.js`, and routed the literal `/deadline` in `src/textMessageHandler.js`; added the menu entry metadata.  
- Implemented refresh callback handling in `src/callbackQueryHandler.js` (`handleDeadlineRefreshCallback`) which always calls `answerCallbackQuery`, recalculates the countdown, and attempts `editMessageText` while swallowing Telegram’s `message is not modified` error and logging other edit failures; on schedule-fetch failure the refresh leaves the message unchanged (v1 behavior).  
- Added Hebrew translations and message keys in `src/translations.js`, test coverage and unit tests under `src/commandsHandler/deadlineHandler.test.js`, updated `AGENTS.md` to document the new command and callback contract.  

### Testing
- Unit tests added and run: `npm test -- src/commandsHandler/deadlineHandler.test.js src/raceScheduleService.test.js src/callbackQueryHandler.test.js src/textMessageHandler.test.js` and all targeted suites passed.  
- Full project checks (pre-commit hooks) executed: `npm run lint` and `npm run test:coverage`, and the full test suite passed (51 test suites, 452 tests passed).  
- Tests include: countdown formatting, sending message with refresh keyboard, fallback when no upcoming race, `findNextRace` behavior, and refresh callback handling (including swallowing the `message is not modified` error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd4514113483268063fdb9f02661d7)