### PR TITLE
Add `/deadline` command and refreshable deadline callback (countdown to lock)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ This repository contains a Telegram bot that helps manage F1 Fantasy teams. The 
    - `nextRaceInfoHandler.js` – detailed next race info.
    - `nextRaceWeatherHandler.js` – weather forecasts.
    - `nextRacesHandler.js` – upcoming race schedule (new `/next_races`).
+   - `deadlineHandler.js` – next fantasy lock deadline countdown with refresh callback (`/deadline`).
    - `selectTeamHandler.js` – switch between multiple teams.
    - `setBestTeamRankingHandler.js` – choose how expected budget changes influence best-team ranking.
    - `setNicknameHandler.js` – admin command to set user nicknames.
@@ -57,7 +58,7 @@ This repository contains a Telegram bot that helps manage F1 Fantasy teams. The 
 - `/best_teams`, `/best_team_scenarios`, `/current_team_info`, `/chips`, `/extra_boost`, `/limitless`, `/wildcard`, `/reset_chip`
 - `/set_best_team_ranking`
 - `/select_team`, `/print_cache`, `/reset_cache`
-- `/next_race_info`, `/next_races`, `/next_race_weather`
+- `/next_race_info`, `/next_races`, `/next_race_weather`, `/deadline`
 - `/get_current_simulation`
 - `/load_simulation`
 - `/menu`, `/help`, `/lang`

