### PR TITLE
feat: add F1 Fantasy API service and documentation

### DIFF
--- a/docs/f1-fantasy-api-examples.md
+++ b/docs/f1-fantasy-api-examples.md
@@ -1,0 +1,656 @@
+# F1 Fantasy API — Response Examples
+
+> Captured 2026-04-16. All responses are unwrapped from the standard `{ Data: { Value: ... } }` envelope.
+> Some fields are `null` because the current matchday (4) hasn't been scored yet.
+
+---
+
+## POST /services/session/login
+
+```json
+{
+  "GUID": "3dbedbda-3994-11f1-9222-c9d91d11b5d6",
+  "Token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "HomeCountry": "ISR",
+  "IsRegistered": 1,
+  "TeamCount": 1,
+  "SocialId": 233913084,
+  "UserId": 5042290105,
+  "IsEmailVerified": true,
+  "EmailExpiry": 0,
+  "FirstName": "das five",
+  "LastName": "das",
+  "HasSubscription": false,
+  "SubscribedProduct": ""
+}
+```
+
+---
+
+## GET /services/user/league/{GUID}/leaguelandingv1
+
+Returns `user_leagues` array — all leagues the user belongs to.
+
+```json
+[
+  {
+    "teams": [
+      {
+        "trend": null,
+        "team_no": 1,
+        "cur_rank": 0,
+        "formatted_cur_rank": "0"
+      }
+    ],
+    "is_vip": 0,
+    "is_admin": 0,
+    "is_sponcer": 0,
+    "is_system_name_upd": 0,
+    "is_report_flag": 0,
+    "raceweeks": null,
+    "is_profane_name_flag": 0,
+    "league_id": 0,
+    "league_code": null,
+    "league_name": "Global League",
+    "league_type": "Global",
+    "no_of_teams": 3,
+    "league_order": 1,
+    "member_count": 1975805,
+    "battle_result": null,
+    "top_percentage": null,
+    "formatted_member_count": "1.9m+"
+  },
+  {
+    "teams": [
+      { "trend": null, "team_no": 1, "cur_rank": 0, "formatted_cur_rank": "0" }
+    ],
+    "is_vip": 0,
+    "is_admin": 0,
+    "is_sponcer": 0,
+    "is_system_name_upd": 0,
+    "is_report_flag": 0,
+    "raceweeks": null,
+    "is_profane_name_flag": 1,
+    "league_id": 2976007,
+    "league_code": "C7UYMMWIO07",
+    "league_name": "MSFT%20ILDC%202026%20League",
+    "league_type": "Private",
+    "no_of_teams": 1,
+    "league_order": 2,
+    "member_count": 16,
+    "battle_result": null,
+    "top_percentage": null,
+    "formatted_member_count": "16"
+  },
+  {
+    "teams": [
+      { "trend": null, "team_no": 1, "cur_rank": 0, "formatted_cur_rank": "0" }
+    ],
+    "league_id": 16870204,
+    "league_code": "C6LTNQCNB04",
+    "league_name": "kilzi%20test",
+    "league_type": "Private",
+    "no_of_teams": 3,
+    "league_order": 2,
+    "member_count": 5,
+    "formatted_member_count": "5"
+  },
+  {
+    "league_id": 27,
+    "league_code": "27",
+    "league_name": "McLaren",
+    "league_type": "Team",
+    "no_of_teams": 3,
+    "member_count": 424667,
+    "formatted_member_count": "424k+"
+  },
+  {
+    "league_id": 11059,
+    "league_code": "11059",
+    "league_name": "Franco Colapinto",
+    "league_type": "Driver",
+    "member_count": 28495,
+    "formatted_member_count": "28.4k+"
+  },
+  {
+    "league_id": 202,
+    "league_code": "ALB",
+    "league_name": "Albania",
+    "league_type": "Country",
+    "member_count": 1446,
+    "formatted_member_count": "1.4k+"
+  }
+]
+```
+
+---
+
+## GET /services/user/gameplay/{GUID}/getusergamedaysv1/{teamNo}
+
+Response is `{ "0": { ... } }` — keyed by team index. The service unwraps to the `"0"` entry.
+
+```json
+{
+  "ftmdid": 4,
+  "ftgdid": 8,
+  "cugdid": 8,
+  "cumdid": 4,
+  "prvmdid": 3,
+  "islastday": 1,
+  "lastdaygdid": 0,
+  "teamid": 5042290105,
+  "teamno": 1,
+  "teamname": "the%20best%20bot",
+  "iswildcardtaken": 0,
+  "wildcardtakengd": 0,
+  "islimitlesstaken": 0,
+  "limitlesstakengd": 0,
+  "isfinalfixtaken": 0,
+  "finalfixtakengd": 0,
+  "isextradrstaken": 0,
+  "extradrstakengd": 0,
+  "isnonigativetaken": 0,
+  "nonigativetakengd": 0,
+  "isautopilottaken": 0,
+  "isautopilottakengd": 0,
+  "islateonboard": 0,
+  "mddetails": {
+    "4": { "mds": 0, "phId": 1, "pts": null }
+  },
+  "userhome": {
+    "teanNo": 1,
+    "ovPoints": null,
+    "racePoints": null,
+    "overallBestweek": null,
+    "bestDriverWeek": null,
+    "bestDriverOverall": null,
+    "totalTransfer": null,
+    "freeTransfer": null,
+    "nigativeTransfer": null
+  },
+  "teamcount": 1,
+  "iswebpurifycalled": 1,
+  "webpurifyresponse": "clean",
+  "issystemnameupd": 0
+}
+```
+
+### Key fields
+
+| Field                   | Description                                                                          |
+| ----------------------- | ------------------------------------------------------------------------------------ |
+| `cumdid`                | Current matchday ID                                                                  |
+| `cugdid`                | Current gameday ID                                                                   |
+| `ftmdid`                | First matchday ID                                                                    |
+| `prvmdid`               | Previous matchday ID                                                                 |
+| `teamname`              | URL-encoded team name                                                                |
+| `teamcount`             | How many teams the user has                                                          |
+| `mddetails`             | Matchday → points/phase map                                                          |
+| `userhome`              | Summary stats (overall points, best week, transfers)                                 |
+| `is*taken` / `*takengd` | Chip usage flags (wildcard, limitless, final fix, extra DRS, no-negative, autopilot) |
+
+---
+
+## GET /services/user/gameplay/{GUID}/getteam/{teamNo}/1/{matchdayId}/1
+
+```json
+{
+  "mdid": 4,
+  "userTeam": [
+    {
+      "gdrank": null,
+      "ovrank": null,
+      "teamno": 1,
+      "teambal": 0.9,
+      "teamval": 99.1,
+      "gdpoints": null,
+      "matchday": 8,
+      "ovpoints": null,
+      "playerid": [
+        {
+          "id": "11031",
+          "isfinal": 0,
+          "iscaptain": 0,
+          "ismgcaptain": 0,
+          "playerpostion": 2
+        },
+        {
+          "id": "114",
+          "isfinal": 0,
+          "iscaptain": 0,
+          "ismgcaptain": 0,
+          "playerpostion": 3
+        },
+        {
+          "id": "115",
+          "isfinal": 0,
+          "iscaptain": 1,
+          "ismgcaptain": 0,
+          "playerpostion": 1
+        },
+        {
+          "id": "118",
+          "isfinal": 0,
+          "iscaptain": 0,
+          "ismgcaptain": 0,
+          "playerpostion": 4
+        },
+        {
+          "id": "125",
+          "isfinal": 0,
+          "iscaptain": 0,
+          "ismgcaptain": 0,
+          "playerpostion": 5
+        },
+        {
+          "id": "2636",
+          "isfinal": 0,
+          "iscaptain": 0,
+          "ismgcaptain": 0,
+          "playerpostion": 7
+        },
+        {
+          "id": "29",
+          "isfinal": 0,
+          "iscaptain": 0,
+          "ismgcaptain": 0,
+          "playerpostion": 6
+        }
+      ],
+      "teamname": "the%20best%20bot",
+      "usersubs": 0,
+      "boosterid": null,
+      "team_info": {
+        "teamBal": 0.9,
+        "teamVal": 99.1,
+        "maxTeambal": 100,
+        "subsallowed": 0,
+        "userSubsleft": 0
+      },
+      "capplayerid": "115",
+      "subsallowed": 0,
+      "extrasubscost": 10,
+      "mgcapplayerid": null,
+      "race_category": "S",
+      "gd_initial_team": ["115", "11031", "114", "118", "125", "29", "2636"],
+      "iswildcardtaken": 0,
+      "islimitlesstaken": 0,
+      "isextradrstaken": 0,
+      "isfinalfixtaken": 0,
+      "isnonigativetaken": 0,
+      "isautopilottaken": 0,
+      "inactive_driver_penality_points": 0
+    }
+  ],
+  "retval": 1
+}
+```
+
+### Key fields
+
+| Field                      | Description                             |
+| -------------------------- | --------------------------------------- |
+| `teamval`                  | Total team value (in $M)                |
+| `teambal`                  | Remaining budget balance                |
+| `playerid[]`               | Array of selected players               |
+| `playerid[].id`            | Player ID (cross-ref with drivers feed) |
+| `playerid[].iscaptain`     | 1 = captain (2× points)                 |
+| `playerid[].ismgcaptain`   | 1 = mega captain                        |
+| `playerid[].playerpostion` | Slot position (1-7)                     |
+| `capplayerid`              | Captain's player ID                     |
+| `gdpoints`                 | Gameday points (null if not scored)     |
+| `ovpoints`                 | Overall cumulative points               |
+| `race_category`            | "S" = Sprint, "R" = Race                |
+
+---
+
+## GET /services/user/league/getleagueinfo/{leagueCode}
+
+```json
+{
+  "leagueName": "MSFT%20ILDC%202026%20League",
+  "maxMem": 99999999,
+  "noOfteam": 1,
+  "teamName": "NoNoItsSoNotRightMikeyNO",
+  "userName": "Tom Kregenbild",
+  "leaugeType": "Private",
+  "locktime": null,
+  "legaueVipFlag": 0,
+  "isSponsor": null,
+  "leagueId": 2976007,
+  "raceweek": null,
+  "extno": [1],
+  "isOpted": null,
+  "bannerImgURL": null,
+  "bannerInternalURL": null,
+  "bannerExternalURL": null,
+  "translationKey": "league_sponsor_private_2976007",
+  "isJoin": 1,
+  "isAdmin": 0,
+  "dateCreated": "2026-02-25T19:44:58.856754",
+  "shareable_league_name": null,
+  "leagueCode": "C7UYMMWIO07",
+  "teams_count": 16,
+  "memberCount": 16,
+  "userRank": null,
+  "userPoints": null,
+  "user_list": ["Doron Kilzi", "Dor Segal", "Ron Cooper"]
+}
+```
+
+### Notes
+
+- `userName` / `teamName` = league admin's name & team
+- `user_list` returns **only a partial** list of member names (3 out of 16) — not all members
+- `user_list` entries are plain strings (names), not objects with GUIDs
+
+---
+
+## GET /services/user/leaderboard/{GUID}/userrankgetv1/0/{teamNo}/{leagueType}/{leagueId}
+
+League type must be **lowercase**: `global`, `private`, `team`, `driver`, `country`.
+
+```json
+[
+  {
+    "trend": null,
+    "team_no": 1,
+    "cur_rank": null,
+    "social_id": "233913084",
+    "team_name": "the%20best%20bot",
+    "user_name": "das five das",
+    "user_guid": "3dbedbda-3994-11f1-9222-c9d91d11b5d6-0-233913084",
+    "user_team": null,
+    "cur_points": null
+  }
+]
+```
+
+### Key fields
+
+| Field        | Description                                               |
+| ------------ | --------------------------------------------------------- |
+| `cur_rank`   | User's rank in the league (null if season not scored yet) |
+| `cur_points` | Total points in this league                               |
+| `trend`      | Rank change direction                                     |
+| `user_guid`  | Opponent-format GUID: `{guid}-0-{socialId}`               |
+| `team_name`  | URL-encoded team name                                     |
+
+---
+
+## GET /services/user/league/{GUID}/featuredleaguev1
+
+```json
+{
+  "featured_leagues": [
+    {
+      "is_new": null,
+      "is_vip": 0,
+      "is_joined": 0,
+      "league_id": 412910,
+      "raceweeks": null,
+      "is_popular": null,
+      "is_sponcer": 1,
+      "is_official": 0,
+      "league_code": "P5SZLUS2W10",
+      "league_name": "SKY%20SPORTS%20F1",
+      "league_type": "Public",
+      "created_date": "2026-03-02T06:09:29.089996",
+      "member_count": 140329,
+      "is_last_chance": null,
+      "lock_datetime_utc": null,
+      "formatted_member_count": "140k+",
+      "is_ended": 0,
+      "is_admin": 0,
+      "banner_url_internal": null,
+      "banner_url_external": null,
+      "banner_img_url": null
+    },
+    {
+      "league_id": 143604,
+      "league_code": "P7ECRUYCO04",
+      "league_name": "F1%20Nation%20-%20Official%20F1%20Podcast",
+      "league_type": "Public",
+      "member_count": 68865,
+      "formatted_member_count": "68.8k+"
+    }
+  ]
+}
+```
+
+---
+
+## GET /services/user/opponentteam/opponentgamedayget/{teamNo}/{opponentGUID}/{v}
+
+Opponent GUID format: `{guid}-0-{socialId}` (e.g. `3dbedbda-3994-11f1-9222-c9d91d11b5d6-0-233913084`).
+
+```json
+{
+  "ftMdid": 4,
+  "ftGdid": 8,
+  "CuGdid": 8,
+  "mdDetails": {
+    "4": { "mds": 0, "phId": 1, "pts": null }
+  },
+  "teamCount": 1,
+  "lastDaygdid": 0,
+  "isLastday": 0,
+  "isWildcardtaken": 0,
+  "wildCardtakengd": 0,
+  "isLimitlesstaken": 0,
+  "limitLesstakengd": 0,
+  "isFinalfixtaken": 0,
+  "finalFixtakengd": 0,
+  "isExtradrstaken": 0,
+  "extraDrstakengd": 0,
+  "isNonigativetaken": 0,
+  "noNigativetakengd": 0,
+  "isAutopilottaken": 0,
+  "isAutopilottakengd": 0,
+  "islateonboard": 0
+}
+```
+
+> Note: Field casing differs from user's own game days (e.g. `ftMdid` vs `ftmdid`).
+
+---
+
+## GET /services/user/opponentteam/opponentgamedayplayerteamget/{teamNo}/{opponentGUID}/{v}/{matchdayId}/{v2}
+
+```json
+{
+  "mdid": 4,
+  "userTeam": [
+    {
+      "gdrank": null,
+      "ovrank": null,
+      "teamno": 1,
+      "teambal": 0.9,
+      "teamval": 99.1,
+      "gdpoints": null,
+      "matchday": 8,
+      "ovpoints": null,
+      "playerid": [
+        {
+          "id": "11031",
+          "isfinal": 0,
+          "iscaptain": 0,
+          "ismgcaptain": 0,
+          "playerpostion": 2
+        },
+        {
+          "id": "114",
+          "isfinal": 0,
+          "iscaptain": 0,
+          "ismgcaptain": 0,
+          "playerpostion": 3
+        },
+        {
+          "id": "115",
+          "isfinal": 0,
+          "iscaptain": 1,
+          "ismgcaptain": 0,
+          "playerpostion": 1
+        },
+        {
+          "id": "118",
+          "isfinal": 0,
+          "iscaptain": 0,
+          "ismgcaptain": 0,
+          "playerpostion": 4
+        },
+        {
+          "id": "125",
+          "isfinal": 0,
+          "iscaptain": 0,
+          "ismgcaptain": 0,
+          "playerpostion": 5
+        },
+        {
+          "id": "2636",
+          "isfinal": 0,
+          "iscaptain": 0,
+          "ismgcaptain": 0,
+          "playerpostion": 7
+        },
+        {
+          "id": "29",
+          "isfinal": 0,
+          "iscaptain": 0,
+          "ismgcaptain": 0,
+          "playerpostion": 6
+        }
+      ],
+      "socialId": 233913084,
+      "teamname": "the%20best%20bot",
+      "capplayerid": "115",
+      "team_info": {
+        "teamBal": 0.9,
+        "teamVal": 99.1,
+        "maxTeambal": 100,
+        "subsallowed": 0,
+        "userSubsleft": 0
+      },
+      "race_category": "S",
+      "iswildcardtaken": 0,
+      "islimitlesstaken": 0,
+      "inactive_driver_penality_points": 0
+    }
+  ],
+  "retval": 1
+}
+```
+
+> Same shape as user team but includes `socialId` field and excludes some user-specific flags.
+
+---
+
+## GET /feeds/drivers/{matchdayId}\_en.json
+
+Public — no auth. Returns all drivers and constructors.
+
+```json
+[
+  {
+    "PlayerId": "18",
+    "Skill": 1,
+    "PositionName": "DRIVER",
+    "Value": 13.0,
+    "TeamId": "23",
+    "FUllName": "Pierre Gasly",
+    "DisplayName": "P. Gasly",
+    "TeamName": "Alpine",
+    "Status": "0",
+    "IsActive": "1",
+    "DriverTLA": "GAS",
+    "DriverReference": "PIEGAS01",
+    "CountryName": "Rouen, France",
+    "OverallPpints": "45.00",
+    "GamedayPoints": "0",
+    "SelectedPercentage": "18",
+    "CaptainSelectedPercentage": "1",
+    "OldPlayerValue": 12.8,
+    "BestRaceFinished": "6",
+    "HigestGridStart": "7",
+    "HigestChampFinish": "",
+    "FastestPitstopAward": "",
+    "BestRaceFinishCount": 1,
+    "HighestGridStartCount": 1,
+    "QualifyingPoints": "",
+    "RacePoints": "",
+    "SprintPoints": "",
+    "NoNegativePoints": "",
+    "F1PlayerId": "8",
+    "FirstName": "Pierre",
+    "LastName": "Gasly",
+    "SessionWisePoints": [
+      {
+        "sessionnumber": 1,
+        "sessiontype": "Sprint Qualifying",
+        "points": null,
+        "nonegative_points": null
+      },
+      {
+        "sessionnumber": 2,
+        "sessiontype": "Qualifying",
+        "points": null,
+        "nonegative_points": null
+      },
+      {
+        "sessionnumber": 3,
+        "sessiontype": "Race",
+        "points": null,
+        "nonegative_points": null
+      }
+    ],
+    "AdditionalStats": {
+      "fastest_lap_pts": 0,
+      "dotd_pts": 0,
+      "overtaking_pts": 21,
+      "q3_finishes_pts": 8,
+      "top10_race_position_pts": 15,
+      "top8_sprint_position_pts": 0,
+      "total_position_pts": 23,
+      "total_position_gained_lost": 1,
+      "total_dnf_dq_pts": 0,
+      "value_for_money": 1.15
+    },
+    "ProjectedGamedayPoints": "0",
+    "ProjectedNoNegativePoints": "0",
+    "ProjectedOverallPpints": "45.00"
+  }
+]
+```
+
+### Key fields
+
+| Field                             | Description                                        |
+| --------------------------------- | -------------------------------------------------- |
+| `PlayerId`                        | Used in team `playerid[].id`                       |
+| `Skill`                           | 1 = Driver, 2 = Constructor                        |
+| `PositionName`                    | "DRIVER" or "CONSTRUCTOR"                          |
+| `Value`                           | Current price in $M                                |
+| `OldPlayerValue`                  | Previous price                                     |
+| `OverallPpints`                   | Total season points (note: typo in API — "Ppints") |
+| `GamedayPoints`                   | Points for current matchday                        |
+| `SelectedPercentage`              | % of all teams that selected this player           |
+| `CaptainSelectedPercentage`       | % of teams captaining this player                  |
+| `DriverTLA`                       | Three-letter abbreviation                          |
+| `AdditionalStats.value_for_money` | Points per $M (useful for analysis)                |
+
+---
+
+## GET /feeds/v2/apps/web_config.json
+
+> Large response (~100KB). Key fields only shown here.
+
+```json
+{
+  "tourId": 4,
+  "predictorGameEnabled": true,
+  "maintenanceModeReloadCta": true
+}
+```
+
+> This endpoint returns the full app config including image paths, feature flags, tournament settings, etc.
+> The `tourId` is needed for some API calls and changes each season.

