### PR TITLE
Add league registration and leaderboard admin commands

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,1 +1,41 @@
-- @azure Rule - Use Azure Best Practices: When generating code for Azure, running terminal commands for Azure, or performing operations related to Azure, invoke your `azure_development-get_best_practices` tool if available.
+# Copilot Instructions — f1-fantazy-bot
+
+> **Primary reference:** `AGENTS.md` at the repo root is the authoritative handbook for this codebase (architecture, conventions, command catalogue, multi-team system, pending reply manager, user registry, nickname system). Read it before making non-trivial changes — do not duplicate its content, update it when you change the patterns it describes.
+
+## Commands
+
+- **Install:** `npm install`
+- **Run (dev, polling):** `npm start`
+- **Lint:** `npm run lint` / `npm run lint:fix`
+- **Test (full suite):** `npm test`
+- **Test with coverage:** `npm run test:coverage`
+- **Run a single test file:** `npx jest path/to/file.test.js`
+- **Run a single test by name:** `npx jest -t "test name pattern"`
+
+Tests intentionally log errors to stderr to exercise error paths — noisy output during a green run is normal.
+
+## Architecture essentials
+
+- **Runtime:** Node.js Telegram bot (`node-telegram-bot-api`). Two entry points share the same bot instance:
+  - `src/bot.js` — long-polling for local dev. Exports `bot` **and** a `cacheReady` promise.
+  - `telegramWebhook/index.js` — Azure Function webhook for production. **Must `await bot.cacheReady`** before calling `bot.processUpdate` (prevents cold-start race where caches are empty).
+- **Message flow:** `messageHandler.js` → checks pending replies first (regardless of text/photo) → routes to `textMessageHandler.js` or photo handler → dispatches via `commandsHandler/commandHandlers.js` (central `executeCommand` map). Non-command text falls through to the AI ASK agent (`askHandler.js` + `prompts.js`).
+- **Caches** (`src/cache.js`) are in-memory and populated on startup by `cacheInitializer.js` from Azure Blob Storage + the `UserRegistry` Azure Table. Team-scoped caches (`currentTeamCache`, `bestTeamsCache`, `selectedChipCache`) are **nested by team ID**: `cache[chatId][teamId]`. Per-user non-team caches (`driversCache`, `constructorsCache`, `userCache`) are keyed by `chatId` only.
+- **Persistence:** Azure Blob Storage for team JSON blobs (`user-teams/{chatId}_{teamId}.json`) and pending team assignments; Azure Table Storage (`UserRegistry` table) for user metadata + pending replies. Both use the single `AZURE_STORAGE_CONNECTION_STRING`.
+
+## Key conventions
+
+- **Adding a command:** constant in `src/constants.js` → handler in `src/commandsHandler/` → export in `commandsHandler/index.js` → mapping in `commandHandlers.js` → route in `textMessageHandler.js` → Jest test alongside handler. Adding the command to `MENU_CATEGORIES` automatically exposes it to the ASK NL agent (admin commands only exposed to admins). See AGENTS.md "Adding a New Command".
+- **Reply-based commands** use the Pending Reply Manager (`src/pendingReplyManager.js`) + Registry (`src/pendingReplyRegistry.js`). Only a command-ID string (+ optional JSON `data`) is persisted — builders reconstruct handler/validate/prompt on any server instance. See AGENTS.md "Adding a Reply-Based Command".
+- **Team-scoped commands must guard with `resolveSelectedTeam(bot, chatId)`** (returns `null` → early return). This handles the 0-team / 1-team-auto / multi-team prompt cases uniformly.
+- **Localization:** wrap every user-facing string with `t('key', chatId)` from `src/i18n.js` and add both `en` and `he` entries in `src/translations.js`.
+- **Logging:** use `sendLogMessage(bot, message)` for info → `LOG_CHANNEL_ID`; use `sendErrorMessage(bot, message)` for any error/failure → both `LOG_CHANNEL_ID` and `ERRORS_CHANNEL_ID`. Use `getDisplayName(chatId)` (nickname → chatName → chatId) when mentioning users in logs.
+- **User registry writes are fire-and-forget** — never `await upsertUser(...)` in the hot path; failures must not block message handling. Use `updateUserAttributes(chatId, { ... })` (Azure Table Merge mode) to add/change user attributes without reading first — new fields can be added without schema changes.
+- **Admin safeguards:** gate sensitive commands with `isAdminMessage(msg)` from `src/utils`.
+- **Menu visibility:** hide from interactive menu (but still registerable) via `hideFromMenu: true` in the `MENU_CATEGORIES` entry.
+- **Time zone:** `formatDateTime` uses `Asia/Jerusalem` — be deliberate if touching time-sensitive code.
+- **Keep AGENTS.md current:** if your change alters architecture, caches, commands, or the patterns documented there, update AGENTS.md in the same PR.
+
+## Azure
+
+- `@azure` rule: when generating code, running terminal commands, or performing operations related to Azure, invoke the `azure_development-get_best_practices` tool if available.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ This repository contains a Telegram bot that helps manage F1 Fantasy teams. The 
   - `src/messageHandler.js` distinguishes between text, photo, and other message types. It also checks for pending replies (see Pending Reply Manager below) before routing to type-specific handlers.
   - `src/textMessageHandler.js` routes command strings to handler functions defined in `src/commandsHandler`.
   - Generic command execution is centralized in `src/commandsHandler/commandHandlers.js`, which maps command constants to handler implementations.
-- **Pending Reply Manager:** `src/pendingReplyManager.js` provides a centralized mechanism for commands that need a follow-up reply from the user (text or photo). State is stored in **Azure Table Storage** for multi-server support. The check happens in `messageHandler.js` **before** the text/photo branching, so reply handlers receive the full message regardless of type. Supports optional `data` parameter for multi-step commands that need to store intermediate state between steps.
+- **Pending Reply Manager:** `src/pendingReplyManager.js` provides a centralized mechanism for commands that need a follow-up reply from the user (text or photo). State is stored in **Azure Table Storage** for multi-server support. The check happens in `messageHandler.js` **before** the text/photo branching, so reply handlers receive the full message regardless of type. Supports optional `data` parameter for multi-step commands that need to store intermediate state between steps. **Global cancel:** `messageHandler.js` intercepts `/cancel`, `cancel`, or `ביטול` (case-insensitive) while any pending reply is active — it clears the entry and confirms with `t('Operation cancelled.')`. This works for every command registered in the pending-reply registry without any per-command changes.
 - **Pending Reply Registry:** `src/pendingReplyRegistry.js` maps command identifiers (e.g., `'report_bug'`, `'send_message_to_user'`, `'set_nickname'`) to builder functions that reconstruct handlers, validators, and prompts. This enables serializable storage — only the command ID and optional data are persisted, and the full behavior is rebuilt on any server instance. Builder functions receive `(chatId, data)` where `data` is optional stored state for multi-step commands.
 - **Caching:** `src/cache.js` holds in-memory data for drivers, constructors, current team info, simulations, next race info, weather forecasts, a cached remaining-race count, and a unified `userCache`. Team-related caches (`currentTeamCache`, `bestTeamsCache`, `selectedChipCache`) are **nested by team ID** — see the [Multi-Team System](#multi-team-system) section below. `src/cacheInitializer.js` populates those caches on startup — most data comes from Azure Blob Storage (with team-aware blob naming), while `userCache` is populated from the `UserRegistry` Azure Table via a single `listAllUsers()` call. Each entry in `userCache` is keyed by `chatId` and holds `{ lang, nickname, chatName, selectedTeam, ... }`.
 - **Display Names:** `src/utils/utils.js` provides `getDisplayName(chatId)` which checks the in-memory `userCache` and returns the nickname if set, then falls back to `chatName`, then to the stringified `chatId`. This is used in `messageHandler.js` for all log messages so admins see nicknames in logs instead of Telegram display names.
@@ -64,7 +64,7 @@ This repository contains a Telegram bot that helps manage F1 Fantasy teams. The 
 - `/menu`, `/help`, `/lang`
 - `/report_bug` _(reply-based — uses pending reply manager)_
 
-**Admin-only:** `/trigger_scraping`, `/get_botfather_commands`, `/billing_stats`, `/version`, `/list_users`, `/send_message_to_user`, `/broadcast`, `/set_nickname`, `/live_score`
+**Admin-only:** `/trigger_scraping`, `/get_botfather_commands`, `/billing_stats`, `/version`, `/list_users`, `/send_message_to_user`, `/broadcast`, `/set_nickname`, `/live_score`, `/register_league`, `/unregister_league`, `/leaderboard`
 
 ---
 
@@ -281,6 +281,44 @@ The table is **extensible** — new attributes can be added at any time without 
 | `updateUserAttributes` | `updateUserAttributes(chatId, attributes) → Promise` | Update one or more user attributes using Merge mode. No read step needed. Example: `updateUserAttributes(chatId, { nickname: 'Max' })`.                                                                           |
 | `getUserById`          | `getUserById(chatId) → Promise<Object\|null>`        | Point lookup for a single user by chat ID. Returns user object with all stored attributes, or `null` if not found. Throws on real storage errors. More efficient than `listAllUsers` when you only need one user. |
 | `listAllUsers`         | `listAllUsers() → Promise<Array<Object>>`            | Return all registered users with all stored attributes. Automatically includes future fields. Used by `cacheInitializer` to populate `userCache` on startup.                                                      |
+
+---
+
+## League Registry
+
+`src/leagueRegistryService.js` tracks league subscriptions in an Azure Table Storage table (`UserLeagues`). Data is produced by the sibling repo `f1-fantasy-api-data`, which writes league blobs to Azure Blob Storage at `leagues/{leagueCode}/f1-fantasy-api-data.json` in the same container (`AZURE_STORAGE_CONTAINER_NAME`) used by the bot.
+
+### How It Works
+
+1. Admin runs `/register_league` → pending-reply flow prompts for the league code.
+2. The `register_league` registry entry calls `getLeagueData(code)` from `src/azureStorageService.js`. If the blob is missing, the flow re-registers itself and re-prompts so the admin can retry without typing the command again.
+3. On success, `addUserLeague(chatId, leagueCode, leagueName)` stores a row in `UserLeagues` (partitionKey=chatId, rowKey=leagueCode) with the league name captured at registration time.
+4. `/leaderboard` calls `listUserLeagues(chatId)`:
+   - 0 leagues → prompt to run `/register_league`.
+   - 1 league → auto-fetch blob and render leaderboard.
+   - 2+ leagues → inline keyboard (`LEAGUE_CALLBACK_TYPE`) showing each league by name; on selection, callback handler fetches the blob and renders.
+5. `/unregister_league` shows an inline keyboard (`LEAGUE_UNREGISTER_CALLBACK_TYPE`) with all registered leagues; selection calls `removeUserLeague(chatId, leagueCode)`.
+
+The leaderboard is rendered compactly (position, team name, total score) with a header showing league name, member count, and fetch time. Teams from the blob are already sorted by `position`.
+
+### Table Schema
+
+| Field          | Type     | Description                                   |
+| -------------- | -------- | --------------------------------------------- |
+| `partitionKey` | `string` | The `chatId` (stringified)                    |
+| `rowKey`       | `string` | The league code (e.g., `C8EFGOXCB04`)         |
+| `leagueName`   | `string` | League display name captured at registration  |
+| `registeredAt` | `string` | ISO timestamp — set when the league was added |
+
+### API Reference
+
+| Method             | Signature                                                          | Purpose                                                                                            |
+| ------------------ | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| `addUserLeague`    | `addUserLeague(chatId, leagueCode, leagueName) → Promise`          | Upsert a league subscription (Merge mode).                                                         |
+| `removeUserLeague` | `removeUserLeague(chatId, leagueCode) → Promise`                   | Delete a league subscription. 404 is ignored (idempotent).                                         |
+| `listUserLeagues`  | `listUserLeagues(chatId) → Promise<Array<{leagueCode, leagueName, registeredAt}>>` | Partition-scoped query returning all leagues for a user.                                           |
+| `getUserLeague`    | `getUserLeague(chatId, leagueCode) → Promise<Object\|null>`        | Point lookup for a specific subscription.                                                          |
+| `getLeagueData`    | `getLeagueData(leagueCode) → Promise<Object\|null>`                | (in `azureStorageService.js`) Fetches the league blob. Returns `null` when the blob does not exist. |
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,12 @@ A Telegram bot designed to help users manage their F1 Fantasy teams, providing t
 - **Automated Data Updates**: Trigger web scraping for the latest F1 Fantasy data (admin feature)
 - **Real-time Updates**: Stay current with the latest fantasy prices and availability
 
+### League Leaderboards
+
+- **League Registration**: Admins can register leagues via `/register_league` (league code captured and validated against the blob produced by the sibling `f1-fantasy-api-data` repo)
+- **Leaderboard Viewer**: `/leaderboard` shows a compact standings table (position, team name, total score) for any registered league; supports multiple leagues per user with inline selection
+- **League Unregistration**: `/unregister_league` removes a league subscription via an inline keyboard
+
 ### Azure Cost Management
 
 - **Real-time Billing Stats**: View current and previous month Azure spending with service breakdown

--- a/src/azureStorageService.js
+++ b/src/azureStorageService.js
@@ -371,6 +371,41 @@ async function deletePendingTeamAssignment(chatId, uniqueKey) {
   }
 }
 
