### PR TITLE
Add race name to /deadline response

### DIFF
--- a/src/commandsHandler/deadlineHandler.js
+++ b/src/commandsHandler/deadlineHandler.js
@@ -42,14 +42,17 @@ function getDeadlineSession(race) {
   };
 }
 
-function buildDeadlineMessage(chatId, deadlineSession, now = new Date()) {
+function buildDeadlineMessage(chatId, raceName, deadlineSession, now = new Date()) {
   const title = `*${t('Teams Lock Deadline', chatId)}*`;
+  const raceLabel = t('Race', chatId);
+  const raceValue = raceName || t('Unavailable', chatId);
   const sessionLabel = t('Session type', chatId);
   const reminder = t('Dont forget to lock the team before that time', chatId);
 
   if (!deadlineSession?.startsAt) {
     return [
       title,
+      `${raceLabel}: ${raceValue}`,
       `${sessionLabel}: ${t('Unavailable', chatId)}`,
       t('Unable to determine deadline for the next race.', chatId),
       reminder,
@@ -61,6 +64,7 @@ function buildDeadlineMessage(chatId, deadlineSession, now = new Date()) {
   if (millisecondsToDeadline <= 0) {
     return [
       title,
+      `${raceLabel}: ${raceValue}`,
       `${sessionLabel}: ${t(deadlineSession.label, chatId)}`,
       t('This session already started.', chatId),
       reminder,
@@ -71,6 +75,7 @@ function buildDeadlineMessage(chatId, deadlineSession, now = new Date()) {
 
   return [
     title,
+    `${raceLabel}: ${raceValue}`,
     `${sessionLabel}: ${t(deadlineSession.label, chatId)}`,
     duration,
     reminder,
@@ -102,7 +107,7 @@ async function getDeadlinePayload(chatId, now = new Date()) {
   }
 
   const deadlineSession = getDeadlineSession(race);
-  const text = buildDeadlineMessage(chatId, deadlineSession, now);
+  const text = buildDeadlineMessage(chatId, race.raceName, deadlineSession, now);
 
   return {
     text,

--- a/src/commandsHandler/deadlineHandler.test.js
+++ b/src/commandsHandler/deadlineHandler.test.js
@@ -60,6 +60,7 @@ describe('deadlineHandler', () => {
   it('builds active countdown message in the requested format', () => {
     const message = buildDeadlineMessage(
       123,
+      'Miami Grand Prix',
       {
         label: 'quali',
         startsAt: new Date('2026-05-03T15:30:00Z'),
@@ -68,13 +69,14 @@ describe('deadlineHandler', () => {
     );
 
     expect(message).toBe(
-      '*Teams Lock Deadline*\n\nSession type: quali\n\n2 days, 0 hours, 0 minutes and 0 seconds\n\nDont forget to lock the team before that time',
+      '*Teams Lock Deadline*\n\nRace: Miami Grand Prix\n\nSession type: quali\n\n2 days, 0 hours, 0 minutes and 0 seconds\n\nDont forget to lock the team before that time',
     );
   });
 
   it('builds started message when deadline already passed', () => {
     const message = buildDeadlineMessage(
       123,
+      'Miami Grand Prix',
       {
         label: 'sprint',
         startsAt: new Date('2026-05-01T15:30:00Z'),
@@ -83,7 +85,7 @@ describe('deadlineHandler', () => {
     );
 
     expect(message).toBe(
-      '*Teams Lock Deadline*\n\nSession type: sprint\n\nThis session already started.\n\nDont forget to lock the team before that time',
+      '*Teams Lock Deadline*\n\nRace: Miami Grand Prix\n\nSession type: sprint\n\nThis session already started.\n\nDont forget to lock the team before that time',
     );
   });
 
@@ -99,6 +101,7 @@ describe('deadlineHandler', () => {
     const payload = await getDeadlinePayload(123, new Date('2026-05-01T15:30:00Z'));
 
     expect(fetchNextRace).toHaveBeenCalledTimes(1);
+    expect(payload.text).toContain('Race: Miami Grand Prix');
     expect(payload.text).toContain('Session type: quali');
     expect(payload.options.parse_mode).toBe('Markdown');
     expect(payload.options.reply_markup.inline_keyboard[0][0].callback_data).toBe('DEADLINE:refresh');

--- a/src/translations.js
+++ b/src/translations.js
@@ -276,6 +276,7 @@ const translations = {
     'Show time left until your next fantasy team lock deadline':
       'הצג את הזמן שנותר עד דדליין נעילת הקבוצה הבאה שלך',
     'Teams Lock Deadline': 'דדליין נעילת הקבוצה',
+    Race: 'מרוץ',
     'Session type': 'סוג סשן',
     'Dont forget to lock the team before that time':
       'אל תשכח לנעול את הקבוצה לפני הזמן הזה',


### PR DESCRIPTION
### Motivation
- Make the `/deadline` output clearer by showing which race the lock countdown refers to so users can immediately identify the event.

### Description
- Added a `raceName` parameter to `buildDeadlineMessage` and include a `Race: {name}` line in all message variants (countdown, already-started, and missing-session fallback).
- Wire `fetchNextRace()` result into the message builder by passing `race.raceName` from `getDeadlinePayload` to `buildDeadlineMessage`.
- Added the `Race` translation entry to `src/translations.js` so the new label is localized.
- Updated `src/commandsHandler/deadlineHandler.test.js` to assert the new race-name line is present in generated messages and payloads.

### Testing
- Ran `npm test -- src/commandsHandler/deadlineHandler.test.js` and the deadline handler tests all passed (7 tests).
- The pre-commit validation ran linting and the full test/coverage suite and completed successfully during the change application.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cec93e02b08326bb8da15addfe04d6)