--- a/docs/f1-fantasy-api.md
+++ b/docs/f1-fantasy-api.md
@@ -1,0 +1,230 @@
+# F1 Fantasy API Reference
+
+> Reverse-engineered from fantasy.formula1.com (June 2025).
+> All `/services/*` endpoints require an authenticated browser session.
+>
+> **See [f1-fantasy-api-examples.md](./f1-fantasy-api-examples.md) for full response examples.**
+
+## Base URL
+
+```
+https://fantasy.formula1.com
+```
+
+## Authentication
+
+The F1 Fantasy site is protected by **Distil/reese84 bot detection** — direct HTTP
+requests (curl/axios) are blocked. A real Chromium browser (via Playwright) is required.
+
+### Login Flow
+
+1. Navigate to `https://account.formula1.com/#/en/login?redirect=https%3A%2F%2Ffantasy.formula1.com%2Fen%2F&lead_source=web_fantasy`
+2. Dismiss cookie-consent banner (iframe overlay blocks form)
+3. Fill email + password with human-like typing (50-100 ms/char delay)
+4. Click **Sign In**
+5. Browser POSTs to `api.formula1.com/v2/account/subscriber/authenticate/by-password`
+   ```json
+   {
+     "Login": "<email>",
+     "Password": "<pwd>",
+     "DistributionChannel": "d861e38f-05ea-4063-8776-a7e2b6d885a4"
+   }
+   ```
+6. On success → `login-session` cookie set on `.formula1.com`, redirect to `fantasy.formula1.com`
+7. Call `POST /services/session/login` to obtain Fantasy GUID & Token
+
+### Session Login
+
+```
+POST /services/session/login
+Body: { "optType": 1, "platformId": 1, "platformVersion": "1", "platformCategory": "web", "clientId": 1 }
+```
+
+**Response:**
+
+```json
+{
+  "GUID": "3dbedbda-3994-11f1-9222-c9d91d11b5d6",
+  "Token": "<jwt>",
+  "IsRegistered": 1,
+  "TeamCount": 1,
+  "SocialId": 188548302,
+  "UserId": 200301063,
+  "FirstName": "drive",
+  "LastName": "senna",
+  "HomeCountry": 80
+}
+```
+
+The `GUID` is used as a path parameter in most authenticated endpoints.
+
+---
+
+## Authenticated Endpoints
+
+### User Gameplay
+
+#### Get User Game Days
+
+```
+GET /services/user/gameplay/{GUID}/getusergamedaysv1/{teamNo}
+```
+
+Returns matchday list with points, chip usage (wildcard/limitless/extraboost), team name.
+
+- `teamNo` — 1-based team index (users can have multiple teams; see `TeamCount`)
+- Key fields: `cumdid` (current matchday ID), `ftmdid` (first matchday ID)
+
+#### Get User Team
+
+```
+GET /services/user/gameplay/{GUID}/getteam/{teamNo}/1/{matchdayId}/1
+```
+
+Returns team composition: player IDs, captain, team value, balance, points.
+
+---
+
+### League
+
+#### League Landing (all user leagues)
+
+```
+GET /services/user/league/{GUID}/leaguelandingv1
+```
+
+Returns array of leagues the user belongs to:
+
+```json
+{
+  "league_id": 2976007,
+  "league_code": "C7UYMMWIO07",
+  "league_name": "MSFT%20ILDC%202026%20League",
+  "league_type": "Private",
+  "teams_count": 16,
+  "cur_rank": 5
+}
+```
+
+League types: `Global`, `Private`, `Team`, `Driver`, `Country`.
+
+#### Get League Info
+
+```
+GET /services/user/league/getleagueinfo/{leagueCode}
+```
+
+Returns league details: name, member count, admin, date created, and a **partial** `user_list`
+(may not include all members — observed 3 out of 16).
+
+#### Featured Leagues
+
+```
+GET /services/user/league/{GUID}/featuredleaguev1
+```
+
+---
+
+### Leaderboard
+
+#### User Rank
+
+```
+GET /services/user/leaderboard/{GUID}/userrankgetv1/0/{teamNo}/{leagueType}/{leagueId}
+```
+
+`leagueType` must be **lowercase**: `global`, `private`, `team`, `driver`, `country`.
+
+Returns **only the current user's** rank in the specified league (as a single-element array):
+
+```json
+{
+  "trend": 0,
+  "cur_rank": 5,
+  "social_id": 188548302,
+  "team_name": "the%20best%20bot",
+  "user_name": "drive%20senna",
+  "user_guid": "3dbedbda-3994-11f1-9222-c9d91d11b5d6-0-188548302",
+  "cur_points": 496
+}
+```
+
+> ⚠️ No single endpoint returns the **full** league leaderboard with all members.
+> The web app loads individual opponent data via the opponent endpoints below.
+
+---
+
+### Opponent Data
+
+Requires the **opponent GUID** (format: `{guid}-0-{socialId}`).
+
+#### Opponent Game Days
+
+```
+GET /services/user/opponentteam/opponentgamedayget/{teamNo}/{opponentGUID}/{v}
+```
+
+Returns opponent's matchday points, chip usage, team count.
+
+#### Opponent Team
+
+```
+GET /services/user/opponentteam/opponentgamedayplayerteamget/{teamNo}/{opponentGUID}/{v}/{matchdayId}/{v}
+```
+
+Returns opponent's full team: player IDs, captain, value, balance, points.
+
+---
+
+## Public Endpoints (no auth required)
+
+#### Drivers Feed
+
+```
+GET /feeds/drivers/{matchdayId}_en.json
+```
+
+All drivers with: `PlayerId`, `Value`, `TeamId`, `FullName`, `DisplayName`, `DriverTLA`,
+`OverallPoints`, `GamedayPoints`, `SelectedPercentage`, `OldPlayerValue`.
+
+#### Live Game State
+
+```
+GET /feeds/live/mixapi.json
+```
+
+#### Web Config
+
+```
+GET /feeds/v2/apps/web_config.json
+```
+
+Contains `tourId`, current matchday info, feature flags.
+
+#### Race Schedule
+
+```
+GET /feeds/v2/schedule/raceday_en.json
+```
+
+---
+
+## Key Values
+
+| Item                 | Value                                  |
+| -------------------- | -------------------------------------- |
+| MSFT league ID       | `2976007`                              |
+| MSFT league code     | `C7UYMMWIO07`                          |
+| Test league code     | `C6LTNQCNB04`                          |
+| User team name       | `the best bot`                         |
+| Opponent GUID format | `{guid}-0-{socialId}`                  |
+| Team names           | URL-encoded (e.g., `the%20best%20bot`) |
+
+## Stealth Requirements
+
+- `--disable-blink-features=AutomationControlled`
+- `navigator.webdriver = false`
+- Realistic user-agent string
+- Char-by-char typing with 50-100 ms random delay
+- Mouse hover before click
+- Rate limit: max 1 login per email per minute, 3 per 5 minutes