+/**
+ * Get the league leaderboard data for a given league code from Azure Blob Storage.
+ * Blob path mirrors the writer in the sibling f1-fantasy-api-data repo:
+ *   leagues/{leagueCode}/f1-fantasy-api-data.json
+ * @param {string} leagueCode
+ * @returns {Promise<Object|null>} Parsed league data, or null if the blob does not exist.
+ * @throws {Error} If the blob exists but can not be retrieved/parsed.
+ */
+async function getLeagueData(leagueCode) {
+  try {
+    if (!containerClient) {
+      initializeAzureStorage();
+    }
+
+    const blobName = `leagues/${leagueCode}/f1-fantasy-api-data.json`;
+    const blockBlobClient = containerClient.getBlockBlobClient(blobName);
+
+    const exists = await blockBlobClient.exists();
+    if (!exists) {
+      return null;
+    }
+
+    const downloadResponse = await blockBlobClient.download();
+    const jsonString = await streamToString(
+      downloadResponse.readableStreamBody,
+    );
+
+    return JSON.parse(jsonString);
+  } catch (error) {
+    throw new Error(
+      `Failed to get league data for ${leagueCode}: ${error.message}`,
+    );
+  }
+}
+
 module.exports = {
   getFantasyData,
   getUserTeam,
@@ -383,4 +418,5 @@ module.exports = {
   savePendingTeamAssignment,
   getPendingTeamAssignment,
   deletePendingTeamAssignment,
+  getLeagueData,
 };

--- a/src/azureStorageService.test.js
+++ b/src/azureStorageService.test.js
@@ -277,4 +277,41 @@ describe('azureStorageService', () => {
       });
     });
   });
+
+  describe('getLeagueData', () => {
+    it('downloads and parses the league blob when it exists', async () => {
+      const mockData = {
+        leagueName: 'Amba',
+        leagueCode: 'ABC',
+        teams: [],
+      };
+
+      mockExists.mockResolvedValueOnce(true);
+      mockDownload.mockResolvedValueOnce({
+        readableStreamBody: createMockStream(mockData),
+      });
+
+      const result = await azureStorageService.getLeagueData('ABC');
+
+      expect(result).toEqual(mockData);
+      expect(mockExists).toHaveBeenCalled();
+    });
+
+    it('returns null when the league blob does not exist', async () => {
+      mockExists.mockResolvedValueOnce(false);
+
+      const result = await azureStorageService.getLeagueData('MISSING');
+
+      expect(result).toBeNull();
+      expect(mockDownload).not.toHaveBeenCalled();
+    });
+
+    it('wraps real errors', async () => {
+      mockExists.mockRejectedValueOnce(new Error('boom'));
+
+      await expect(
+        azureStorageService.getLeagueData('ABC'),
+      ).rejects.toThrow('Failed to get league data for ABC: boom');
+    });
+  });
 });

--- a/src/callbackQueryHandler.js
+++ b/src/callbackQueryHandler.js
@@ -19,6 +19,8 @@ const {
   TEAM_ASSIGN_CALLBACK_TYPE,
   BEST_TEAM_WEIGHTS_CALLBACK_TYPE,
   DEADLINE_CALLBACK_TYPE,
+  LEAGUE_CALLBACK_TYPE,
+  LEAGUE_UNREGISTER_CALLBACK_TYPE,
 } = require('./constants');
 
 const {
@@ -34,6 +36,10 @@ const {
   getDeadlinePayload,
   getRefreshMarkup,
 } = require('./commandsHandler/deadlineHandler');
+const {
+  sendLeaderboard,
+} = require('./commandsHandler/leaderboardHandler');
+const { removeUserLeague } = require('./leagueRegistryService');
 
 exports.handleCallbackQuery = async function (bot, query) {
   const callbackType = query.data.split(':')[0];
@@ -53,6 +59,10 @@ exports.handleCallbackQuery = async function (bot, query) {
       return await handleBestTeamRankingCallback(bot, query);
     case DEADLINE_CALLBACK_TYPE:
       return await handleDeadlineRefreshCallback(bot, query);
+    case LEAGUE_CALLBACK_TYPE:
+      return await handleLeagueCallback(bot, query);
+    case LEAGUE_UNREGISTER_CALLBACK_TYPE:
+      return await handleLeagueUnregisterCallback(bot, query);
     default:
       await sendLogMessage(bot, `Unknown callback type: ${callbackType}`);
   }
@@ -312,6 +322,38 @@ async function handleTeamAssignCallback(bot, query) {
       errorMessageToLog: 'Error sending extracted data to user',
     },
   );
+
+  await bot.answerCallbackQuery(query.id);
+}
+
+async function handleLeagueCallback(bot, query) {
+  const chatId = query.message.chat.id;
+  const leagueCode = query.data.split(':')[1];
+
+  await sendLeaderboard(bot, chatId, leagueCode);
+  await bot.answerCallbackQuery(query.id);
+}
+
+async function handleLeagueUnregisterCallback(bot, query) {
+  const chatId = query.message.chat.id;
+  const messageId = query.message.message_id;
+  const leagueCode = query.data.split(':')[1];
+
+  try {
+    await removeUserLeague(chatId, leagueCode);
+    await bot.editMessageText(
+      t('Unregistered from league {CODE}.', chatId, { CODE: leagueCode }),
+      { chat_id: chatId, message_id: messageId },
+    );
+  } catch (err) {
+    console.error('Error unregistering league:', err);
+    await bot.editMessageText(
+      t('❌ Failed to unregister league: {ERROR}', chatId, {
+        ERROR: err.message,
+      }),
+      { chat_id: chatId, message_id: messageId },
+    );
+  }
 
   await bot.answerCallbackQuery(query.id);
 }

--- a/src/callbackQueryHandler.test.js
+++ b/src/callbackQueryHandler.test.js
@@ -6,6 +6,8 @@ const {
   TEAM_ASSIGN_CALLBACK_TYPE,
   BEST_TEAM_WEIGHTS_CALLBACK_TYPE,
   DEADLINE_CALLBACK_TYPE,
+  LEAGUE_CALLBACK_TYPE,
+  LEAGUE_UNREGISTER_CALLBACK_TYPE,
   EXTRA_BOOST_CHIP,
 } = require('./constants');
 const cache = require('./cache');