--- a/src/callbackQueryHandler.js
+++ b/src/callbackQueryHandler.js
@@ -18,6 +18,7 @@ const {
   TEAM_CALLBACK_TYPE,
   TEAM_ASSIGN_CALLBACK_TYPE,
   BEST_TEAM_WEIGHTS_CALLBACK_TYPE,
+  DEADLINE_CALLBACK_TYPE,
 } = require('./constants');
 
 const {
@@ -29,6 +30,10 @@ const { t, setLanguage, getLanguageName } = require('./i18n');
 const {
   BEST_TEAM_RANKING_PRESETS,
 } = require('./commandsHandler/setBestTeamRankingHandler');
+const {
+  getDeadlinePayload,
+  getRefreshMarkup,
+} = require('./commandsHandler/deadlineHandler');
 
 exports.handleCallbackQuery = async function (bot, query) {
   const callbackType = query.data.split(':')[0];
@@ -46,10 +51,63 @@ exports.handleCallbackQuery = async function (bot, query) {
       return await handleTeamAssignCallback(bot, query);
     case BEST_TEAM_WEIGHTS_CALLBACK_TYPE:
       return await handleBestTeamRankingCallback(bot, query);
+    case DEADLINE_CALLBACK_TYPE:
+      return await handleDeadlineRefreshCallback(bot, query);
     default:
       await sendLogMessage(bot, `Unknown callback type: ${callbackType}`);
   }
 };
+
+
+
+function isTelegramMessageNotModifiedError(error) {
+  const description =
+    error?.response?.body?.description ||
+    error?.message ||
+    '';
+
+  return description.toLowerCase().includes('message is not modified');
+}
+
+async function handleDeadlineRefreshCallback(bot, query) {
+  const chatId = query.message.chat.id;
+  const messageId = query.message.message_id;
+
+  try {
+    const payload = await getDeadlinePayload(chatId);
+
+    try {
+      await bot.editMessageText(payload.text, {
+        chat_id: chatId,
+        message_id: messageId,
+        ...payload.options,
+      });
+    } catch (error) {
+      if (!isTelegramMessageNotModifiedError(error)) {
+        throw error;
+      }
+    }
+  } catch (error) {
+    const fallbackText = t(
+      'Failed to fetch deadline data. Please try again later.',
+      chatId,
+    );
+
+    try {
+      await bot.editMessageText(fallbackText, {
+        chat_id: chatId,
+        message_id: messageId,
+        ...getRefreshMarkup(chatId),
+      });
+    } catch (editError) {
+      if (!isTelegramMessageNotModifiedError(editError)) {
+        throw editError;
+      }
+    }
+  }
+
+  await bot.answerCallbackQuery(query.id);
+}
 
 async function handleChipCallback(bot, query) {
   const chatId = query.message.chat.id;

--- a/src/callbackQueryHandler.test.js
+++ b/src/callbackQueryHandler.test.js
@@ -5,6 +5,7 @@ const {
   TEAM_CALLBACK_TYPE,
   TEAM_ASSIGN_CALLBACK_TYPE,
   BEST_TEAM_WEIGHTS_CALLBACK_TYPE,
+  DEADLINE_CALLBACK_TYPE,
   EXTRA_BOOST_CHIP,
 } = require('./constants');
 const cache = require('./cache');
@@ -12,6 +13,10 @@ const azureStorageService = require('./azureStorageService');
 const { updateUserAttributes } = require('./userRegistryService');
 const { setLanguage } = require('./i18n');
 const { selectChip } = require('./commandsHandler/selectChipHandlers');
+const {
+  getDeadlinePayload,
+  getRefreshMarkup,
+} = require('./commandsHandler/deadlineHandler');
 
 jest.mock('./utils', () => ({
   sendLogMessage: jest.fn().mockResolvedValue(undefined),
@@ -30,6 +35,24 @@ jest.mock('./userRegistryService', () => ({
 
 jest.mock('./commandsHandler/selectChipHandlers', () => ({
   selectChip: jest.fn().mockResolvedValue('chip selected'),
+}));
+
+jest.mock('./commandsHandler/deadlineHandler', () => ({
+  getDeadlinePayload: jest.fn().mockResolvedValue({
+    text: 'updated deadline',
+    options: {
+      parse_mode: 'Markdown',
+      reply_markup: {
+        inline_keyboard: [[{ text: 'Refresh', callback_data: 'DEADLINE:refresh' }]],
+      },
+    },
+  }),
+  getRefreshMarkup: jest.fn(() => ({
+    parse_mode: 'Markdown',
+    reply_markup: {
+      inline_keyboard: [[{ text: 'Refresh', callback_data: 'DEADLINE:refresh' }]],
+    },
+  })),
 }));
 
 jest.mock('./i18n', () => ({
@@ -167,5 +190,67 @@ describe('handleCallbackQuery', () => {
 
     expect(updateUserAttributes).toHaveBeenCalled();
     expect(bot.answerCallbackQuery).toHaveBeenCalledWith('q6');
+  });
+
+  it('should handle deadline refresh callback', async () => {
+    const query = {
+      id: 'q7',
+      data: `${DEADLINE_CALLBACK_TYPE}:refresh`,
+      message: { chat: { id: 123 }, message_id: 456 },
+    };
+
+    await handleCallbackQuery(bot, query);
+
+    expect(getDeadlinePayload).toHaveBeenCalledWith(123);
+    expect(bot.editMessageText).toHaveBeenCalledWith('updated deadline', {
+      chat_id: 123,
+      message_id: 456,
+      parse_mode: 'Markdown',
+      reply_markup: {
+        inline_keyboard: [[{ text: 'Refresh', callback_data: 'DEADLINE:refresh' }]],
+      },
+    });
+    expect(bot.answerCallbackQuery).toHaveBeenCalledWith('q7');
+  });
+
+  it('should swallow Telegram message is not modified errors', async () => {
+    const query = {
+      id: 'q8',
+      data: `${DEADLINE_CALLBACK_TYPE}:refresh`,
+      message: { chat: { id: 123 }, message_id: 456 },
+    };
+
+    bot.editMessageText.mockRejectedValue({
+      response: { body: { description: 'Bad Request: message is not modified' } },
+    });
+
+    await expect(handleCallbackQuery(bot, query)).resolves.toBeUndefined();
+    expect(bot.answerCallbackQuery).toHaveBeenCalledWith('q8');
+  });
+
+  it('should keep refresh button on fallback error message', async () => {
+    const query = {
+      id: 'q9',
+      data: `${DEADLINE_CALLBACK_TYPE}:refresh`,
+      message: { chat: { id: 123 }, message_id: 456 },
+    };
+
+    getDeadlinePayload.mockRejectedValueOnce(new Error('boom'));
+
+    await handleCallbackQuery(bot, query);
+
+    expect(getRefreshMarkup).toHaveBeenCalledWith(123);
+    expect(bot.editMessageText).toHaveBeenCalledWith(
+      'Failed to fetch deadline data. Please try again later.',
+      {
+        chat_id: 123,
+        message_id: 456,
+        parse_mode: 'Markdown',
+        reply_markup: {
+          inline_keyboard: [[{ text: 'Refresh', callback_data: 'DEADLINE:refresh' }]],
+        },
+      },
+    );
+    expect(bot.answerCallbackQuery).toHaveBeenCalledWith('q9');
   });
 });

--- a/src/commandsHandler/commandHandlers.js
+++ b/src/commandsHandler/commandHandlers.js
@@ -33,6 +33,7 @@ const {
   COMMAND_SELECT_TEAM,
   COMMAND_SET_BEST_TEAM_RANKING,
   COMMAND_LIVE_SCORE,
+  COMMAND_DEADLINE,
 } = require('../constants');
 
 const { handleBestTeamsMessage } = require('./bestTeamsHandler');
@@ -74,6 +75,7 @@ const {
 const { handleSelectTeamCommand } = require('./selectTeamHandler');
 const { handleSetBestTeamRanking } = require('./setBestTeamRankingHandler');
 const { handleLiveScoreCommand } = require('./liveScoreHandler');
+const { handleDeadlineCommand } = require('./deadlineHandler');
 
 // Mapping of command constants to their handler functions
 const COMMAND_HANDLERS = {
@@ -111,6 +113,7 @@ const COMMAND_HANDLERS = {
   [COMMAND_SELECT_TEAM]: handleSelectTeamCommand,
   [COMMAND_SET_BEST_TEAM_RANKING]: handleSetBestTeamRanking,
   [COMMAND_LIVE_SCORE]: handleLiveScoreCommand,
+  [COMMAND_DEADLINE]: handleDeadlineCommand,
 };
 
 async function executeCommand(bot, msg, command) {

--- a/src/commandsHandler/deadlineHandler.js
+++ b/src/commandsHandler/deadlineHandler.js
@@ -61,7 +61,7 @@ function buildDeadlineMessage(chatId, deadlineSession, now = new Date()) {
   if (millisecondsToDeadline <= 0) {
     return [
       title,
-      `${sessionLabel}: ${deadlineSession.label}`,
+      `${sessionLabel}: ${t(deadlineSession.label, chatId)}`,
       t('This session already started.', chatId),
       reminder,
     ].join('\n\n');
@@ -71,7 +71,7 @@ function buildDeadlineMessage(chatId, deadlineSession, now = new Date()) {
 
   return [
     title,
-    `${sessionLabel}: ${deadlineSession.label}`,
+    `${sessionLabel}: ${t(deadlineSession.label, chatId)}`,
     duration,
     reminder,
   ].join('\n\n');

--- a/src/commandsHandler/deadlineHandler.js
+++ b/src/commandsHandler/deadlineHandler.js
@@ -12,10 +12,15 @@ function getDurationParts(totalMilliseconds) {
   return { days, hours, minutes, seconds };
 }
 
-function formatDuration(totalMilliseconds) {
+function formatDuration(totalMilliseconds, chatId) {
   const { days, hours, minutes, seconds } = getDurationParts(totalMilliseconds);
 
-  return `${days} days, ${hours} hours, ${minutes} minutes and ${seconds} seconds`;
+  const dayLabel = t(days === 1 ? 'day' : 'days', chatId);
+  const hourLabel = t(hours === 1 ? 'hour' : 'hours', chatId);
+  const minuteLabel = t(minutes === 1 ? 'minute' : 'minutes', chatId);
+  const secondLabel = t(seconds === 1 ? 'second' : 'seconds', chatId);
+
+  return `${days} ${dayLabel}, ${hours} ${hourLabel}, ${minutes} ${minuteLabel} ${t('and', chatId)} ${seconds} ${secondLabel}`;
 }
 
 function getDeadlineSession(race) {
@@ -62,7 +67,7 @@ function buildDeadlineMessage(chatId, deadlineSession, now = new Date()) {
     ].join('\n\n');
   }
 
-  const duration = formatDuration(millisecondsToDeadline);
+  const duration = formatDuration(millisecondsToDeadline, chatId);
 
   return [
     title,

--- a/src/commandsHandler/deadlineHandler.js
+++ b/src/commandsHandler/deadlineHandler.js
@@ -1,0 +1,131 @@
+const { t } = require('../i18n');
+const { buildDate, fetchNextRace } = require('../raceScheduleService');
+const { DEADLINE_CALLBACK_TYPE } = require('../constants');
+
+function getDurationParts(totalMilliseconds) {
+  const totalSeconds = Math.max(0, Math.floor(totalMilliseconds / 1000));
+  const days = Math.floor(totalSeconds / (24 * 60 * 60));
+  const hours = Math.floor((totalSeconds % (24 * 60 * 60)) / (60 * 60));
+  const minutes = Math.floor((totalSeconds % (60 * 60)) / 60);
+  const seconds = totalSeconds % 60;
+
+  return { days, hours, minutes, seconds };
+}
+
+function formatDuration(totalMilliseconds) {
+  const { days, hours, minutes, seconds } = getDurationParts(totalMilliseconds);
+
+  return `${days} days, ${hours} hours, ${minutes} minutes and ${seconds} seconds`;
+}
+
+function getDeadlineSession(race) {
+  const sprintDate = buildDate(race?.Sprint?.date, race?.Sprint?.time);
+  if (sprintDate) {
+    return {
+      type: 'sprint',
+      label: 'sprint',
+      startsAt: sprintDate,
+    };
+  }
+
+  const qualifyingDate = buildDate(race?.Qualifying?.date, race?.Qualifying?.time);
+
+  return {
+    type: 'qualifying',
+    label: 'quali',
+    startsAt: qualifyingDate,
+  };
+}
+
+function buildDeadlineMessage(chatId, deadlineSession, now = new Date()) {
+  const title = `*${t('Teams Lock Deadline', chatId)}*`;
+  const sessionLabel = t('Session type', chatId);
+  const reminder = t('Dont forget to lock the team before that time', chatId);
+
+  if (!deadlineSession?.startsAt) {
+    return [
+      title,
+      `${sessionLabel}: ${t('Unavailable', chatId)}`,
+      t('Unable to determine deadline for the next race.', chatId),
+      reminder,
+    ].join('\n\n');
+  }
+
+  const millisecondsToDeadline = deadlineSession.startsAt.getTime() - now.getTime();
+
+  if (millisecondsToDeadline <= 0) {
+    return [
+      title,
+      `${sessionLabel}: ${deadlineSession.label}`,
+      t('This session already started.', chatId),
+      reminder,
+    ].join('\n\n');
+  }
+
+  const duration = formatDuration(millisecondsToDeadline);
+
+  return [
+    title,
+    `${sessionLabel}: ${deadlineSession.label}`,
+    duration,
+    reminder,
+  ].join('\n\n');
+}
+
+function getRefreshMarkup(chatId) {
+  return {
+    parse_mode: 'Markdown',
+    reply_markup: {
+      inline_keyboard: [[
+        {
+          text: t('🔄 Refresh', chatId),
+          callback_data: `${DEADLINE_CALLBACK_TYPE}:refresh`,
+        },
+      ]],
+    },
+  };
+}
+
+async function getDeadlinePayload(chatId, now = new Date()) {
+  const race = await fetchNextRace();
+
+  if (!race) {
+    return {
+      text: t('Next race information is currently unavailable.', chatId),
+      options: getRefreshMarkup(chatId),
+    };
+  }
+
+  const deadlineSession = getDeadlineSession(race);
+  const text = buildDeadlineMessage(chatId, deadlineSession, now);
+
+  return {
+    text,
+    options: getRefreshMarkup(chatId),
+  };
+}
+
+async function handleDeadlineCommand(bot, msg) {
+  const chatId = msg.chat.id;
+
+  try {
+    const payload = await getDeadlinePayload(chatId);
+    await bot.sendMessage(chatId, payload.text, payload.options);
+  } catch (error) {
+    await bot.sendMessage(
+      chatId,
+      t('Failed to fetch deadline data. Please try again later.', chatId),
+      getRefreshMarkup(chatId),
+    );
+  }
+}
+
+module.exports = {
+  getDurationParts,
+  formatDuration,
+  getDeadlineSession,
+  buildDeadlineMessage,
+  getRefreshMarkup,
+  getDeadlinePayload,
+  handleDeadlineCommand,
+};

--- a/src/commandsHandler/deadlineHandler.test.js
+++ b/src/commandsHandler/deadlineHandler.test.js
@@ -1,0 +1,126 @@
+jest.mock('../raceScheduleService', () => {
+  const actual = jest.requireActual('../raceScheduleService');
+
+  return {
+    ...actual,
+    fetchNextRace: jest.fn(),
+  };
+});
+
+const {
+  formatDuration,
+  getDeadlineSession,
+  buildDeadlineMessage,
+  getDeadlinePayload,
+  handleDeadlineCommand,
+} = require('./deadlineHandler');
+const { fetchNextRace } = require('../raceScheduleService');
+
+describe('deadlineHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('formats duration as days, hours, minutes and seconds', () => {
+    const value = ((2 * 24 * 60 * 60) + (3 * 60 * 60) + (4 * 60) + 5) * 1000;
+
+    expect(formatDuration(value)).toBe('2 days, 3 hours, 4 minutes and 5 seconds');
+  });
+
+  it('uses sprint as deadline in sprint weekend', () => {
+    const session = getDeadlineSession({
+      Sprint: {
+        date: '2026-05-02',
+        time: '15:30:00Z',
+      },
+      Qualifying: {
+        date: '2026-05-03',
+        time: '15:30:00Z',
+      },
+    });
+
+    expect(session.type).toBe('sprint');
+    expect(session.label).toBe('sprint');
+    expect(session.startsAt).toEqual(new Date('2026-05-02T15:30:00Z'));
+  });
+
+  it('uses qualifying as deadline in regular weekend', () => {
+    const session = getDeadlineSession({
+      Qualifying: {
+        date: '2026-05-03',
+        time: '15:30:00Z',
+      },
+    });
+
+    expect(session.type).toBe('qualifying');
+    expect(session.label).toBe('quali');
+    expect(session.startsAt).toEqual(new Date('2026-05-03T15:30:00Z'));
+  });
+
+  it('builds active countdown message in the requested format', () => {
+    const message = buildDeadlineMessage(
+      123,
+      {
+        label: 'quali',
+        startsAt: new Date('2026-05-03T15:30:00Z'),
+      },
+      new Date('2026-05-01T15:30:00Z'),
+    );
+
+    expect(message).toBe(
+      '*Teams Lock Deadline*\n\nSession type: quali\n\n2 days, 0 hours, 0 minutes and 0 seconds\n\nDont forget to lock the team before that time',
+    );
+  });
+
+  it('builds started message when deadline already passed', () => {
+    const message = buildDeadlineMessage(
+      123,
+      {
+        label: 'sprint',
+        startsAt: new Date('2026-05-01T15:30:00Z'),
+      },
+      new Date('2026-05-01T15:30:01Z'),
+    );
+
+    expect(message).toBe(
+      '*Teams Lock Deadline*\n\nSession type: sprint\n\nThis session already started.\n\nDont forget to lock the team before that time',
+    );
+  });
+
+  it('fetches race from raceScheduleService and builds payload', async () => {
+    fetchNextRace.mockResolvedValue({
+      raceName: 'Miami Grand Prix',
+      Qualifying: {
+        date: '2026-05-03',
+        time: '15:30:00Z',
+      },
+    });
+
+    const payload = await getDeadlinePayload(123, new Date('2026-05-01T15:30:00Z'));
+
+    expect(fetchNextRace).toHaveBeenCalledTimes(1);
+    expect(payload.text).toContain('Session type: quali');
+    expect(payload.options.parse_mode).toBe('Markdown');
+    expect(payload.options.reply_markup.inline_keyboard[0][0].callback_data).toBe('DEADLINE:refresh');
+  });
+
+  it('sends fallback error message when service fails', async () => {
+    fetchNextRace.mockRejectedValue(new Error('boom'));
+
+    const botMock = { sendMessage: jest.fn().mockResolvedValue(undefined) };
+    const msg = { chat: { id: 123 } };
+
+    await handleDeadlineCommand(botMock, msg);
+
+    expect(botMock.sendMessage).toHaveBeenCalledWith(
+      123,
+      'Failed to fetch deadline data. Please try again later.',
+      {
+        parse_mode: 'Markdown',
+        reply_markup: {
+          inline_keyboard: [[{ text: '🔄 Refresh', callback_data: 'DEADLINE:refresh' }]],
+        },
+      },
+    );
+  });
+});

--- a/src/commandsHandler/index.js
+++ b/src/commandsHandler/index.js
@@ -41,6 +41,7 @@ const {
 const { handleSelectTeamCommand } = require('./selectTeamHandler');
 const { handleSetBestTeamRanking } = require('./setBestTeamRankingHandler');
 const { handleLiveScoreCommand } = require('./liveScoreHandler');
+const { handleDeadlineCommand } = require('./deadlineHandler');
 
 module.exports = {
   handleBestTeamsMessage,
@@ -79,4 +80,5 @@ module.exports = {
   handleSelectTeamCommand,
   handleSetBestTeamRanking,
   handleLiveScoreCommand,
+  handleDeadlineCommand,
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -30,6 +30,7 @@ exports.LANG_CALLBACK_TYPE = 'LANG';
 exports.TEAM_CALLBACK_TYPE = 'TEAM';
 exports.TEAM_ASSIGN_CALLBACK_TYPE = 'TEAM_ASSIGN';
 exports.BEST_TEAM_WEIGHTS_CALLBACK_TYPE = 'BEST_TEAM_WEIGHTS';
+exports.DEADLINE_CALLBACK_TYPE = 'DEADLINE';
 
 exports.MAX_TELEGRAM_MESSAGE_LENGTH = 4096;
 exports.BEST_TEAMS_RESULT_COUNT = 15;
@@ -68,6 +69,7 @@ exports.COMMAND_UPLOAD_CONSTRUCTORS_PHOTO = '/upload_constructors_photo';
 exports.COMMAND_SELECT_TEAM = '/select_team';
 exports.COMMAND_SET_BEST_TEAM_RANKING = '/set_best_team_ranking';
 exports.COMMAND_BEST_TEAM_SCENARIOS = '/best_team_scenarios';
+exports.COMMAND_DEADLINE = '/deadline';
 
 // Menu configuration for interactive menu command
 exports.MENU_CATEGORIES = {
@@ -160,6 +162,11 @@ exports.MENU_CATEGORIES = {
         constant: exports.COMMAND_NEXT_RACE_WEATHER,
         title: '🌦️ Next Race Weather',
         description: 'Get detailed weather forecast for the next race',
+      },
+      {
+        constant: exports.COMMAND_DEADLINE,
+        title: '⏳ Deadline',
+        description: 'Show time left until your next fantasy team lock deadline',
       },
       {
         constant: exports.COMMAND_GET_CURRENT_SIMULATION,

--- a/src/raceScheduleService.js
+++ b/src/raceScheduleService.js
@@ -1,4 +1,5 @@
 const NEXT_RACES_ENDPOINT = 'https://api.jolpi.ca/ergast/f1/current.json';
+const NEXT_RACE_ENDPOINT = 'https://api.jolpi.ca/ergast/f1/current/next.json';
 
 function buildDate(dateStr, timeStr) {
   if (!dateStr) {
@@ -30,6 +31,18 @@ async function fetchCurrentSeasonRaces() {
   return response.json();
 }
 
+async function fetchNextRace() {
+  const response = await fetch(NEXT_RACE_ENDPOINT);
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  const data = await response.json();
+
+  return data?.MRData?.RaceTable?.Races?.[0] || null;
+}
+
 function filterUpcomingRaces(races) {
   const now = new Date();
 
@@ -48,8 +61,11 @@ async function fetchRemainingRaceCount() {
 }
 
 module.exports = {
+  NEXT_RACES_ENDPOINT,
+  NEXT_RACE_ENDPOINT,
   buildDate,
   fetchCurrentSeasonRaces,
+  fetchNextRace,
   filterUpcomingRaces,
   fetchRemainingRaceCount,
 };

--- a/src/raceScheduleService.test.js
+++ b/src/raceScheduleService.test.js
@@ -1,6 +1,9 @@
 const {
+  NEXT_RACES_ENDPOINT,
+  NEXT_RACE_ENDPOINT,
   buildDate,
   fetchCurrentSeasonRaces,
+  fetchNextRace,
   filterUpcomingRaces,
   fetchRemainingRaceCount,
 } = require('./raceScheduleService');
@@ -26,9 +29,7 @@ describe('raceScheduleService', () => {
     });
 
     await expect(fetchCurrentSeasonRaces()).resolves.toEqual(apiResponse);
-    expect(global.fetch).toHaveBeenCalledWith(
-      'https://api.jolpi.ca/ergast/f1/current.json'
-    );
+    expect(global.fetch).toHaveBeenCalledWith(NEXT_RACES_ENDPOINT);
   });
 
   it('should throw when the season fetch fails', async () => {
@@ -38,6 +39,32 @@ describe('raceScheduleService', () => {
     });
 
     await expect(fetchCurrentSeasonRaces()).rejects.toThrow('HTTP 503');
+  });
+
+  it('should fetch next race data', async () => {
+    const apiResponse = {
+      MRData: {
+        RaceTable: {
+          Races: [{ raceName: 'Miami Grand Prix' }],
+        },
+      },
+    };
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(apiResponse),
+    });
+
+    await expect(fetchNextRace()).resolves.toEqual({ raceName: 'Miami Grand Prix' });
+    expect(global.fetch).toHaveBeenCalledWith(NEXT_RACE_ENDPOINT);
+  });
+
+  it('should throw when next race fetch fails', async () => {
+    global.fetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+
+    await expect(fetchNextRace()).rejects.toThrow('HTTP 500');
   });
 
   it('should filter only upcoming races', () => {

--- a/src/textMessageHandler.js
+++ b/src/textMessageHandler.js
@@ -36,6 +36,7 @@ const {
   handleSelectTeamCommand,
   handleSetBestTeamRanking,
   handleLiveScoreCommand,
+  handleDeadlineCommand,
 } = require('./commandsHandler');
 
 // Import constants
@@ -74,6 +75,7 @@ const {
   COMMAND_SELECT_TEAM,
   COMMAND_SET_BEST_TEAM_RANKING,
   COMMAND_LIVE_SCORE,
+  COMMAND_DEADLINE,
 } = require('./constants');
 
 exports.handleTextMessage = async function (bot, msg) {
@@ -158,6 +160,8 @@ exports.handleTextMessage = async function (bot, msg) {
       return await handleSetBestTeamRanking(bot, msg);
     case msg.text === COMMAND_LIVE_SCORE:
       return await handleLiveScoreCommand(bot, msg);
+    case msg.text === COMMAND_DEADLINE:
+      return await handleDeadlineCommand(bot, msg);
     default:
       try {
         const jsonData = JSON.parse(textTrimmed);

--- a/src/textMessageHandler.test.js
+++ b/src/textMessageHandler.test.js
@@ -24,6 +24,7 @@ const {
   COMMAND_UPLOAD_CONSTRUCTORS_PHOTO,
   COMMAND_SET_BEST_TEAM_RANKING,
   COMMAND_LIVE_SCORE,
+  COMMAND_DEADLINE,
 } = require('./constants');
 
 jest.mock('openai', () => ({
@@ -91,6 +92,9 @@ const {
 const {
   handleLiveScoreCommand,
 } = require('./commandsHandler/liveScoreHandler');
+const {
+  handleDeadlineCommand,
+} = require('./commandsHandler/deadlineHandler');
 
 jest.mock('./commandsHandler/numberInputHandler');
 jest.mock('./commandsHandler/jsonInputHandler');
@@ -119,6 +123,7 @@ jest.mock('./commandsHandler/uploadDriversPhotoHandler');
 jest.mock('./commandsHandler/uploadConstructorsPhotoHandler');
 jest.mock('./commandsHandler/setBestTeamRankingHandler');
 jest.mock('./commandsHandler/liveScoreHandler');
+jest.mock('./commandsHandler/deadlineHandler');
 
 const { handleTextMessage } = require('./textMessageHandler');
 const { handleAskCommand } = require('./commandsHandler/askHandler');
@@ -226,6 +231,18 @@ describe('handleTextMessage', () => {
       await handleTextMessage(botMock, msgMock);
 
       expect(handleLiveScoreCommand).toHaveBeenCalledWith(botMock, msgMock);
+      expect(handleJsonMessage).not.toHaveBeenCalled();
+    });
+
+    it('should route /deadline command to handleDeadlineCommand', async () => {
+      const msgMock = {
+        chat: { id: KILZI_CHAT_ID },
+        text: COMMAND_DEADLINE,
+      };
+
+      await handleTextMessage(botMock, msgMock);
+
+      expect(handleDeadlineCommand).toHaveBeenCalledWith(botMock, msgMock);
       expect(handleJsonMessage).not.toHaveBeenCalled();
     });
 

--- a/src/translations.js
+++ b/src/translations.js
@@ -280,6 +280,7 @@ const translations = {
     'Dont forget to lock the team before that time':
       'אל תשכח לנעול את הקבוצה לפני הזמן הזה',
     'This session already started.': 'הסשן הזה כבר התחיל.',
+    '🔄 Refresh': '🔄 רענון',
     sprint: 'ספרינט',
     quali: 'דירוג',
     day: 'יום',

--- a/src/translations.js
+++ b/src/translations.js
@@ -272,6 +272,23 @@ const translations = {
     '🔴 Live Score': '🔴 ניקוד חי',
     'Show current live points and price change for your team':
       'הצג את הניקוד החי ושינוי המחיר הנוכחיים של הקבוצה שלך',
+    '⏳ Deadline': '⏳ דדליין',
+    'Show time left until your next fantasy team lock deadline':
+      'הצג את הזמן שנותר עד דדליין נעילת הקבוצה הבאה שלך',
+    'Teams Lock Deadline': 'דדליין נעילת הקבוצה',
+    'Session type': 'סוג סשן',
+    'Dont forget to lock the team before that time':
+      'אל תשכח לנעול את הקבוצה לפני הזמן הזה',
+    'This session already started.': 'הסשן הזה כבר התחיל.',
+    day: 'יום',
+    days: 'ימים',
+    hour: 'שעה',
+    hours: 'שעות',
+    minute: 'דקה',
+    minutes: 'דקות',
+    second: 'שנייה',
+    seconds: 'שניות',
+    and: 'ו-',
     'Live Score': 'ניקוד חי',
     'Live Score Summary': 'סיכום ניקוד בזמן אמת',
     'Updated At': 'עודכן ב',

--- a/src/translations.js
+++ b/src/translations.js
@@ -280,6 +280,8 @@ const translations = {
     'Dont forget to lock the team before that time':
       'אל תשכח לנעול את הקבוצה לפני הזמן הזה',
     'This session already started.': 'הסשן הזה כבר התחיל.',
+    sprint: 'ספרינט',
+    quali: 'דירוג',
     day: 'יום',
     days: 'ימים',
     hour: 'שעה',


### PR DESCRIPTION
### Motivation
- Provide users with a quick way to see the time left until the next fantasy team lock deadline and allow refreshing the countdown via an inline button.
- Reuse race schedule data to determine whether the sprint or qualifying session is the relevant lock time.

### Description
- Add a new `deadlineHandler` (`src/commandsHandler/deadlineHandler.js`) that builds a human-readable countdown, returns a payload with `parse_mode: 'Markdown'` and a refresh inline keyboard, and exposes `handleDeadlineCommand`, `getDeadlinePayload`, and helper functions.`
- Wire the new command into the system by adding `COMMAND_DEADLINE` to `src/constants.js`, registering `handleDeadlineCommand` in `src/commandsHandler/commandHandlers.js` and `src/commandsHandler/index.js`, and routing `/deadline` in `src/textMessageHandler.js`.
- Add callback support for the refresh button by handling `DEADLINE` callbacks in `src/callbackQueryHandler.js`, including graceful swallowing of Telegram "message is not modified" errors and a fallback editable message with the refresh button on fetch failure.
- Extend `raceScheduleService.js` with `fetchNextRace()` and a new `NEXT_RACE_ENDPOINT` used by the deadline logic, and update menus in `src/AGENTS.md` to include the `Deadline` menu item.

### Testing
- Added unit tests for the deadline logic (`src/commandsHandler/deadlineHandler.test.js`) that validate duration formatting, session selection (sprint vs quali), payload building, and fallback behavior, and they passed.
- Updated `src/callbackQueryHandler.test.js` to cover the deadline refresh flow and error swallowing, and the tests passed.
- Extended `src/raceScheduleService.test.js` with tests for `fetchNextRace()` and endpoint usage, and updated `src/textMessageHandler.test.js` to verify routing of `/deadline`, and all tests passed when running the Jest suite via `npm test`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd98becf408326a549eba5dc6b95c0)