--- a/src/f1FantasyApi/f1FantasyApiService.js
+++ b/src/f1FantasyApi/f1FantasyApiService.js
@@ -1,0 +1,301 @@
+/**
+ * F1 Fantasy API Service
+ *
+ * Provides authenticated access to the F1 Fantasy API.
+ * Uses Playwright to drive a real Chromium browser for login (required by Distil bot detection),
+ * then uses page.evaluate(fetch(...)) for all subsequent API calls.
+ *
+ * Usage:
+ *   const fantasyApi = require('./f1FantasyApiService');
+ *   await fantasyApi.init();
+ *   const leagues = await fantasyApi.getLeagues();
+ *   await fantasyApi.close();
+ */
+const { chromium } = require('playwright');
+
+const BASE_URL = 'https://fantasy.formula1.com';
+const LOGIN_URL =
+  'https://account.formula1.com/#/en/login' +
+  '?redirect=https%3A%2F%2Ffantasy.formula1.com%2Fen%2F' +
+  '&lead_source=web_fantasy';
+
+let browser = null;
+let context = null;
+let page = null;
+let sessionData = null; // { GUID, Token, ... } from /services/session/login
+
+// ---------------------------------------------------------------------------
+// Browser & Login
+// ---------------------------------------------------------------------------
+
+async function init() {
+  if (page) {return sessionData;}
+
+  const email = process.env.F1_FANTASY_EMAIL;
+  const password = process.env.F1_FANTASY_PASSWORD;
+  if (!email || !password) {
+    throw new Error('Set F1_FANTASY_EMAIL and F1_FANTASY_PASSWORD in .env');
+  }
+
+  browser = await chromium.launch({
+    headless: process.env.F1_HEADLESS !== 'false',
+    args: ['--disable-blink-features=AutomationControlled'],
+  });
+
+  context = await browser.newContext({
+    viewport: { width: 1280, height: 900 },
+    userAgent:
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+  });
+
+  page = await context.newPage();
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, 'webdriver', { get: () => false });
+  });
+
+  await _login(email, password);
+  sessionData = await _sessionLogin();
+
+  return sessionData;
+}
+
+async function _login(email, password) {
+  await page.goto(LOGIN_URL, { waitUntil: 'domcontentloaded', timeout: 30000 });
+  await page.waitForSelector('input[name="Login"]', { visible: true, timeout: 20000 });
+
+  // Dismiss cookie consent overlay
+  try {
+    const consentFrame = page.frameLocator('iframe[title*="Consent"]');
+    await consentFrame
+      .locator('button[title="Accept All"], button:has-text("Accept All"), button:has-text("ACCEPT ALL")')
+      .click({ timeout: 5000 });
+    await page.waitForTimeout(1000);
+  } catch {
+    // No banner — fine
+  }
+
+  await page.waitForTimeout(2000);
+
+  // Human-like credential entry
+  const emailInput = page.locator('input[name="Login"]');
+  await emailInput.hover();
+  await page.waitForTimeout(500);
+  await emailInput.click();
+  await page.waitForTimeout(300);
+  for (const char of email) {
+    await page.keyboard.type(char, { delay: 50 + Math.random() * 50 });
+  }
+
+  await page.waitForTimeout(800);
+  await page.keyboard.press('Tab');
+  await page.waitForTimeout(500);
+  for (const char of password) {
+    await page.keyboard.type(char, { delay: 50 + Math.random() * 50 });
+  }
+
+  await page.waitForTimeout(1000);
+
+  const signInBtn = page.locator('button:has-text("Sign In"):visible');
+  await signInBtn.hover();
+  await page.waitForTimeout(300);
+  await signInBtn.click();
+
+  try {
+    await page.waitForURL(/^https:\/\/fantasy\.formula1\.com/, { timeout: 30000 });
+  } catch {
+    const errorMsg = await page
+      .locator('.loginError, [class*="error"]:visible')
+      .first()
+      .textContent()
+      .catch(() => null);
+    throw new Error(errorMsg ? `Login failed: ${errorMsg.trim()}` : `Login failed — stuck at ${page.url()}`);
+  }
+
+  // Let the Fantasy app fully load
+  try {
+    await page.goto(`${BASE_URL}/en/`, { waitUntil: 'domcontentloaded', timeout: 30000 });
+  } catch {
+    // ERR_ABORTED on redirect is fine
+  }
+  await page.waitForTimeout(5000);
+}
+
+async function _sessionLogin() {
+  return _apiPost('/services/session/login', {
+    optType: 1,
+    platformId: 1,
+    platformVersion: '1',
+    platformCategory: 'web',
+    clientId: 1,
+  });
+}
+
+async function close() {
+  if (browser) {
+    await browser.close();
+    browser = null;
+    context = null;
+    page = null;
+    sessionData = null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Low-level API helpers
+// ---------------------------------------------------------------------------
+
+async function _apiGet(path) {
+  _ensureReady();
+  const url = path.startsWith('http') ? path : `${BASE_URL}${path}`;
+  const result = await page.evaluate(async (fetchUrl) => {
+    const res = await fetch(fetchUrl, { credentials: 'include' });
+    const text = await res.text();
+
+    return { status: res.status, ok: res.ok, body: text };
+  }, url);
+
+  if (!result.ok) {
+    throw new Error(`GET ${path} → HTTP ${result.status}: ${result.body.substring(0, 200)}`);
+  }
+  const json = JSON.parse(result.body);
+
+  return _unwrap(json);
+}
+
+async function _apiPost(path, body) {
+  _ensureReady();
+  const url = path.startsWith('http') ? path : `${BASE_URL}${path}`;
+  const result = await page.evaluate(
+    async ({ fetchUrl, fetchBody }) => {
+      const res = await fetch(fetchUrl, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(fetchBody),
+      });
+      const text = await res.text();
+
+      return { status: res.status, ok: res.ok, body: text };
+    },
+    { fetchUrl: url, fetchBody: body },
+  );
+
+  if (!result.ok) {
+    throw new Error(`POST ${path} → HTTP ${result.status}: ${result.body.substring(0, 200)}`);
+  }
+  const json = JSON.parse(result.body);
+
+  return _unwrap(json);
+}
+
+/** Unwrap the standard F1 API response envelope { Data: { Value: ... } } */
+function _unwrap(json) {
+  if (json?.Data?.Value !== undefined && json?.Data?.Value !== null) {
+    return json.Data.Value;
+  }
+  if (json?.Meta?.Success === false) {
+    throw new Error(`API error: ${json.Meta.Message || `RetVal ${json.Meta.RetVal}`}`);
+  }
+
+  return json?.Data?.Value ?? json;
+}
+
+function _ensureReady() {
+  if (!page) {throw new Error('Call init() before making API calls');}
+}
+
+function _guid() {
+  if (!sessionData?.GUID) {throw new Error('No session — call init() first');}
+
+  return sessionData.GUID;
+}
+
+// ---------------------------------------------------------------------------
+// High-level API methods
+// ---------------------------------------------------------------------------
+
+/** Get all leagues the user belongs to */
+async function getLeagues() {
+  const data = await _apiGet(`/services/user/league/${_guid()}/leaguelandingv1`);
+
+  return data?.user_leagues || data;
+}
+
+/** Get league details by league code */
+async function getLeagueInfo(leagueCode) {
+  return _apiGet(`/services/user/league/getleagueinfo/${leagueCode}`);
+}
+
+/** Get the user's game days for a team */
+async function getUserGameDays(teamNo = 1) {
+  const data = await _apiGet(`/services/user/gameplay/${_guid()}/getusergamedaysv1/${teamNo}`);
+
+  // Response is { "0": { teamname, cumdid, ftmdid, ... } } — extract the first team
+  return data?.['0'] || data;
+}
+
+/** Get the user's team composition for a specific matchday */
+async function getUserTeam(teamNo = 1, matchdayId) {
+  const data = await _apiGet(`/services/user/gameplay/${_guid()}/getteam/${teamNo}/1/${matchdayId}/1`);
+
+  return data;
+}
+
+/** Get the user's rank in a specific league (leagueType: global|private|team|driver|country) */
+async function getUserRank(teamNo = 1, leagueType = 'private', leagueId) {
+  return _apiGet(
+    `/services/user/leaderboard/${_guid()}/userrankgetv1/0/${teamNo}/${leagueType}/${leagueId}`,
+  );
+}
+
+/** Get featured leagues */
+async function getFeaturedLeagues() {
+  return _apiGet(`/services/user/league/${_guid()}/featuredleaguev1`);
+}
+
+/** Get opponent's game days */
+async function getOpponentGameDays(opponentGuid, teamNo = 1, v = 1) {
+  return _apiGet(`/services/user/opponentteam/opponentgamedayget/${teamNo}/${opponentGuid}/${v}`);
+}
+
+/** Get opponent's team for a specific matchday */
+async function getOpponentTeam(opponentGuid, matchdayId, { teamNo = 1, v = 1, v2 = 1 } = {}) {
+  return _apiGet(
+    `/services/user/opponentteam/opponentgamedayplayerteamget/${teamNo}/${opponentGuid}/${v}/${matchdayId}/${v2}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public endpoints (no auth needed, but we use the same browser for simplicity)
+// ---------------------------------------------------------------------------
+
+/** Get all drivers for a matchday */
+async function getDrivers(matchdayId) {
+  return _apiGet(`/feeds/drivers/${matchdayId}_en.json`);
+}
+
+/** Get web config (tourId, current matchday, etc.) */
+async function getWebConfig() {
+  return _apiGet('/feeds/v2/apps/web_config.json');
+}
+
+/** Get the session data returned by /services/session/login */
+function getSession() {
+  return sessionData;
+}
+
+module.exports = {
+  init,
+  close,
+  getSession,
+  getLeagues,
+  getLeagueInfo,
+  getUserGameDays,
+  getUserTeam,
+  getUserRank,
+  getFeaturedLeagues,
+  getOpponentGameDays,
+  getOpponentTeam,
+  getDrivers,
+  getWebConfig,
+};

--- a/src/f1FantasyApi/verifyFantasyApi.js
+++ b/src/f1FantasyApi/verifyFantasyApi.js
@@ -1,0 +1,90 @@
+/**
+ * Quick verification script for f1FantasyApiService.
+ * Run: F1_HEADLESS=false node src/verifyFantasyApi.js
+ */
+require('dotenv').config();
+const fantasyApi = require('./f1FantasyApiService');
+// Note: run from project root: node src/f1FantasyApi/verifyFantasyApi.js
+
+async function main() {
+  console.log('🏎️  F1 Fantasy API Service — Verification\n');
+
+  try {
+    // 1. Init (login)
+    console.log('--- INIT (login) ---');
+    const session = await fantasyApi.init();
+    console.log(`✅ Logged in as: ${session.FirstName} ${session.LastName}`);
+    console.log(`   GUID: ${session.GUID}`);
+    console.log(`   Teams: ${session.TeamCount}, Registered: ${session.IsRegistered}\n`);
+
+    // 2. Get leagues
+    console.log('--- LEAGUES ---');
+    const leagues = await fantasyApi.getLeagues();
+    if (Array.isArray(leagues)) {
+      leagues.forEach((l) => {
+        const rank = l.teams?.[0]?.cur_rank ?? '?';
+        console.log(
+          `   ${decodeURIComponent(l.league_name)} (${l.league_type}) — rank #${rank}`,
+        );
+      });
+    }
+    console.log();
+
+    // 3. Get user game days
+    console.log('--- USER GAME DAYS ---');
+    const gameDays = await fantasyApi.getUserGameDays(1);
+    console.log(`   Team: ${decodeURIComponent(gameDays.teamname || 'unknown')}`);
+    console.log(`   Current matchday: ${gameDays.cumdid}`);
+    console.log(`   Matchday details: ${gameDays.mddetails?.length || 0} entries\n`);
+
+    // 4. Get user team for current matchday
+    const currentMatchday = gameDays.cumdid;
+    if (currentMatchday) {
+      console.log('--- USER TEAM ---');
+      const teamData = await fantasyApi.getUserTeam(1, currentMatchday);
+      const team = teamData?.userTeam?.[0] || teamData;
+      console.log(`   Team value: ${team.teamval}`);
+      console.log(`   Balance: ${team.teambal}`);
+      console.log(`   Players: ${team.playerid?.length || 0}\n`);
+    }
+
+    // 5. Get league info for MSFT league
+    console.log('--- LEAGUE INFO (MSFT) ---');
+    const leagueInfo = await fantasyApi.getLeagueInfo('C7UYMMWIO07');
+    console.log(`   Name: ${decodeURIComponent(leagueInfo.leagueName || '')}`);
+    console.log(`   Members: ${leagueInfo.memberCount}`);
+    console.log(`   Admin: ${decodeURIComponent(leagueInfo.userName || '')}`);
+    console.log(`   User list: ${leagueInfo.user_list?.length || 0} entries\n`);
+
+    // 6. Get user rank in MSFT league
+    console.log('--- USER RANK (MSFT private league) ---');
+    const rankData = await fantasyApi.getUserRank(1, 'private', 2976007);
+    if (Array.isArray(rankData)) {
+      const rank = rankData[0];
+      console.log(`   Rank: #${rank?.cur_rank}`);
+      console.log(`   Points: ${rank?.cur_points}`);
+      console.log(`   Team: ${decodeURIComponent(rank?.team_name || '')}\n`);
+    } else {
+      console.log(`   Response:`, JSON.stringify(rankData).substring(0, 200), '\n');
+    }
+
+    // 7. Drivers feed
+    console.log('--- DRIVERS (public) ---');
+    const drivers = await fantasyApi.getDrivers(currentMatchday);
+    const driverList = Array.isArray(drivers) ? drivers : drivers?.Players || [];
+    console.log(`   ${driverList.length} drivers loaded`);
+    driverList.slice(0, 3).forEach((d) => {
+      console.log(`   ${d.DisplayName || d.FullName}: ${d.OverallPoints} pts, $${d.Value}M`);
+    });
+
+    console.log('\n✅ All API calls successful!');
+  } catch (err) {
+    console.error(`\n❌ Error: ${err.message}`);
+    if (err.stack) {console.error(err.stack.split('\n').slice(1, 4).join('\n'));}
+  } finally {
+    await fantasyApi.close();
+    console.log('🏁 Done.');
+  }
+}
+
+main();


### PR DESCRIPTION
- Add Playwright-based API service for authenticated F1 Fantasy calls
- Add verification script for all endpoints
- Document all discovered API endpoints with full response examples
- Endpoints: session login, leagues, game days, team, league info, user rank, opponent data, drivers feed, web config


it is only for now, we need to move it to different service in the future 