@@ -27,6 +29,14 @@ jest.mock('./azureStorageService', () => ({
   saveUserTeam: jest.fn().mockResolvedValue(undefined),
   getPendingTeamAssignment: jest.fn().mockResolvedValue(null),
   deletePendingTeamAssignment: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('./commandsHandler/leaderboardHandler', () => ({
+  sendLeaderboard: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('./leagueRegistryService', () => ({
+  removeUserLeague: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('./userRegistryService', () => ({
@@ -252,5 +262,41 @@ describe('handleCallbackQuery', () => {
       },
     );
     expect(bot.answerCallbackQuery).toHaveBeenCalledWith('q9');
+  });
+
+  it('should handle LEAGUE callback by sending the leaderboard', async () => {
+    const {
+      sendLeaderboard,
+    } = require('./commandsHandler/leaderboardHandler');
+
+    const query = {
+      id: 'q-league',
+      data: `${LEAGUE_CALLBACK_TYPE}:ABC`,
+      message: { chat: { id: 123 }, message_id: 456 },
+    };
+
+    await handleCallbackQuery(bot, query);
+
+    expect(sendLeaderboard).toHaveBeenCalledWith(bot, 123, 'ABC');
+    expect(bot.answerCallbackQuery).toHaveBeenCalledWith('q-league');
+  });
+
+  it('should handle LEAGUE_UNREGISTER callback by removing the league', async () => {
+    const { removeUserLeague } = require('./leagueRegistryService');
+
+    const query = {
+      id: 'q-unreg',
+      data: `${LEAGUE_UNREGISTER_CALLBACK_TYPE}:ABC`,
+      message: { chat: { id: 123 }, message_id: 456 },
+    };
+
+    await handleCallbackQuery(bot, query);
+
+    expect(removeUserLeague).toHaveBeenCalledWith(123, 'ABC');
+    expect(bot.editMessageText).toHaveBeenCalledWith(
+      'Unregistered from league {CODE}.',
+      { chat_id: 123, message_id: 456 },
+    );
+    expect(bot.answerCallbackQuery).toHaveBeenCalledWith('q-unreg');
   });
 });

--- a/src/commandsHandler/commandHandlers.js
+++ b/src/commandsHandler/commandHandlers.js
@@ -34,6 +34,9 @@ const {
   COMMAND_SET_BEST_TEAM_RANKING,
   COMMAND_LIVE_SCORE,
   COMMAND_DEADLINE,
+  COMMAND_REGISTER_LEAGUE,
+  COMMAND_UNREGISTER_LEAGUE,
+  COMMAND_LEADERBOARD,
 } = require('../constants');
 
 const { handleBestTeamsMessage } = require('./bestTeamsHandler');
@@ -76,6 +79,11 @@ const { handleSelectTeamCommand } = require('./selectTeamHandler');
 const { handleSetBestTeamRanking } = require('./setBestTeamRankingHandler');
 const { handleLiveScoreCommand } = require('./liveScoreHandler');
 const { handleDeadlineCommand } = require('./deadlineHandler');
+const { handleRegisterLeagueCommand } = require('./registerLeagueHandler');
+const {
+  handleUnregisterLeagueCommand,
+} = require('./unregisterLeagueHandler');
+const { handleLeaderboardCommand } = require('./leaderboardHandler');
 
 // Mapping of command constants to their handler functions
 const COMMAND_HANDLERS = {
@@ -114,6 +122,9 @@ const COMMAND_HANDLERS = {
   [COMMAND_SET_BEST_TEAM_RANKING]: handleSetBestTeamRanking,
   [COMMAND_LIVE_SCORE]: handleLiveScoreCommand,
   [COMMAND_DEADLINE]: handleDeadlineCommand,
+  [COMMAND_REGISTER_LEAGUE]: handleRegisterLeagueCommand,
+  [COMMAND_UNREGISTER_LEAGUE]: handleUnregisterLeagueCommand,
+  [COMMAND_LEADERBOARD]: handleLeaderboardCommand,
 };
 
 async function executeCommand(bot, msg, command) {

--- a/src/commandsHandler/index.js
+++ b/src/commandsHandler/index.js
@@ -42,6 +42,11 @@ const { handleSelectTeamCommand } = require('./selectTeamHandler');
 const { handleSetBestTeamRanking } = require('./setBestTeamRankingHandler');
 const { handleLiveScoreCommand } = require('./liveScoreHandler');
 const { handleDeadlineCommand } = require('./deadlineHandler');
+const { handleRegisterLeagueCommand } = require('./registerLeagueHandler');
+const {
+  handleUnregisterLeagueCommand,
+} = require('./unregisterLeagueHandler');
+const { handleLeaderboardCommand } = require('./leaderboardHandler');
 
 module.exports = {
   handleBestTeamsMessage,
@@ -81,4 +86,7 @@ module.exports = {
   handleSetBestTeamRanking,
   handleLiveScoreCommand,
   handleDeadlineCommand,
+  handleRegisterLeagueCommand,
+  handleUnregisterLeagueCommand,
+  handleLeaderboardCommand,
 };

--- a/src/commandsHandler/leaderboardHandler.js
+++ b/src/commandsHandler/leaderboardHandler.js
@@ -1,0 +1,144 @@
+const { t } = require('../i18n');
+const { isAdminMessage } = require('../utils/utils');
+const { listUserLeagues } = require('../leagueRegistryService');
+const { getLeagueData } = require('../azureStorageService');
+const {
+  LEAGUE_CALLBACK_TYPE,
+  COMMAND_REGISTER_LEAGUE,
+} = require('../constants');
+
+/**
+ * Render a compact leaderboard message from the blob payload.
+ * Format: header with league name + member count + fetchedAt,
+ * followed by `position. teamName — totalScore` lines sorted by position.
+ * @param {Object} leagueData
+ * @param {number|string} chatId
+ * @returns {string}
+ */
+function formatLeaderboard(leagueData, chatId) {
+  const teams = Array.isArray(leagueData.teams) ? [...leagueData.teams] : [];
+  teams.sort((a, b) => (a.position || 0) - (b.position || 0));
+
+  const header =
+    `🏆 ${leagueData.leagueName || leagueData.leagueCode}\n` +
+    t('👥 {COUNT} teams · updated {TIME}', chatId, {
+      COUNT: String(leagueData.memberCount ?? teams.length),
+      TIME: leagueData.fetchedAt || '',
+    });
+
+  if (teams.length === 0) {
+    return `${header}\n\n${t('No teams in this league yet.', chatId)}`;
+  }
+
+  const maxPos = teams[teams.length - 1].position ?? teams.length;
+  const posWidth = String(maxPos).length;
+  const lines = teams.map((team) => {
+    const pos = String(team.position ?? '?').padStart(posWidth, ' ');
+    const name = team.teamName || team.userName || '—';
+    const score = team.totalScore ?? 0;
+
+    return ` ${pos}. ${name} — ${score}`;
+  });
+
+  return `${header}\n\n${lines.join('\n')}`;
+}
+
+async function sendLeaderboard(bot, chatId, leagueCode) {
+  let leagueData;
+  try {
+    leagueData = await getLeagueData(leagueCode);
+  } catch (err) {
+    console.error('Error fetching league data for leaderboard:', err);
+    await bot.sendMessage(
+      chatId,
+      t('❌ Failed to load league data: {ERROR}', chatId, {
+        ERROR: err.message,
+      }),
+    );
+
+    return;
+  }
+
+  if (!leagueData) {
+    await bot.sendMessage(
+      chatId,
+      t(
+        'No leaderboard data is available yet for this league. Please try again later.',
+        chatId,
+      ),
+    );
+
+    return;
+  }
+
+  await bot.sendMessage(chatId, formatLeaderboard(leagueData, chatId));
+}
+
+async function handleLeaderboardCommand(bot, msg) {
+  const chatId = msg.chat.id;
+
+  if (!isAdminMessage(msg)) {
+    await bot.sendMessage(
+      chatId,
+      t('Sorry, only admins can use this command.', chatId),
+    );
+
+    return;
+  }
+
+  let leagues;
+  try {
+    leagues = await listUserLeagues(chatId);
+  } catch (err) {
+    console.error('Error listing user leagues:', err);
+    await bot.sendMessage(
+      chatId,
+      t('❌ Failed to load your leagues: {ERROR}', chatId, {
+        ERROR: err.message,
+      }),
+    );
+
+    return;
+  }
+
+  if (!leagues || leagues.length === 0) {
+    await bot.sendMessage(
+      chatId,
+      t(
+        'You are not registered to any league. Run {CMD} to register to one first.',
+        chatId,
+        { CMD: COMMAND_REGISTER_LEAGUE },
+      ),
+    );
+
+    return;
+  }
+
+  if (leagues.length === 1) {
+    await sendLeaderboard(bot, chatId, leagues[0].leagueCode);
+
+    return;
+  }
+
+  const keyboard = leagues.map((league) => [
+    {
+      text: league.leagueName || league.leagueCode,
+      callback_data: `${LEAGUE_CALLBACK_TYPE}:${league.leagueCode}`,
+    },
+  ]);
+
+  await bot.sendMessage(
+    chatId,
+    t('Which league leaderboard do you want to see?', chatId),
+    {
+      reply_to_message_id: msg.message_id,
+      reply_markup: { inline_keyboard: keyboard },
+    },
+  );
+}
+
+module.exports = {
+  handleLeaderboardCommand,
+  formatLeaderboard,
+  sendLeaderboard,
+};

--- a/src/commandsHandler/leaderboardHandler.test.js
+++ b/src/commandsHandler/leaderboardHandler.test.js
@@ -1,0 +1,181 @@
+const {
+  handleLeaderboardCommand,
+  formatLeaderboard,
+  sendLeaderboard,
+} = require('./leaderboardHandler');
+
+jest.mock('../i18n', () => ({
+  t: jest.fn((key, _chatId, vars) =>
+    vars
+      ? Object.entries(vars).reduce(
+          (acc, [k, v]) => acc.replace(`{${k}}`, v),
+          key,
+        )
+      : key,
+  ),
+}));
+
+jest.mock('../utils/utils', () => ({
+  isAdminMessage: jest.fn(),
+}));
+
+jest.mock('../leagueRegistryService', () => ({
+  listUserLeagues: jest.fn(),
+}));
+
+jest.mock('../azureStorageService', () => ({
+  getLeagueData: jest.fn(),
+}));
+
+const { isAdminMessage } = require('../utils/utils');
+const { listUserLeagues } = require('../leagueRegistryService');
+const { getLeagueData } = require('../azureStorageService');
+
+describe('leaderboardHandler', () => {
+  let botMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    botMock = { sendMessage: jest.fn().mockResolvedValue() };
+  });
+
+  describe('formatLeaderboard', () => {
+    it('produces header + position-sorted rows', () => {
+      const data = {
+        leagueName: 'Amba',
+        leagueCode: 'ABC',
+        memberCount: 3,
+        fetchedAt: '2026-04-16T19:14:40.583Z',
+        teams: [
+          { teamName: 'B', totalScore: 800, position: 2 },
+          { teamName: 'A', totalScore: 900, position: 1 },
+          { teamName: 'C', totalScore: 700, position: 3 },
+        ],
+      };
+
+      const output = formatLeaderboard(data, 1);
+
+      expect(output).toContain('🏆 Amba');
+      expect(output).toContain('👥 3 teams · updated 2026-04-16T19:14:40.583Z');
+      expect(output.indexOf(' 1. A — 900')).toBeGreaterThan(-1);
+      expect(output.indexOf(' 1. A — 900')).toBeLessThan(
+        output.indexOf(' 2. B — 800'),
+      );
+      expect(output.indexOf(' 2. B — 800')).toBeLessThan(
+        output.indexOf(' 3. C — 700'),
+      );
+    });
+
+    it('handles empty teams', () => {
+      const output = formatLeaderboard(
+        { leagueName: 'Empty', memberCount: 0, teams: [] },
+        1,
+      );
+
+      expect(output).toContain('No teams in this league yet.');
+    });
+  });
+
+  describe('handleLeaderboardCommand', () => {
+    it('rejects non-admins', async () => {
+      isAdminMessage.mockReturnValue(false);
+
+      await handleLeaderboardCommand(botMock, { chat: { id: 9 } });
+
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        9,
+        'Sorry, only admins can use this command.',
+      );
+      expect(listUserLeagues).not.toHaveBeenCalled();
+    });
+
+    it('asks the user to register when they have no leagues', async () => {
+      isAdminMessage.mockReturnValue(true);
+      listUserLeagues.mockResolvedValueOnce([]);
+
+      await handleLeaderboardCommand(botMock, { chat: { id: 1 } });
+
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        1,
+        'You are not registered to any league. Run /register_league to register to one first.',
+      );
+    });
+
+    it('auto-renders the leaderboard when the user has one league', async () => {
+      isAdminMessage.mockReturnValue(true);
+      listUserLeagues.mockResolvedValueOnce([
+        { leagueCode: 'ABC', leagueName: 'Amba' },
+      ]);
+      getLeagueData.mockResolvedValueOnce({
+        leagueName: 'Amba',
+        memberCount: 1,
+        fetchedAt: 't',
+        teams: [{ teamName: 'A', totalScore: 1, position: 1 }],
+      });
+
+      await handleLeaderboardCommand(botMock, { chat: { id: 1 } });
+
+      expect(getLeagueData).toHaveBeenCalledWith('ABC');
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining('🏆 Amba'),
+      );
+    });
+
+    it('shows an inline keyboard when the user has multiple leagues', async () => {
+      isAdminMessage.mockReturnValue(true);
+      listUserLeagues.mockResolvedValueOnce([
+        { leagueCode: 'ABC', leagueName: 'Amba' },
+        { leagueCode: 'XYZ', leagueName: 'Other' },
+      ]);
+
+      await handleLeaderboardCommand(botMock, {
+        chat: { id: 1 },
+        message_id: 5,
+      });
+
+      expect(getLeagueData).not.toHaveBeenCalled();
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        1,
+        'Which league leaderboard do you want to see?',
+        expect.objectContaining({
+          reply_to_message_id: 5,
+          reply_markup: {
+            inline_keyboard: [
+              [{ text: 'Amba', callback_data: 'LEAGUE:ABC' }],
+              [{ text: 'Other', callback_data: 'LEAGUE:XYZ' }],
+            ],
+          },
+        }),
+      );
+    });
+  });
+
+  describe('sendLeaderboard', () => {
+    it('tells the user when the blob is missing', async () => {
+      getLeagueData.mockResolvedValueOnce(null);
+
+      await sendLeaderboard(botMock, 1, 'ABC');
+
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        1,
+        'No leaderboard data is available yet for this league. Please try again later.',
+      );
+    });
+
+    it('reports fetch errors gracefully', async () => {
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      getLeagueData.mockRejectedValueOnce(new Error('boom'));
+
+      await sendLeaderboard(botMock, 1, 'ABC');
+
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        1,
+        '❌ Failed to load league data: boom',
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/src/commandsHandler/registerLeagueHandler.js
+++ b/src/commandsHandler/registerLeagueHandler.js
@@ -1,0 +1,45 @@
+const { t } = require('../i18n');
+const { isAdminMessage } = require('../utils/utils');
+const { registerPendingReply } = require('../pendingReplyManager');
+
+/**
+ * Handle the /register_league admin command.
+ * Initiates a pending-reply flow that asks the admin for the league code.
+ * The actual registration (blob validation + persistence) happens in the
+ * pendingReplyRegistry entry for 'register_league'.
+ */
+async function handleRegisterLeagueCommand(bot, msg) {
+  const chatId = msg.chat.id;
+
+  if (!isAdminMessage(msg)) {
+    await bot.sendMessage(
+      chatId,
+      t('Sorry, only admins can use this command.', chatId),
+    );
+
+    return;
+  }
+
+  const prompt = [
+    t('Please enter the league code you want to register to:', chatId),
+    '',
+    t(
+      'To find your league code: go to the F1 Fantasy website, open the league you want to register to, click the share button, and copy the league code from there.',
+      chatId,
+    ),
+    '',
+    t('💡 Send /cancel at any time to abort the registration.', chatId),
+  ].join('\n');
+
+  await registerPendingReply(chatId, 'register_league');
+
+  await bot
+    .sendMessage(chatId, prompt, {
+      reply_markup: { force_reply: true },
+    })
+    .catch((err) =>
+      console.error('Error sending register league prompt:', err),
+    );
+}
+
+module.exports = { handleRegisterLeagueCommand };

--- a/src/commandsHandler/registerLeagueHandler.test.js
+++ b/src/commandsHandler/registerLeagueHandler.test.js
@@ -1,0 +1,63 @@
+const { handleRegisterLeagueCommand } = require('./registerLeagueHandler');
+
+jest.mock('../i18n', () => ({
+  t: jest.fn((key) => key),
+}));
+
+jest.mock('../utils/utils', () => ({
+  isAdminMessage: jest.fn(),
+}));
+
+jest.mock('../pendingReplyManager', () => ({
+  registerPendingReply: jest.fn().mockResolvedValue(),
+}));
+
+const { isAdminMessage } = require('../utils/utils');
+const { registerPendingReply } = require('../pendingReplyManager');
+
+describe('registerLeagueHandler', () => {
+  let botMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    botMock = { sendMessage: jest.fn().mockResolvedValue() };
+  });
+
+  it('rejects non-admin users', async () => {
+    isAdminMessage.mockReturnValue(false);
+
+    await handleRegisterLeagueCommand(botMock, { chat: { id: 999 } });
+
+    expect(botMock.sendMessage).toHaveBeenCalledWith(
+      999,
+      'Sorry, only admins can use this command.',
+    );
+    expect(registerPendingReply).not.toHaveBeenCalled();
+  });
+
+  it('registers a pending reply for admins', async () => {
+    isAdminMessage.mockReturnValue(true);
+
+    await handleRegisterLeagueCommand(botMock, { chat: { id: 1 } });
+
+    expect(registerPendingReply).toHaveBeenCalledWith(1, 'register_league');
+  });
+
+  it('sends a prompt with force_reply', async () => {
+    isAdminMessage.mockReturnValue(true);
+
+    await handleRegisterLeagueCommand(botMock, { chat: { id: 1 } });
+
+    expect(botMock.sendMessage).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining(
+        'Please enter the league code you want to register to:',
+      ),
+      { reply_markup: { force_reply: true } },
+    );
+    expect(botMock.sendMessage.mock.calls[0][1]).toContain(
+      'To find your league code',
+    );
+    expect(botMock.sendMessage.mock.calls[0][1]).toContain('/cancel');
+  });
+});

--- a/src/commandsHandler/unregisterLeagueHandler.js
+++ b/src/commandsHandler/unregisterLeagueHandler.js
@@ -1,0 +1,66 @@
+const { t } = require('../i18n');
+const { isAdminMessage } = require('../utils/utils');
+const { listUserLeagues } = require('../leagueRegistryService');
+const {
+  LEAGUE_UNREGISTER_CALLBACK_TYPE,
+  COMMAND_REGISTER_LEAGUE,
+} = require('../constants');
+
+async function handleUnregisterLeagueCommand(bot, msg) {
+  const chatId = msg.chat.id;
+
+  if (!isAdminMessage(msg)) {
+    await bot.sendMessage(
+      chatId,
+      t('Sorry, only admins can use this command.', chatId),
+    );
+
+    return;
+  }
+
+  let leagues;
+  try {
+    leagues = await listUserLeagues(chatId);
+  } catch (err) {
+    console.error('Error listing user leagues for unregister:', err);
+    await bot.sendMessage(
+      chatId,
+      t('❌ Failed to load your leagues: {ERROR}', chatId, {
+        ERROR: err.message,
+      }),
+    );
+
+    return;
+  }
+
+  if (!leagues || leagues.length === 0) {
+    await bot.sendMessage(
+      chatId,
+      t(
+        'You are not registered to any league. Run {CMD} to register to one first.',
+        chatId,
+        { CMD: COMMAND_REGISTER_LEAGUE },
+      ),
+    );
+
+    return;
+  }
+
+  const keyboard = leagues.map((league) => [
+    {
+      text: league.leagueName || league.leagueCode,
+      callback_data: `${LEAGUE_UNREGISTER_CALLBACK_TYPE}:${league.leagueCode}`,
+    },
+  ]);
+
+  await bot.sendMessage(
+    chatId,
+    t('Which league do you want to unregister from?', chatId),
+    {
+      reply_to_message_id: msg.message_id,
+      reply_markup: { inline_keyboard: keyboard },
+    },
+  );
+}
+
+module.exports = { handleUnregisterLeagueCommand };

--- a/src/commandsHandler/unregisterLeagueHandler.test.js
+++ b/src/commandsHandler/unregisterLeagueHandler.test.js
@@ -1,0 +1,104 @@
+const {
+  handleUnregisterLeagueCommand,
+} = require('./unregisterLeagueHandler');
+
+jest.mock('../i18n', () => ({
+  t: jest.fn((key, _chatId, vars) =>
+    vars
+      ? Object.entries(vars).reduce(
+          (acc, [k, v]) => acc.replace(`{${k}}`, v),
+          key,
+        )
+      : key,
+  ),
+}));
+
+jest.mock('../utils/utils', () => ({
+  isAdminMessage: jest.fn(),
+}));
+
+jest.mock('../leagueRegistryService', () => ({
+  listUserLeagues: jest.fn(),
+}));
+
+const { isAdminMessage } = require('../utils/utils');
+const { listUserLeagues } = require('../leagueRegistryService');
+
+describe('unregisterLeagueHandler', () => {
+  let botMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    botMock = { sendMessage: jest.fn().mockResolvedValue() };
+  });
+
+  it('rejects non-admin users', async () => {
+    isAdminMessage.mockReturnValue(false);
+
+    await handleUnregisterLeagueCommand(botMock, { chat: { id: 999 } });
+
+    expect(botMock.sendMessage).toHaveBeenCalledWith(
+      999,
+      'Sorry, only admins can use this command.',
+    );
+    expect(listUserLeagues).not.toHaveBeenCalled();
+  });
+
+  it('tells the admin when no leagues are registered', async () => {
+    isAdminMessage.mockReturnValue(true);
+    listUserLeagues.mockResolvedValueOnce([]);
+
+    await handleUnregisterLeagueCommand(botMock, {
+      chat: { id: 1 },
+      message_id: 10,
+    });
+
+    expect(botMock.sendMessage).toHaveBeenCalledWith(
+      1,
+      'You are not registered to any league. Run /register_league to register to one first.',
+    );
+  });
+
+  it('shows an inline keyboard with league name labels', async () => {
+    isAdminMessage.mockReturnValue(true);
+    listUserLeagues.mockResolvedValueOnce([
+      { leagueCode: 'ABC', leagueName: 'Amba' },
+      { leagueCode: 'XYZ', leagueName: 'Other' },
+    ]);
+
+    await handleUnregisterLeagueCommand(botMock, {
+      chat: { id: 1 },
+      message_id: 10,
+    });
+
+    expect(botMock.sendMessage).toHaveBeenCalledWith(
+      1,
+      'Which league do you want to unregister from?',
+      expect.objectContaining({
+        reply_to_message_id: 10,
+        reply_markup: {
+          inline_keyboard: [
+            [{ text: 'Amba', callback_data: 'LEAGUE_UNREGISTER:ABC' }],
+            [{ text: 'Other', callback_data: 'LEAGUE_UNREGISTER:XYZ' }],
+          ],
+        },
+      }),
+    );
+  });
+
+  it('surfaces service errors', async () => {
+    isAdminMessage.mockReturnValue(true);
+    const consoleSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    listUserLeagues.mockRejectedValueOnce(new Error('boom'));
+
+    await handleUnregisterLeagueCommand(botMock, { chat: { id: 1 } });
+
+    expect(botMock.sendMessage).toHaveBeenCalledWith(
+      1,
+      '❌ Failed to load your leagues: boom',
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/constants.js
+++ b/src/constants.js
@@ -31,6 +31,8 @@ exports.TEAM_CALLBACK_TYPE = 'TEAM';
 exports.TEAM_ASSIGN_CALLBACK_TYPE = 'TEAM_ASSIGN';
 exports.BEST_TEAM_WEIGHTS_CALLBACK_TYPE = 'BEST_TEAM_WEIGHTS';
 exports.DEADLINE_CALLBACK_TYPE = 'DEADLINE';
+exports.LEAGUE_CALLBACK_TYPE = 'LEAGUE';
+exports.LEAGUE_UNREGISTER_CALLBACK_TYPE = 'LEAGUE_UNREGISTER';
 
 exports.MAX_TELEGRAM_MESSAGE_LENGTH = 4096;
 exports.BEST_TEAMS_RESULT_COUNT = 15;
@@ -70,6 +72,9 @@ exports.COMMAND_SELECT_TEAM = '/select_team';
 exports.COMMAND_SET_BEST_TEAM_RANKING = '/set_best_team_ranking';
 exports.COMMAND_BEST_TEAM_SCENARIOS = '/best_team_scenarios';
 exports.COMMAND_DEADLINE = '/deadline';
+exports.COMMAND_REGISTER_LEAGUE = '/register_league';
+exports.COMMAND_UNREGISTER_LEAGUE = '/unregister_league';
+exports.COMMAND_LEADERBOARD = '/leaderboard';
 
 // Menu configuration for interactive menu command
 exports.MENU_CATEGORIES = {
@@ -263,6 +268,29 @@ exports.MENU_CATEGORIES = {
         constant: exports.COMMAND_UPLOAD_CONSTRUCTORS_PHOTO,
         title: '📤 Upload Constructors Photo',
         description: 'Upload a constructors screenshot for cache extraction',
+      },
+    ],
+  },
+  LEAGUE_MANAGEMENT: {
+    id: 'league_management',
+    title: '🏁 League Management',
+    description: 'Register and view F1 Fantasy leagues',
+    adminOnly: true,
+    commands: [
+      {
+        constant: exports.COMMAND_REGISTER_LEAGUE,
+        title: '➕ Register League',
+        description: 'Register to an F1 Fantasy league by its code',
+      },
+      {
+        constant: exports.COMMAND_UNREGISTER_LEAGUE,
+        title: '➖ Unregister League',
+        description: 'Remove a registered F1 Fantasy league',
+      },
+      {
+        constant: exports.COMMAND_LEADERBOARD,
+        title: '🏆 Leaderboard',
+        description: 'View the leaderboard of a registered league',
       },
     ],
   },

--- a/src/leagueRegistryService.js
+++ b/src/leagueRegistryService.js
@@ -1,0 +1,151 @@
+// League Registry Service
+// Tracks the F1 Fantasy leagues each user is registered to in Azure Table Storage.
+// One row per (chatId, leagueCode). Uses Azure Table Storage "Merge" mode so that
+// adding attributes in the future does not require migrations.
+
+const { TableClient } = require('@azure/data-tables');
+
+const TABLE_NAME = 'UserLeagues';
+
+// Azure Table Storage system fields excluded when returning league data
+const SYSTEM_FIELDS = new Set([
+  'partitionKey',
+  'rowKey',
+  'etag',
+  'timestamp',
+  'odata.etag',
+  'odata.metadata',
+]);
+
+let tableClient;
+let tableReady = false;
+
+function initializeTableClient() {
+  const connectionString = process.env.AZURE_STORAGE_CONNECTION_STRING;
+
+  if (!connectionString) {
+    throw new Error(
+      'Missing AZURE_STORAGE_CONNECTION_STRING for league registry storage',
+    );
+  }
+
+  tableClient = TableClient.fromConnectionString(connectionString, TABLE_NAME);
+  tableReady = false;
+}
+
+async function ensureTable() {
+  if (!tableClient) {
+    initializeTableClient();
+  }
+
+  if (!tableReady) {
+    await tableClient.createTable().catch(() => {
+      // Table already exists — ignore
+    });
+    tableReady = true;
+  }
+}
+
+function entityToLeague(entity) {
+  const league = {
+    chatId: entity.partitionKey,
+    leagueCode: entity.rowKey,
+  };
+
+  for (const [key, value] of Object.entries(entity)) {
+    if (!SYSTEM_FIELDS.has(key)) {
+      league[key] = value;
+    }
+  }
+
+  return league;
+}
+
+/**
+ * Register (upsert) a league for a user using Merge mode.
+ * Preserves any other fields already stored on the row.
+ * @param {number|string} chatId
+ * @param {string} leagueCode
+ * @param {string} leagueName
+ */
+async function addUserLeague(chatId, leagueCode, leagueName) {
+  await ensureTable();
+
+  const entity = {
+    partitionKey: String(chatId),
+    rowKey: String(leagueCode),
+    leagueName,
+    registeredAt: new Date().toISOString(),
+  };
+
+  await tableClient.upsertEntity(entity, 'Merge');
+}
+
+/**
+ * Remove a league registration for a user.
+ * @param {number|string} chatId
+ * @param {string} leagueCode
+ */
+async function removeUserLeague(chatId, leagueCode) {
+  await ensureTable();
+
+  try {
+    await tableClient.deleteEntity(String(chatId), String(leagueCode));
+  } catch (err) {
+    if (err.statusCode !== 404) {
+      throw err;
+    }
+  }
+}
+
+/**
+ * List all leagues a user is registered to.
+ * @param {number|string} chatId
+ * @returns {Promise<Array<{chatId, leagueCode, leagueName, registeredAt}>>}
+ */
+async function listUserLeagues(chatId) {
+  await ensureTable();
+
+  const partitionKey = String(chatId);
+  const leagues = [];
+
+  for await (const entity of tableClient.listEntities({
+    queryOptions: { filter: `PartitionKey eq '${partitionKey}'` },
+  })) {
+    leagues.push(entityToLeague(entity));
+  }
+
+  return leagues;
+}
+
+/**
+ * Point lookup for a single registration.
+ * @param {number|string} chatId
+ * @param {string} leagueCode
+ * @returns {Promise<Object|null>}
+ */
+async function getUserLeague(chatId, leagueCode) {
+  await ensureTable();
+
+  try {
+    const entity = await tableClient.getEntity(
+      String(chatId),
+      String(leagueCode),
+    );
+
+    return entityToLeague(entity);
+  } catch (err) {
+    if (err.statusCode === 404) {
+      return null;
+    }
+
+    throw err;
+  }
+}
+
+module.exports = {
+  addUserLeague,
+  removeUserLeague,
+  listUserLeagues,
+  getUserLeague,
+};

--- a/src/leagueRegistryService.test.js
+++ b/src/leagueRegistryService.test.js
@@ -1,0 +1,184 @@
+const mockGetEntity = jest.fn();
+const mockUpsertEntity = jest.fn();
+const mockDeleteEntity = jest.fn();
+const mockCreateTable = jest.fn().mockResolvedValue();
+const mockListEntities = jest.fn();
+
+jest.mock('@azure/data-tables', () => ({
+  TableClient: {
+    fromConnectionString: jest.fn().mockReturnValue({
+      getEntity: mockGetEntity,
+      upsertEntity: mockUpsertEntity,
+      deleteEntity: mockDeleteEntity,
+      createTable: mockCreateTable,
+      listEntities: mockListEntities,
+    }),
+  },
+}));
+
+describe('leagueRegistryService', () => {
+  const originalEnv = process.env;
+  let service;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetEntity.mockReset();
+    mockUpsertEntity.mockReset();
+    mockDeleteEntity.mockReset();
+    mockCreateTable.mockReset().mockResolvedValue();
+    mockListEntities.mockReset();
+
+    process.env = {
+      ...originalEnv,
+      AZURE_STORAGE_CONNECTION_STRING: 'mock-connection-string',
+    };
+
+    jest.isolateModules(() => {
+      service = require('./leagueRegistryService');
+    });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  function notFound() {
+    const err = new Error('ResourceNotFound');
+    err.statusCode = 404;
+
+    return err;
+  }
+
+  function makeAsyncIterator(items) {
+    return {
+      async *[Symbol.asyncIterator]() {
+        for (const item of items) {
+          yield item;
+        }
+      },
+    };
+  }
+
+  describe('addUserLeague', () => {
+    it('upserts the entity in Merge mode with league name and registeredAt', async () => {
+      mockUpsertEntity.mockResolvedValueOnce();
+
+      await service.addUserLeague(123, 'ABC', 'Amba');
+
+      expect(mockCreateTable).toHaveBeenCalledTimes(1);
+      expect(mockUpsertEntity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          partitionKey: '123',
+          rowKey: 'ABC',
+          leagueName: 'Amba',
+          registeredAt: expect.any(String),
+        }),
+        'Merge',
+      );
+    });
+  });
+
+  describe('removeUserLeague', () => {
+    it('deletes the entity', async () => {
+      mockDeleteEntity.mockResolvedValueOnce();
+
+      await service.removeUserLeague(123, 'ABC');
+
+      expect(mockDeleteEntity).toHaveBeenCalledWith('123', 'ABC');
+    });
+
+    it('ignores 404 errors', async () => {
+      mockDeleteEntity.mockRejectedValueOnce(notFound());
+
+      await expect(service.removeUserLeague(123, 'ABC')).resolves.toBeUndefined();
+    });
+
+    it('rethrows non-404 errors', async () => {
+      mockDeleteEntity.mockRejectedValueOnce(new Error('boom'));
+
+      await expect(service.removeUserLeague(123, 'ABC')).rejects.toThrow('boom');
+    });
+  });
+
+  describe('listUserLeagues', () => {
+    it('returns all leagues for a chatId with stored attributes', async () => {
+      mockListEntities.mockReturnValueOnce(
+        makeAsyncIterator([
+          {
+            partitionKey: '123',
+            rowKey: 'ABC',
+            leagueName: 'Amba',
+            registeredAt: '2026-01-01T00:00:00Z',
+            etag: 'x',
+          },
+          {
+            partitionKey: '123',
+            rowKey: 'XYZ',
+            leagueName: 'Other',
+            registeredAt: '2026-02-01T00:00:00Z',
+          },
+        ]),
+      );
+
+      const result = await service.listUserLeagues(123);
+
+      expect(mockListEntities).toHaveBeenCalledWith({
+        queryOptions: { filter: "PartitionKey eq '123'" },
+      });
+      expect(result).toEqual([
+        {
+          chatId: '123',
+          leagueCode: 'ABC',
+          leagueName: 'Amba',
+          registeredAt: '2026-01-01T00:00:00Z',
+        },
+        {
+          chatId: '123',
+          leagueCode: 'XYZ',
+          leagueName: 'Other',
+          registeredAt: '2026-02-01T00:00:00Z',
+        },
+      ]);
+    });
+
+    it('returns empty array when user has no leagues', async () => {
+      mockListEntities.mockReturnValueOnce(makeAsyncIterator([]));
+
+      const result = await service.listUserLeagues(999);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getUserLeague', () => {
+    it('returns league on hit', async () => {
+      mockGetEntity.mockResolvedValueOnce({
+        partitionKey: '123',
+        rowKey: 'ABC',
+        leagueName: 'Amba',
+      });
+
+      const result = await service.getUserLeague(123, 'ABC');
+
+      expect(result).toEqual({
+        chatId: '123',
+        leagueCode: 'ABC',
+        leagueName: 'Amba',
+      });
+    });
+
+    it('returns null on 404', async () => {
+      mockGetEntity.mockRejectedValueOnce(notFound());
+
+      const result = await service.getUserLeague(123, 'ABC');
+
+      expect(result).toBeNull();
+    });
+
+    it('rethrows non-404 errors', async () => {
+      mockGetEntity.mockRejectedValueOnce(new Error('fail'));
+
+      await expect(service.getUserLeague(123, 'ABC')).rejects.toThrow('fail');
+    });
+  });
+});

--- a/src/messageHandler.js
+++ b/src/messageHandler.js
@@ -44,6 +44,19 @@ exports.handleMessage = async function (bot, msg) {
   const pendingReply = await getPendingReply(chatId);
 
   if (pendingReply) {
+    // Global cancel keyword — works for any pending reply flow
+    if (msg.text && isCancelKeyword(msg.text)) {
+      await clearPendingReply(chatId);
+
+      await bot
+        .sendMessage(chatId, t('Operation cancelled.', chatId))
+        .catch((err) =>
+          console.error('Error sending cancel confirmation:', err),
+        );
+
+      return;
+    }
+
     // If a validate function is defined and the message fails validation,
     // re-send the prompt and keep the pending reply active
     if (pendingReply.validate && !(await pendingReply.validate(msg))) {
@@ -96,3 +109,15 @@ exports.handleMessage = async function (bot, msg) {
       console.error('Error sending unsupported type reply:', err),
     );
 };
+
+/**
+ * Match cancel keywords (English/Hebrew), with or without leading slash.
+ * Used to abort any pending-reply flow globally.
+ */
+function isCancelKeyword(text) {
+  const normalized = String(text).trim().toLowerCase().replace(/^\//, '');
+
+  return normalized === 'cancel' || normalized === 'ביטול';
+}
+
+exports.isCancelKeyword = isCancelKeyword;

--- a/src/messageHandler.test.js
+++ b/src/messageHandler.test.js
@@ -317,4 +317,63 @@ describe('handleMessage', () => {
     expect(clearPendingReply).toHaveBeenCalledWith(KILZI_CHAT_ID);
     expect(mockHandler).toHaveBeenCalledWith(botMock, msgMock);
   });
+
+  describe('global cancel keyword', () => {
+    it.each([
+      ['/cancel'],
+      ['cancel'],
+      ['CANCEL'],
+      ['  /Cancel  '],
+      ['ביטול'],
+    ])('should cancel pending reply when text is %p', async (text) => {
+      const mockHandler = jest.fn().mockResolvedValue();
+      const mockValidate = jest.fn().mockReturnValue(true);
+      getPendingReply.mockResolvedValue({
+        handler: mockHandler,
+        validate: mockValidate,
+        resendPromptIfNotValid: 'Please send text only',
+      });
+
+      const msgMock = { chat: { id: KILZI_CHAT_ID }, text };
+
+      await handleMessage(botMock, msgMock);
+
+      expect(clearPendingReply).toHaveBeenCalledWith(KILZI_CHAT_ID);
+      expect(mockValidate).not.toHaveBeenCalled();
+      expect(mockHandler).not.toHaveBeenCalled();
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        KILZI_CHAT_ID,
+        'Operation cancelled.',
+      );
+    });
+
+    it('should not cancel when no pending reply exists', async () => {
+      getPendingReply.mockResolvedValue(undefined);
+
+      const msgMock = { chat: { id: KILZI_CHAT_ID }, text: '/cancel' };
+
+      await handleMessage(botMock, msgMock);
+
+      expect(clearPendingReply).not.toHaveBeenCalled();
+    });
+
+    it('should not cancel for photo messages even if pending reply exists', async () => {
+      const mockHandler = jest.fn().mockResolvedValue();
+      getPendingReply.mockResolvedValue({
+        handler: mockHandler,
+        validate: null,
+        resendPromptIfNotValid: null,
+      });
+
+      const msgMock = {
+        chat: { id: KILZI_CHAT_ID },
+        photo: [{ file_id: 'p1' }],
+      };
+
+      await handleMessage(botMock, msgMock);
+
+      expect(clearPendingReply).toHaveBeenCalledWith(KILZI_CHAT_ID);
+      expect(mockHandler).toHaveBeenCalledWith(botMock, msgMock);
+    });
+  });
 });

--- a/src/pendingReplyRegistry.js
+++ b/src/pendingReplyRegistry.js
@@ -446,6 +446,125 @@ const PENDING_REPLY_REGISTRY = {
         chatId,
       ),
   },
+  register_league: {
+    buildHandler: (chatId) => {
+      // Lazy require to avoid circular dependency via pendingReplyManager
+      const { registerPendingReply } = require('./pendingReplyManager');
+      const { getLeagueData } = require('./azureStorageService');
+      const { addUserLeague } = require('./leagueRegistryService');
+      const { sendLogMessage } = require('./utils/utils');
+
+      return async (replyBot, replyMsg) => {
+        const leagueCode = replyMsg.text.trim();
+
+        let leagueData;
+        try {
+          leagueData = await getLeagueData(leagueCode);
+        } catch (err) {
+          console.error('Error fetching league data for registration:', err);
+          await replyBot
+            .sendMessage(
+              chatId,
+              t('❌ Failed to load league data: {ERROR}', chatId, {
+                ERROR: err.message,
+              }),
+            )
+            .catch((sendErr) =>
+              console.error(
+                'Error sending league fetch error message:',
+                sendErr,
+              ),
+            );
+
+          return;
+        }
+
+        if (!leagueData) {
+          // Blob missing → treat as invalid code; re-register pending reply
+          // so the user can try again without re-typing the command.
+          await registerPendingReply(chatId, 'register_league');
+
+          const retryPrompt = [
+            t(
+              'League "{CODE}" not found. Please enter a valid league code:',
+              chatId,
+              { CODE: leagueCode },
+            ),
+            '',
+            t(
+              'To find your league code: go to the F1 Fantasy website, open the league you want to register to, click the share button, and copy the league code from there.',
+              chatId,
+            ),
+            '',
+            t(
+              '📩 If the code is correct but the league is not yet tracked, please report it to the admins via /report_bug with the league code and we will add the bot to the league as soon as possible.',
+              chatId,
+            ),
+            '',
+            t('💡 Send /cancel at any time to abort the registration.', chatId),
+          ].join('\n');
+
+          await replyBot
+            .sendMessage(chatId, retryPrompt, {
+              reply_markup: { force_reply: true },
+            })
+            .catch((err) =>
+              console.error('Error sending league-not-found prompt:', err),
+            );
+
+          return;
+        }
+
+        const leagueName = leagueData.leagueName || leagueCode;
+
+        try {
+          await addUserLeague(chatId, leagueCode, leagueName);
+        } catch (err) {
+          console.error('Error persisting league registration:', err);
+          await replyBot
+            .sendMessage(
+              chatId,
+              t('❌ Failed to register league: {ERROR}', chatId, {
+                ERROR: err.message,
+              }),
+            )
+            .catch((sendErr) =>
+              console.error(
+                'Error sending league registration error message:',
+                sendErr,
+              ),
+            );
+
+          return;
+        }
+
+        await replyBot
+          .sendMessage(
+            chatId,
+            t(
+              'Registered to league "{NAME}" ({CODE}).',
+              chatId,
+              { NAME: leagueName, CODE: leagueCode },
+            ),
+          )
+          .catch((err) =>
+            console.error('Error sending league registration confirmation:', err),
+          );
+
+        await sendLogMessage(
+          replyBot,
+          `Registered league ${leagueName} (${leagueCode}) for chatId ${chatId}`,
+        ).catch(() => {});
+      };
+    },
+    buildValidate: () => (replyMsg) =>
+      !!replyMsg.text && replyMsg.text.trim().length > 0,
+    buildResendPrompt: (chatId) =>
+      t(
+        'We support only text. Please enter the league code:',
+        chatId,
+      ),
+  },
 };
 
 /**

--- a/src/pendingReplyRegistry.test.js
+++ b/src/pendingReplyRegistry.test.js
@@ -6,6 +6,7 @@ jest.mock('./utils/utils', () => ({
   getChatName: jest.fn(() => 'Test User'),
   getDisplayName: jest.fn(() => 'Test Nickname'),
   sendMessageToAdmins: jest.fn().mockResolvedValue(),
+  sendLogMessage: jest.fn().mockResolvedValue(),
 }));
 
 jest.mock('./constants', () => ({
@@ -25,6 +26,14 @@ jest.mock('./pendingReplyManager', () => ({
 
 jest.mock('./photoProcessingService', () => ({
   processPhotoByType: jest.fn().mockResolvedValue(),
+}));
+
+jest.mock('./azureStorageService', () => ({
+  getLeagueData: jest.fn(),
+}));
+
+jest.mock('./leagueRegistryService', () => ({
+  addUserLeague: jest.fn().mockResolvedValue(),
 }));
 
 const {
@@ -750,6 +759,88 @@ describe('pendingReplyRegistry', () => {
         expect(resolved.resendPromptIfNotValid).toBe(
           'We support only text. Please enter the message to broadcast.',
         );
+      });
+    });
+  });
+
+  describe('register_league', () => {
+    const { getLeagueData } = require('./azureStorageService');
+    const { addUserLeague } = require('./leagueRegistryService');
+
+    beforeEach(() => {
+      getLeagueData.mockReset();
+      addUserLeague.mockReset().mockResolvedValue();
+      registerPendingReply.mockClear();
+    });
+
+    it('registers the league when the blob exists', async () => {
+      getLeagueData.mockResolvedValueOnce({
+        leagueName: 'Amba',
+        leagueCode: 'ABC',
+      });
+
+      const resolved = resolveCommand('register_league', 42);
+      const botMock = { sendMessage: jest.fn().mockResolvedValue() };
+
+      await resolved.handler(botMock, { text: '  ABC  ' });
+
+      expect(getLeagueData).toHaveBeenCalledWith('ABC');
+      expect(addUserLeague).toHaveBeenCalledWith(42, 'ABC', 'Amba');
+      expect(registerPendingReply).not.toHaveBeenCalled();
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        42,
+        expect.any(String),
+      );
+    });
+
+    it('re-registers the pending reply when the league blob is missing', async () => {
+      getLeagueData.mockResolvedValueOnce(null);
+
+      const resolved = resolveCommand('register_league', 42);
+      const botMock = { sendMessage: jest.fn().mockResolvedValue() };
+
+      await resolved.handler(botMock, { text: 'BADCODE' });
+
+      expect(addUserLeague).not.toHaveBeenCalled();
+      expect(registerPendingReply).toHaveBeenCalledWith(42, 'register_league');
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        42,
+        expect.any(String),
+        { reply_markup: { force_reply: true } },
+      );
+    });
+
+    it('reports blob fetch errors without persisting', async () => {
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      getLeagueData.mockRejectedValueOnce(new Error('boom'));
+
+      const resolved = resolveCommand('register_league', 42);
+      const botMock = { sendMessage: jest.fn().mockResolvedValue() };
+
+      await resolved.handler(botMock, { text: 'ABC' });
+
+      expect(addUserLeague).not.toHaveBeenCalled();
+      expect(registerPendingReply).not.toHaveBeenCalled();
+      expect(botMock.sendMessage).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    describe('buildValidate', () => {
+      it('accepts non-empty text', () => {
+        const resolved = resolveCommand('register_league', 1);
+        expect(resolved.validate({ text: 'ABC' })).toBe(true);
+      });
+
+      it('rejects empty text', () => {
+        const resolved = resolveCommand('register_league', 1);
+        expect(resolved.validate({ text: '  ' })).toBe(false);
+      });
+
+      it('rejects missing text', () => {
+        const resolved = resolveCommand('register_league', 1);
+        expect(resolved.validate({})).toBe(false);
       });
     });
   });

--- a/src/textMessageHandler.js
+++ b/src/textMessageHandler.js
@@ -37,6 +37,9 @@ const {
   handleSetBestTeamRanking,
   handleLiveScoreCommand,
   handleDeadlineCommand,
+  handleRegisterLeagueCommand,
+  handleUnregisterLeagueCommand,
+  handleLeaderboardCommand,
 } = require('./commandsHandler');
 
 // Import constants
@@ -76,6 +79,9 @@ const {
   COMMAND_SET_BEST_TEAM_RANKING,
   COMMAND_LIVE_SCORE,
   COMMAND_DEADLINE,
+  COMMAND_REGISTER_LEAGUE,
+  COMMAND_UNREGISTER_LEAGUE,
+  COMMAND_LEADERBOARD,
 } = require('./constants');
 
 exports.handleTextMessage = async function (bot, msg) {
@@ -162,6 +168,12 @@ exports.handleTextMessage = async function (bot, msg) {
       return await handleLiveScoreCommand(bot, msg);
     case msg.text === COMMAND_DEADLINE:
       return await handleDeadlineCommand(bot, msg);
+    case msg.text === COMMAND_REGISTER_LEAGUE:
+      return await handleRegisterLeagueCommand(bot, msg);
+    case msg.text === COMMAND_UNREGISTER_LEAGUE:
+      return await handleUnregisterLeagueCommand(bot, msg);
+    case msg.text === COMMAND_LEADERBOARD:
+      return await handleLeaderboardCommand(bot, msg);
     default:
       try {
         const jsonData = JSON.parse(textTrimmed);

--- a/src/textMessageHandler.test.js
+++ b/src/textMessageHandler.test.js
@@ -25,6 +25,9 @@ const {
   COMMAND_SET_BEST_TEAM_RANKING,
   COMMAND_LIVE_SCORE,
   COMMAND_DEADLINE,
+  COMMAND_REGISTER_LEAGUE,
+  COMMAND_UNREGISTER_LEAGUE,
+  COMMAND_LEADERBOARD,
 } = require('./constants');
 
 jest.mock('openai', () => ({
@@ -95,6 +98,15 @@ const {
 const {
   handleDeadlineCommand,
 } = require('./commandsHandler/deadlineHandler');
+const {
+  handleRegisterLeagueCommand,
+} = require('./commandsHandler/registerLeagueHandler');
+const {
+  handleUnregisterLeagueCommand,
+} = require('./commandsHandler/unregisterLeagueHandler');
+const {
+  handleLeaderboardCommand,
+} = require('./commandsHandler/leaderboardHandler');
 
 jest.mock('./commandsHandler/numberInputHandler');
 jest.mock('./commandsHandler/jsonInputHandler');
@@ -124,6 +136,9 @@ jest.mock('./commandsHandler/uploadConstructorsPhotoHandler');
 jest.mock('./commandsHandler/setBestTeamRankingHandler');
 jest.mock('./commandsHandler/liveScoreHandler');
 jest.mock('./commandsHandler/deadlineHandler');
+jest.mock('./commandsHandler/registerLeagueHandler');
+jest.mock('./commandsHandler/unregisterLeagueHandler');
+jest.mock('./commandsHandler/leaderboardHandler');
 
 const { handleTextMessage } = require('./textMessageHandler');
 const { handleAskCommand } = require('./commandsHandler/askHandler');
@@ -244,6 +259,45 @@ describe('handleTextMessage', () => {
 
       expect(handleDeadlineCommand).toHaveBeenCalledWith(botMock, msgMock);
       expect(handleJsonMessage).not.toHaveBeenCalled();
+    });
+
+    it('should route /register_league command to handleRegisterLeagueCommand', async () => {
+      const msgMock = {
+        chat: { id: KILZI_CHAT_ID },
+        text: COMMAND_REGISTER_LEAGUE,
+      };
+
+      await handleTextMessage(botMock, msgMock);
+
+      expect(handleRegisterLeagueCommand).toHaveBeenCalledWith(
+        botMock,
+        msgMock,
+      );
+    });
+
+    it('should route /unregister_league command to handleUnregisterLeagueCommand', async () => {
+      const msgMock = {
+        chat: { id: KILZI_CHAT_ID },
+        text: COMMAND_UNREGISTER_LEAGUE,
+      };
+
+      await handleTextMessage(botMock, msgMock);
+
+      expect(handleUnregisterLeagueCommand).toHaveBeenCalledWith(
+        botMock,
+        msgMock,
+      );
+    });
+
+    it('should route /leaderboard command to handleLeaderboardCommand', async () => {
+      const msgMock = {
+        chat: { id: KILZI_CHAT_ID },
+        text: COMMAND_LEADERBOARD,
+      };
+
+      await handleTextMessage(botMock, msgMock);
+
+      expect(handleLeaderboardCommand).toHaveBeenCalledWith(botMock, msgMock);
     });
 
     it('should route /print_cache command to sendPrintableCache', async () => {

--- a/src/translations.js
+++ b/src/translations.js
@@ -422,6 +422,51 @@ const translations = {
     'Selected Team: {TEAM}': 'קבוצה נבחרת: {TEAM}',
     '🔀 Select Team': '🔀 בחירת קבוצה',
     'Switch between your fantasy teams': 'מעבר בין הקבוצות שלך',
+    'Please enter the league code you want to register to:':
+      'אנא הזן את קוד הליגה שברצונך להירשם אליה:',
+    'We support only text. Please enter the league code:':
+      'אנחנו תומכים רק בטקסט. אנא הזן את קוד הליגה:',
+    'League "{CODE}" not found. Please enter a valid league code:':
+      'ליגה "{CODE}" לא נמצאה. אנא הזן קוד ליגה תקין:',
+    '❌ Failed to load league data: {ERROR}':
+      '❌ טעינת נתוני הליגה נכשלה: {ERROR}',
+    '❌ Failed to register league: {ERROR}':
+      '❌ רישום הליגה נכשל: {ERROR}',
+    'Registered to league "{NAME}" ({CODE}).':
+      'נרשמת לליגה "{NAME}" ({CODE}).',
+    'You are not registered to any league. Run {CMD} to register to one first.':
+      'אינך רשום לאף ליגה. הפעל {CMD} כדי להירשם לליגה.',
+    'Which league leaderboard do you want to see?':
+      'איזו טבלת ליגה ברצונך לראות?',
+    'Which league do you want to unregister from?':
+      'מאיזו ליגה ברצונך להתנתק?',
+    'Unregistered from league {CODE}.': 'התנתקת מהליגה {CODE}.',
+    '❌ Failed to unregister league: {ERROR}':
+      '❌ ביטול רישום הליגה נכשל: {ERROR}',
+    '❌ Failed to load your leagues: {ERROR}':
+      '❌ טעינת הליגות שלך נכשלה: {ERROR}',
+    'No leaderboard data is available yet for this league. Please try again later.':
+      'עדיין אין נתוני טבלה עבור הליגה הזו. נסה שוב מאוחר יותר.',
+    'No teams in this league yet.': 'אין עדיין קבוצות בליגה הזו.',
+    '👥 {COUNT} teams · updated {TIME}':
+      '👥 {COUNT} קבוצות · עודכן {TIME}',
+    '➕ Register League': '➕ רישום ליגה',
+    'Register to an F1 Fantasy league by its code':
+      'הירשם לליגת F1 Fantasy לפי קוד',
+    '➖ Unregister League': '➖ ביטול רישום ליגה',
+    'Remove a registered F1 Fantasy league': 'הסר ליגת F1 Fantasy רשומה',
+    '🏆 Leaderboard': '🏆 טבלת ליגה',
+    'View the leaderboard of a registered league': 'צפה בטבלה של ליגה רשומה',
+    '🏁 League Management': '🏁 ניהול ליגות',
+    'Register and view F1 Fantasy leagues':
+      'רישום וצפייה בליגות F1 Fantasy',
+    'To find your league code: go to the F1 Fantasy website, open the league you want to register to, click the share button, and copy the league code from there.':
+      'כדי למצוא את קוד הליגה: היכנס לאתר \u2066F1 Fantasy\u2069, פתח את הליגה שברצונך להירשם אליה, לחץ על כפתור השיתוף והעתק את קוד הליגה משם.',
+    '📩 If the code is correct but the league is not yet tracked, please report it to the admins via /report_bug with the league code and we will add the bot to the league as soon as possible.':
+      '📩\u200F אם הקוד תקין אך הליגה עדיין לא מנוטרת, דווח לאדמינים עם קוד הליגה באמצעות \u2066/report_bug\u2069 ונוסיף את הבוט לליגה בהקדם האפשרי.',
+    '💡 Send /cancel at any time to abort the registration.':
+      '💡\u200F שלח \u2066/cancel\u2069 בכל רגע כדי לבטל את הרישום.',
+    'Operation cancelled.': 'הפעולה בוטלה.',
   },
 };
 


### PR DESCRIPTION
## Summary

Introduces three admin-only Telegram commands that consume data written to Azure Blob Storage by the sibling `f1-fantasy-api-data` repo:

- **`/register_league`** — pending-reply flow that validates the league code against `leagues/{code}/f1-fantasy-api-data.json` and stores the subscription in a new `UserLeagues` Azure Table (partitionKey=`chatId`, rowKey=`leagueCode`). League name is captured at registration time. Invalid codes re-prompt with guidance + `/report_bug` link for missing leagues.
- **`/unregister_league`** — inline-keyboard selection to remove a registered league.
- **`/leaderboard`** — compact standings (position, team name, total score) with header showing league name, member count, and fetch time. 0 leagues → prompt to register · 1 league → auto-render · 2+ → inline league picker.

## Also in this PR

- **Global cancel keyword** — `/cancel`, `cancel`, or `ביטול` (case-insensitive) while any pending-reply flow is active clears the state and confirms with *Operation cancelled.* Works for every command in the pending-reply registry with no per-command changes.
- **RTL rendering fix** — Latin command tokens (`/cancel`, `/report_bug`, `F1 Fantasy`) inside Hebrew strings are wrapped with Unicode directional isolates (U+2066 LRI … U+2069 PDI) so the `/` and comma render on the correct side.

## Storage

- **Table:** `UserLeagues` — reuses `AZURE_STORAGE_CONNECTION_STRING`. Schema: `leagueName`, `registeredAt`.
- **Blob:** `leagues/{leagueCode}/f1-fantasy-api-data.json` in the existing `AZURE_STORAGE_CONTAINER_NAME` container (produced by sibling repo).

## Tests & lint

- `npm test` → **504 passing** (55 suites, +45 new tests)
- `npm run lint` → clean (pre-existing `max-params` warning only)

## Docs

- `AGENTS.md` — new *League Registry* section; global cancel mentioned in Pending Reply Manager bullet; admin command list updated.
- `readme.md` — new *League Leaderboards* feature bullet.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>