### PR TITLE
Rename register_league/unregister_league to follow_league/unfollow_league

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ This repository contains a Telegram bot that helps manage F1 Fantasy teams. The 
 - `/menu`, `/help`, `/lang`
 - `/report_bug` _(reply-based — uses pending reply manager)_
 
-**Admin-only:** `/trigger_scraping`, `/get_botfather_commands`, `/billing_stats`, `/version`, `/list_users`, `/send_message_to_user`, `/broadcast`, `/set_nickname`, `/live_score`, `/register_league`, `/unregister_league`, `/leaderboard`
+**Admin-only:** `/trigger_scraping`, `/get_botfather_commands`, `/billing_stats`, `/version`, `/list_users`, `/send_message_to_user`, `/broadcast`, `/set_nickname`, `/live_score`, `/follow_league`, `/unfollow_league`, `/leaderboard`
 
 ---
 
@@ -286,38 +286,38 @@ The table is **extensible** — new attributes can be added at any time without 
 
 ## League Registry
 
-`src/leagueRegistryService.js` tracks league subscriptions in an Azure Table Storage table (`UserLeagues`). Data is produced by the sibling repo `f1-fantasy-api-data`, which writes league blobs to Azure Blob Storage at `leagues/{leagueCode}/f1-fantasy-api-data.json` in the same container (`AZURE_STORAGE_CONTAINER_NAME`) used by the bot.
+`src/leagueRegistryService.js` tracks league follows in an Azure Table Storage table (`UserLeagues`). Data is produced by the sibling repo `f1-fantasy-api-data`, which writes league blobs to Azure Blob Storage at `leagues/{leagueCode}/f1-fantasy-api-data.json` in the same container (`AZURE_STORAGE_CONTAINER_NAME`) used by the bot.
 
 ### How It Works
 
-1. Admin runs `/register_league` → pending-reply flow prompts for the league code.
-2. The `register_league` registry entry calls `getLeagueData(code)` from `src/azureStorageService.js`. If the blob is missing, the flow re-registers itself and re-prompts so the admin can retry without typing the command again.
-3. On success, `addUserLeague(chatId, leagueCode, leagueName)` stores a row in `UserLeagues` (partitionKey=chatId, rowKey=leagueCode) with the league name captured at registration time.
+1. Admin runs `/follow_league` → pending-reply flow prompts for the league code.
+2. The `follow_league` registry entry calls `getLeagueData(code)` from `src/azureStorageService.js`. If the blob is missing, the flow re-registers itself and re-prompts so the admin can retry without typing the command again.
+3. On success, `addUserLeague(chatId, leagueCode, leagueName)` stores a row in `UserLeagues` (partitionKey=chatId, rowKey=leagueCode) with the league name captured at follow time.
 4. `/leaderboard` calls `listUserLeagues(chatId)`:
-   - 0 leagues → prompt to run `/register_league`.
+   - 0 leagues → prompt to run `/follow_league`.
    - 1 league → auto-fetch blob and render leaderboard.
    - 2+ leagues → inline keyboard (`LEAGUE_CALLBACK_TYPE`) showing each league by name; on selection, callback handler fetches the blob and renders.
-5. `/unregister_league` shows an inline keyboard (`LEAGUE_UNREGISTER_CALLBACK_TYPE`) with all registered leagues; selection calls `removeUserLeague(chatId, leagueCode)`.
+5. `/unfollow_league` shows an inline keyboard (`LEAGUE_UNFOLLOW_CALLBACK_TYPE`) with all followed leagues; selection calls `removeUserLeague(chatId, leagueCode)`.
 
 The leaderboard is rendered compactly (position, team name, total score) with a header showing league name, member count, and fetch time. Teams from the blob are already sorted by `position`.
 
 ### Table Schema
 
-| Field          | Type     | Description                                   |
-| -------------- | -------- | --------------------------------------------- |
-| `partitionKey` | `string` | The `chatId` (stringified)                    |
-| `rowKey`       | `string` | The league code (e.g., `C8EFGOXCB04`)         |
-| `leagueName`   | `string` | League display name captured at registration  |
-| `registeredAt` | `string` | ISO timestamp — set when the league was added |
+| Field          | Type     | Description                                          |
+| -------------- | -------- | ---------------------------------------------------- |
+| `partitionKey` | `string` | The `chatId` (stringified)                           |
+| `rowKey`       | `string` | The league code (e.g., `C8EFGOXCB04`)                |
+| `leagueName`   | `string` | League display name captured when the user followed  |
+| `registeredAt` | `string` | ISO timestamp — set when the league was followed     |
 
 ### API Reference
 
 | Method             | Signature                                                          | Purpose                                                                                            |
 | ------------------ | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
-| `addUserLeague`    | `addUserLeague(chatId, leagueCode, leagueName) → Promise`          | Upsert a league subscription (Merge mode).                                                         |
-| `removeUserLeague` | `removeUserLeague(chatId, leagueCode) → Promise`                   | Delete a league subscription. 404 is ignored (idempotent).                                         |
-| `listUserLeagues`  | `listUserLeagues(chatId) → Promise<Array<{leagueCode, leagueName, registeredAt}>>` | Partition-scoped query returning all leagues for a user.                                           |
-| `getUserLeague`    | `getUserLeague(chatId, leagueCode) → Promise<Object\|null>`        | Point lookup for a specific subscription.                                                          |
+| `addUserLeague`    | `addUserLeague(chatId, leagueCode, leagueName) → Promise`          | Upsert a league follow (Merge mode).                                                               |
+| `removeUserLeague` | `removeUserLeague(chatId, leagueCode) → Promise`                   | Delete a league follow. 404 is ignored (idempotent).                                               |
+| `listUserLeagues`  | `listUserLeagues(chatId) → Promise<Array<{leagueCode, leagueName, registeredAt}>>` | Partition-scoped query returning all leagues a user follows.                       |
+| `getUserLeague`    | `getUserLeague(chatId, leagueCode) → Promise<Object\|null>`        | Point lookup for a specific league follow.                                                         |
 | `getLeagueData`    | `getLeagueData(leagueCode) → Promise<Object\|null>`                | (in `azureStorageService.js`) Fetches the league blob. Returns `null` when the blob does not exist. |
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -43,9 +43,9 @@ A Telegram bot designed to help users manage their F1 Fantasy teams, providing t
 
 ### League Leaderboards
 
-- **League Registration**: Admins can register leagues via `/register_league` (league code captured and validated against the blob produced by the sibling `f1-fantasy-api-data` repo)
-- **Leaderboard Viewer**: `/leaderboard` shows a compact standings table (position, team name, total score) for any registered league; supports multiple leagues per user with inline selection
-- **League Unregistration**: `/unregister_league` removes a league subscription via an inline keyboard
+- **League Follow**: Admins can follow leagues via `/follow_league` (league code captured and validated against the blob produced by the sibling `f1-fantasy-api-data` repo)
+- **Leaderboard Viewer**: `/leaderboard` shows a compact standings table (position, team name, total score) for any followed league; supports multiple leagues per user with inline selection
+- **League Unfollow**: `/unfollow_league` removes a league follow via an inline keyboard
 
 ### Azure Cost Management
 

--- a/src/callbackQueryHandler.js
+++ b/src/callbackQueryHandler.js
@@ -20,7 +20,7 @@ const {
   BEST_TEAM_WEIGHTS_CALLBACK_TYPE,
   DEADLINE_CALLBACK_TYPE,
   LEAGUE_CALLBACK_TYPE,
-  LEAGUE_UNREGISTER_CALLBACK_TYPE,
+  LEAGUE_UNFOLLOW_CALLBACK_TYPE,
 } = require('./constants');
 
 const {
@@ -61,8 +61,8 @@ exports.handleCallbackQuery = async function (bot, query) {
       return await handleDeadlineRefreshCallback(bot, query);
     case LEAGUE_CALLBACK_TYPE:
       return await handleLeagueCallback(bot, query);
-    case LEAGUE_UNREGISTER_CALLBACK_TYPE:
-      return await handleLeagueUnregisterCallback(bot, query);
+    case LEAGUE_UNFOLLOW_CALLBACK_TYPE:
+      return await handleLeagueUnfollowCallback(bot, query);
     default:
       await sendLogMessage(bot, `Unknown callback type: ${callbackType}`);
   }
@@ -334,7 +334,7 @@ async function handleLeagueCallback(bot, query) {
   await bot.answerCallbackQuery(query.id);
 }
 
-async function handleLeagueUnregisterCallback(bot, query) {
+async function handleLeagueUnfollowCallback(bot, query) {
   const chatId = query.message.chat.id;
   const messageId = query.message.message_id;
   const leagueCode = query.data.split(':')[1];
@@ -342,13 +342,13 @@ async function handleLeagueUnregisterCallback(bot, query) {
   try {
     await removeUserLeague(chatId, leagueCode);
     await bot.editMessageText(
-      t('Unregistered from league {CODE}.', chatId, { CODE: leagueCode }),
+      t('Unfollowed league {CODE}.', chatId, { CODE: leagueCode }),
       { chat_id: chatId, message_id: messageId },
     );
   } catch (err) {
-    console.error('Error unregistering league:', err);
+    console.error('Error unfollowing league:', err);
     await bot.editMessageText(
-      t('❌ Failed to unregister league: {ERROR}', chatId, {
+      t('❌ Failed to unfollow league: {ERROR}', chatId, {
         ERROR: err.message,
       }),
       { chat_id: chatId, message_id: messageId },

--- a/src/callbackQueryHandler.test.js
+++ b/src/callbackQueryHandler.test.js
@@ -7,7 +7,7 @@ const {
   BEST_TEAM_WEIGHTS_CALLBACK_TYPE,
   DEADLINE_CALLBACK_TYPE,
   LEAGUE_CALLBACK_TYPE,
-  LEAGUE_UNREGISTER_CALLBACK_TYPE,
+  LEAGUE_UNFOLLOW_CALLBACK_TYPE,
   EXTRA_BOOST_CHIP,
 } = require('./constants');
 const cache = require('./cache');
@@ -281,12 +281,12 @@ describe('handleCallbackQuery', () => {
     expect(bot.answerCallbackQuery).toHaveBeenCalledWith('q-league');
   });
 
-  it('should handle LEAGUE_UNREGISTER callback by removing the league', async () => {
+  it('should handle LEAGUE_UNFOLLOW callback by removing the league', async () => {
     const { removeUserLeague } = require('./leagueRegistryService');
 
     const query = {
       id: 'q-unreg',
-      data: `${LEAGUE_UNREGISTER_CALLBACK_TYPE}:ABC`,
+      data: `${LEAGUE_UNFOLLOW_CALLBACK_TYPE}:ABC`,
       message: { chat: { id: 123 }, message_id: 456 },
     };
 
@@ -294,7 +294,7 @@ describe('handleCallbackQuery', () => {
 
     expect(removeUserLeague).toHaveBeenCalledWith(123, 'ABC');
     expect(bot.editMessageText).toHaveBeenCalledWith(
-      'Unregistered from league {CODE}.',
+      'Unfollowed league {CODE}.',
       { chat_id: 123, message_id: 456 },
     );
     expect(bot.answerCallbackQuery).toHaveBeenCalledWith('q-unreg');

--- a/src/commandsHandler/commandHandlers.js
+++ b/src/commandsHandler/commandHandlers.js
@@ -34,8 +34,8 @@ const {
   COMMAND_SET_BEST_TEAM_RANKING,
   COMMAND_LIVE_SCORE,
   COMMAND_DEADLINE,
-  COMMAND_REGISTER_LEAGUE,
-  COMMAND_UNREGISTER_LEAGUE,
+  COMMAND_FOLLOW_LEAGUE,
+  COMMAND_UNFOLLOW_LEAGUE,
   COMMAND_LEADERBOARD,
 } = require('../constants');
 
@@ -79,10 +79,10 @@ const { handleSelectTeamCommand } = require('./selectTeamHandler');
 const { handleSetBestTeamRanking } = require('./setBestTeamRankingHandler');
 const { handleLiveScoreCommand } = require('./liveScoreHandler');
 const { handleDeadlineCommand } = require('./deadlineHandler');
-const { handleRegisterLeagueCommand } = require('./registerLeagueHandler');
+const { handleFollowLeagueCommand } = require('./followLeagueHandler');
 const {
-  handleUnregisterLeagueCommand,
-} = require('./unregisterLeagueHandler');
+  handleUnfollowLeagueCommand,
+} = require('./unfollowLeagueHandler');
 const { handleLeaderboardCommand } = require('./leaderboardHandler');
 
 // Mapping of command constants to their handler functions
@@ -122,8 +122,8 @@ const COMMAND_HANDLERS = {
   [COMMAND_SET_BEST_TEAM_RANKING]: handleSetBestTeamRanking,
   [COMMAND_LIVE_SCORE]: handleLiveScoreCommand,
   [COMMAND_DEADLINE]: handleDeadlineCommand,
-  [COMMAND_REGISTER_LEAGUE]: handleRegisterLeagueCommand,
-  [COMMAND_UNREGISTER_LEAGUE]: handleUnregisterLeagueCommand,
+  [COMMAND_FOLLOW_LEAGUE]: handleFollowLeagueCommand,
+  [COMMAND_UNFOLLOW_LEAGUE]: handleUnfollowLeagueCommand,
   [COMMAND_LEADERBOARD]: handleLeaderboardCommand,
 };
 

--- a/src/commandsHandler/followLeagueHandler.js
+++ b/src/commandsHandler/followLeagueHandler.js
@@ -3,12 +3,12 @@ const { isAdminMessage } = require('../utils/utils');
 const { registerPendingReply } = require('../pendingReplyManager');
 
 /**
- * Handle the /register_league admin command.
+ * Handle the /follow_league admin command.
  * Initiates a pending-reply flow that asks the admin for the league code.
- * The actual registration (blob validation + persistence) happens in the
- * pendingReplyRegistry entry for 'register_league'.
+ * The actual follow (blob validation + persistence) happens in the
+ * pendingReplyRegistry entry for 'follow_league'.
  */
-async function handleRegisterLeagueCommand(bot, msg) {
+async function handleFollowLeagueCommand(bot, msg) {
   const chatId = msg.chat.id;
 
   if (!isAdminMessage(msg)) {
@@ -21,17 +21,17 @@ async function handleRegisterLeagueCommand(bot, msg) {
   }
 
   const prompt = [
-    t('Please enter the league code you want to register to:', chatId),
+    t('Please enter the league code you want to follow:', chatId),
     '',
     t(
-      'To find your league code: go to the F1 Fantasy website, open the league you want to register to, click the share button, and copy the league code from there.',
+      'To find your league code: go to the F1 Fantasy website, open the league you want to follow, click the share button, and copy the league code from there.',
       chatId,
     ),
     '',
-    t('💡 Send /cancel at any time to abort the registration.', chatId),
+    t('💡 Send /cancel at any time to abort.', chatId),
   ].join('\n');
 
-  await registerPendingReply(chatId, 'register_league');
+  await registerPendingReply(chatId, 'follow_league');
 
   await bot
     .sendMessage(chatId, prompt, {
@@ -42,4 +42,4 @@ async function handleRegisterLeagueCommand(bot, msg) {
     );
 }
 
-module.exports = { handleRegisterLeagueCommand };
+module.exports = { handleFollowLeagueCommand };

--- a/src/commandsHandler/followLeagueHandler.test.js
+++ b/src/commandsHandler/followLeagueHandler.test.js
@@ -1,4 +1,4 @@
-const { handleRegisterLeagueCommand } = require('./registerLeagueHandler');
+const { handleFollowLeagueCommand } = require('./followLeagueHandler');
 
 jest.mock('../i18n', () => ({
   t: jest.fn((key) => key),
@@ -15,7 +15,7 @@ jest.mock('../pendingReplyManager', () => ({
 const { isAdminMessage } = require('../utils/utils');
 const { registerPendingReply } = require('../pendingReplyManager');
 
-describe('registerLeagueHandler', () => {
+describe('followLeagueHandler', () => {
   let botMock;
 
   beforeEach(() => {
@@ -26,7 +26,7 @@ describe('registerLeagueHandler', () => {
   it('rejects non-admin users', async () => {
     isAdminMessage.mockReturnValue(false);
 
-    await handleRegisterLeagueCommand(botMock, { chat: { id: 999 } });
+    await handleFollowLeagueCommand(botMock, { chat: { id: 999 } });
 
     expect(botMock.sendMessage).toHaveBeenCalledWith(
       999,
@@ -38,20 +38,20 @@ describe('registerLeagueHandler', () => {
   it('registers a pending reply for admins', async () => {
     isAdminMessage.mockReturnValue(true);
 
-    await handleRegisterLeagueCommand(botMock, { chat: { id: 1 } });
+    await handleFollowLeagueCommand(botMock, { chat: { id: 1 } });
 
-    expect(registerPendingReply).toHaveBeenCalledWith(1, 'register_league');
+    expect(registerPendingReply).toHaveBeenCalledWith(1, 'follow_league');
   });
 
   it('sends a prompt with force_reply', async () => {
     isAdminMessage.mockReturnValue(true);
 
-    await handleRegisterLeagueCommand(botMock, { chat: { id: 1 } });
+    await handleFollowLeagueCommand(botMock, { chat: { id: 1 } });
 
     expect(botMock.sendMessage).toHaveBeenCalledWith(
       1,
       expect.stringContaining(
-        'Please enter the league code you want to register to:',
+        'Please enter the league code you want to follow:',
       ),
       { reply_markup: { force_reply: true } },
     );

--- a/src/commandsHandler/index.js
+++ b/src/commandsHandler/index.js
@@ -42,10 +42,10 @@ const { handleSelectTeamCommand } = require('./selectTeamHandler');
 const { handleSetBestTeamRanking } = require('./setBestTeamRankingHandler');
 const { handleLiveScoreCommand } = require('./liveScoreHandler');
 const { handleDeadlineCommand } = require('./deadlineHandler');
-const { handleRegisterLeagueCommand } = require('./registerLeagueHandler');
+const { handleFollowLeagueCommand } = require('./followLeagueHandler');
 const {
-  handleUnregisterLeagueCommand,
-} = require('./unregisterLeagueHandler');
+  handleUnfollowLeagueCommand,
+} = require('./unfollowLeagueHandler');
 const { handleLeaderboardCommand } = require('./leaderboardHandler');
 
 module.exports = {
@@ -86,7 +86,7 @@ module.exports = {
   handleSetBestTeamRanking,
   handleLiveScoreCommand,
   handleDeadlineCommand,
-  handleRegisterLeagueCommand,
-  handleUnregisterLeagueCommand,
+  handleFollowLeagueCommand,
+  handleUnfollowLeagueCommand,
   handleLeaderboardCommand,
 };

--- a/src/commandsHandler/leaderboardHandler.js
+++ b/src/commandsHandler/leaderboardHandler.js
@@ -4,7 +4,7 @@ const { listUserLeagues } = require('../leagueRegistryService');
 const { getLeagueData } = require('../azureStorageService');
 const {
   LEAGUE_CALLBACK_TYPE,
-  COMMAND_REGISTER_LEAGUE,
+  COMMAND_FOLLOW_LEAGUE,
 } = require('../constants');
 
 /**
@@ -105,9 +105,9 @@ async function handleLeaderboardCommand(bot, msg) {
     await bot.sendMessage(
       chatId,
       t(
-        'You are not registered to any league. Run {CMD} to register to one first.',
+        'You are not following any league. Run {CMD} to follow one first.',
         chatId,
-        { CMD: COMMAND_REGISTER_LEAGUE },
+        { CMD: COMMAND_FOLLOW_LEAGUE },
       ),
     );
 

--- a/src/commandsHandler/leaderboardHandler.test.js
+++ b/src/commandsHandler/leaderboardHandler.test.js
@@ -97,7 +97,7 @@ describe('leaderboardHandler', () => {
 
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         1,
-        'You are not registered to any league. Run /register_league to register to one first.',
+        'You are not following any league. Run /follow_league to follow one first.',
       );
     });
 

--- a/src/commandsHandler/unfollowLeagueHandler.js
+++ b/src/commandsHandler/unfollowLeagueHandler.js
@@ -2,11 +2,11 @@ const { t } = require('../i18n');
 const { isAdminMessage } = require('../utils/utils');
 const { listUserLeagues } = require('../leagueRegistryService');
 const {
-  LEAGUE_UNREGISTER_CALLBACK_TYPE,
-  COMMAND_REGISTER_LEAGUE,
+  LEAGUE_UNFOLLOW_CALLBACK_TYPE,
+  COMMAND_FOLLOW_LEAGUE,
 } = require('../constants');
 
-async function handleUnregisterLeagueCommand(bot, msg) {
+async function handleUnfollowLeagueCommand(bot, msg) {
   const chatId = msg.chat.id;
 
   if (!isAdminMessage(msg)) {
@@ -22,7 +22,7 @@ async function handleUnregisterLeagueCommand(bot, msg) {
   try {
     leagues = await listUserLeagues(chatId);
   } catch (err) {
-    console.error('Error listing user leagues for unregister:', err);
+    console.error('Error listing user leagues for unfollow:', err);
     await bot.sendMessage(
       chatId,
       t('❌ Failed to load your leagues: {ERROR}', chatId, {
@@ -37,9 +37,9 @@ async function handleUnregisterLeagueCommand(bot, msg) {
     await bot.sendMessage(
       chatId,
       t(
-        'You are not registered to any league. Run {CMD} to register to one first.',
+        'You are not following any league. Run {CMD} to follow one first.',
         chatId,
-        { CMD: COMMAND_REGISTER_LEAGUE },
+        { CMD: COMMAND_FOLLOW_LEAGUE },
       ),
     );
 
@@ -49,13 +49,13 @@ async function handleUnregisterLeagueCommand(bot, msg) {
   const keyboard = leagues.map((league) => [
     {
       text: league.leagueName || league.leagueCode,
-      callback_data: `${LEAGUE_UNREGISTER_CALLBACK_TYPE}:${league.leagueCode}`,
+      callback_data: `${LEAGUE_UNFOLLOW_CALLBACK_TYPE}:${league.leagueCode}`,
     },
   ]);
 
   await bot.sendMessage(
     chatId,
-    t('Which league do you want to unregister from?', chatId),
+    t('Which league do you want to unfollow?', chatId),
     {
       reply_to_message_id: msg.message_id,
       reply_markup: { inline_keyboard: keyboard },
@@ -63,4 +63,4 @@ async function handleUnregisterLeagueCommand(bot, msg) {
   );
 }
 
-module.exports = { handleUnregisterLeagueCommand };
+module.exports = { handleUnfollowLeagueCommand };

--- a/src/commandsHandler/unfollowLeagueHandler.test.js
+++ b/src/commandsHandler/unfollowLeagueHandler.test.js
@@ -1,6 +1,6 @@
 const {
-  handleUnregisterLeagueCommand,
-} = require('./unregisterLeagueHandler');
+  handleUnfollowLeagueCommand,
+} = require('./unfollowLeagueHandler');
 
 jest.mock('../i18n', () => ({
   t: jest.fn((key, _chatId, vars) =>
@@ -24,7 +24,7 @@ jest.mock('../leagueRegistryService', () => ({
 const { isAdminMessage } = require('../utils/utils');
 const { listUserLeagues } = require('../leagueRegistryService');
 
-describe('unregisterLeagueHandler', () => {
+describe('unfollowLeagueHandler', () => {
   let botMock;
 
   beforeEach(() => {
@@ -35,7 +35,7 @@ describe('unregisterLeagueHandler', () => {
   it('rejects non-admin users', async () => {
     isAdminMessage.mockReturnValue(false);
 
-    await handleUnregisterLeagueCommand(botMock, { chat: { id: 999 } });
+    await handleUnfollowLeagueCommand(botMock, { chat: { id: 999 } });
 
     expect(botMock.sendMessage).toHaveBeenCalledWith(
       999,
@@ -44,18 +44,18 @@ describe('unregisterLeagueHandler', () => {
     expect(listUserLeagues).not.toHaveBeenCalled();
   });
 
-  it('tells the admin when no leagues are registered', async () => {
+  it('tells the admin when no leagues are followed', async () => {
     isAdminMessage.mockReturnValue(true);
     listUserLeagues.mockResolvedValueOnce([]);
 
-    await handleUnregisterLeagueCommand(botMock, {
+    await handleUnfollowLeagueCommand(botMock, {
       chat: { id: 1 },
       message_id: 10,
     });
 
     expect(botMock.sendMessage).toHaveBeenCalledWith(
       1,
-      'You are not registered to any league. Run /register_league to register to one first.',
+      'You are not following any league. Run /follow_league to follow one first.',
     );
   });
 
@@ -66,20 +66,20 @@ describe('unregisterLeagueHandler', () => {
       { leagueCode: 'XYZ', leagueName: 'Other' },
     ]);
 
-    await handleUnregisterLeagueCommand(botMock, {
+    await handleUnfollowLeagueCommand(botMock, {
       chat: { id: 1 },
       message_id: 10,
     });
 
     expect(botMock.sendMessage).toHaveBeenCalledWith(
       1,
-      'Which league do you want to unregister from?',
+      'Which league do you want to unfollow?',
       expect.objectContaining({
         reply_to_message_id: 10,
         reply_markup: {
           inline_keyboard: [
-            [{ text: 'Amba', callback_data: 'LEAGUE_UNREGISTER:ABC' }],
-            [{ text: 'Other', callback_data: 'LEAGUE_UNREGISTER:XYZ' }],
+            [{ text: 'Amba', callback_data: 'LEAGUE_UNFOLLOW:ABC' }],
+            [{ text: 'Other', callback_data: 'LEAGUE_UNFOLLOW:XYZ' }],
           ],
         },
       }),
@@ -93,7 +93,7 @@ describe('unregisterLeagueHandler', () => {
       .mockImplementation(() => {});
     listUserLeagues.mockRejectedValueOnce(new Error('boom'));
 
-    await handleUnregisterLeagueCommand(botMock, { chat: { id: 1 } });
+    await handleUnfollowLeagueCommand(botMock, { chat: { id: 1 } });
 
     expect(botMock.sendMessage).toHaveBeenCalledWith(
       1,

--- a/src/constants.js
+++ b/src/constants.js
@@ -32,7 +32,7 @@ exports.TEAM_ASSIGN_CALLBACK_TYPE = 'TEAM_ASSIGN';
 exports.BEST_TEAM_WEIGHTS_CALLBACK_TYPE = 'BEST_TEAM_WEIGHTS';
 exports.DEADLINE_CALLBACK_TYPE = 'DEADLINE';
 exports.LEAGUE_CALLBACK_TYPE = 'LEAGUE';
-exports.LEAGUE_UNREGISTER_CALLBACK_TYPE = 'LEAGUE_UNREGISTER';
+exports.LEAGUE_UNFOLLOW_CALLBACK_TYPE = 'LEAGUE_UNFOLLOW';
 
 exports.MAX_TELEGRAM_MESSAGE_LENGTH = 4096;
 exports.BEST_TEAMS_RESULT_COUNT = 15;
@@ -72,8 +72,8 @@ exports.COMMAND_SELECT_TEAM = '/select_team';
 exports.COMMAND_SET_BEST_TEAM_RANKING = '/set_best_team_ranking';
 exports.COMMAND_BEST_TEAM_SCENARIOS = '/best_team_scenarios';
 exports.COMMAND_DEADLINE = '/deadline';
-exports.COMMAND_REGISTER_LEAGUE = '/register_league';
-exports.COMMAND_UNREGISTER_LEAGUE = '/unregister_league';
+exports.COMMAND_FOLLOW_LEAGUE = '/follow_league';
+exports.COMMAND_UNFOLLOW_LEAGUE = '/unfollow_league';
 exports.COMMAND_LEADERBOARD = '/leaderboard';
 
 // Menu configuration for interactive menu command
@@ -274,23 +274,23 @@ exports.MENU_CATEGORIES = {
   LEAGUE_MANAGEMENT: {
     id: 'league_management',
     title: '🏁 League Management',
-    description: 'Register and view F1 Fantasy leagues',
+    description: 'Follow and view F1 Fantasy leagues',
     adminOnly: true,
     commands: [
       {
-        constant: exports.COMMAND_REGISTER_LEAGUE,
-        title: '➕ Register League',
-        description: 'Register to an F1 Fantasy league by its code',
+        constant: exports.COMMAND_FOLLOW_LEAGUE,
+        title: '➕ Follow League',
+        description: 'Follow an F1 Fantasy league by its code',
       },
       {
-        constant: exports.COMMAND_UNREGISTER_LEAGUE,
-        title: '➖ Unregister League',
-        description: 'Remove a registered F1 Fantasy league',
+        constant: exports.COMMAND_UNFOLLOW_LEAGUE,
+        title: '➖ Unfollow League',
+        description: 'Unfollow an F1 Fantasy league',
       },
       {
         constant: exports.COMMAND_LEADERBOARD,
         title: '🏆 Leaderboard',
-        description: 'View the leaderboard of a registered league',
+        description: 'View the leaderboard of a followed league',
       },
     ],
   },

--- a/src/leagueRegistryService.js
+++ b/src/leagueRegistryService.js
@@ -1,5 +1,5 @@
 // League Registry Service
-// Tracks the F1 Fantasy leagues each user is registered to in Azure Table Storage.
+// Tracks the F1 Fantasy leagues each user follows, stored in Azure Table Storage.
 // One row per (chatId, leagueCode). Uses Azure Table Storage "Merge" mode so that
 // adding attributes in the future does not require migrations.
 
@@ -82,7 +82,7 @@ async function addUserLeague(chatId, leagueCode, leagueName) {
 }
 
 /**
- * Remove a league registration for a user.
+ * Remove a league follow for a user.
  * @param {number|string} chatId
  * @param {string} leagueCode
  */
@@ -99,7 +99,7 @@ async function removeUserLeague(chatId, leagueCode) {
 }
 
 /**
- * List all leagues a user is registered to.
+ * List all leagues a user follows.
  * @param {number|string} chatId
  * @returns {Promise<Array<{chatId, leagueCode, leagueName, registeredAt}>>}
  */
@@ -119,7 +119,7 @@ async function listUserLeagues(chatId) {
 }
 
 /**
- * Point lookup for a single registration.
+ * Point lookup for a single league follow.
  * @param {number|string} chatId
  * @param {string} leagueCode
  * @returns {Promise<Object|null>}

--- a/src/pendingReplyRegistry.js
+++ b/src/pendingReplyRegistry.js
@@ -446,7 +446,7 @@ const PENDING_REPLY_REGISTRY = {
         chatId,
       ),
   },
-  register_league: {
+  follow_league: {
     buildHandler: (chatId) => {
       // Lazy require to avoid circular dependency via pendingReplyManager
       const { registerPendingReply } = require('./pendingReplyManager');
@@ -461,7 +461,7 @@ const PENDING_REPLY_REGISTRY = {
         try {
           leagueData = await getLeagueData(leagueCode);
         } catch (err) {
-          console.error('Error fetching league data for registration:', err);
+          console.error('Error fetching league data for follow:', err);
           await replyBot
             .sendMessage(
               chatId,
@@ -482,7 +482,7 @@ const PENDING_REPLY_REGISTRY = {
         if (!leagueData) {
           // Blob missing → treat as invalid code; re-register pending reply
           // so the user can try again without re-typing the command.
-          await registerPendingReply(chatId, 'register_league');
+          await registerPendingReply(chatId, 'follow_league');
 
           const retryPrompt = [
             t(
@@ -492,7 +492,7 @@ const PENDING_REPLY_REGISTRY = {
             ),
             '',
             t(
-              'To find your league code: go to the F1 Fantasy website, open the league you want to register to, click the share button, and copy the league code from there.',
+              'To find your league code: go to the F1 Fantasy website, open the league you want to follow, click the share button, and copy the league code from there.',
               chatId,
             ),
             '',
@@ -501,7 +501,7 @@ const PENDING_REPLY_REGISTRY = {
               chatId,
             ),
             '',
-            t('💡 Send /cancel at any time to abort the registration.', chatId),
+            t('💡 Send /cancel at any time to abort.', chatId),
           ].join('\n');
 
           await replyBot
@@ -520,17 +520,17 @@ const PENDING_REPLY_REGISTRY = {
         try {
           await addUserLeague(chatId, leagueCode, leagueName);
         } catch (err) {
-          console.error('Error persisting league registration:', err);
+          console.error('Error persisting league follow:', err);
           await replyBot
             .sendMessage(
               chatId,
-              t('❌ Failed to register league: {ERROR}', chatId, {
+              t('❌ Failed to follow league: {ERROR}', chatId, {
                 ERROR: err.message,
               }),
             )
             .catch((sendErr) =>
               console.error(
-                'Error sending league registration error message:',
+                'Error sending league follow error message:',
                 sendErr,
               ),
             );
@@ -542,18 +542,18 @@ const PENDING_REPLY_REGISTRY = {
           .sendMessage(
             chatId,
             t(
-              'Registered to league "{NAME}" ({CODE}).',
+              'Now following league "{NAME}" ({CODE}).',
               chatId,
               { NAME: leagueName, CODE: leagueCode },
             ),
           )
           .catch((err) =>
-            console.error('Error sending league registration confirmation:', err),
+            console.error('Error sending league follow confirmation:', err),
           );
 
         await sendLogMessage(
           replyBot,
-          `Registered league ${leagueName} (${leagueCode}) for chatId ${chatId}`,
+          `Followed league ${leagueName} (${leagueCode}) for chatId ${chatId}`,
         ).catch(() => {});
       };
     },

--- a/src/pendingReplyRegistry.test.js
+++ b/src/pendingReplyRegistry.test.js
@@ -763,7 +763,7 @@ describe('pendingReplyRegistry', () => {
     });
   });
 
-  describe('register_league', () => {
+  describe('follow_league', () => {
     const { getLeagueData } = require('./azureStorageService');
     const { addUserLeague } = require('./leagueRegistryService');
 
@@ -779,7 +779,7 @@ describe('pendingReplyRegistry', () => {
         leagueCode: 'ABC',
       });
 
-      const resolved = resolveCommand('register_league', 42);
+      const resolved = resolveCommand('follow_league', 42);
       const botMock = { sendMessage: jest.fn().mockResolvedValue() };
 
       await resolved.handler(botMock, { text: '  ABC  ' });
@@ -796,13 +796,13 @@ describe('pendingReplyRegistry', () => {
     it('re-registers the pending reply when the league blob is missing', async () => {
       getLeagueData.mockResolvedValueOnce(null);
 
-      const resolved = resolveCommand('register_league', 42);
+      const resolved = resolveCommand('follow_league', 42);
       const botMock = { sendMessage: jest.fn().mockResolvedValue() };
 
       await resolved.handler(botMock, { text: 'BADCODE' });
 
       expect(addUserLeague).not.toHaveBeenCalled();
-      expect(registerPendingReply).toHaveBeenCalledWith(42, 'register_league');
+      expect(registerPendingReply).toHaveBeenCalledWith(42, 'follow_league');
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         42,
         expect.any(String),
@@ -816,7 +816,7 @@ describe('pendingReplyRegistry', () => {
         .mockImplementation(() => {});
       getLeagueData.mockRejectedValueOnce(new Error('boom'));
 
-      const resolved = resolveCommand('register_league', 42);
+      const resolved = resolveCommand('follow_league', 42);
       const botMock = { sendMessage: jest.fn().mockResolvedValue() };
 
       await resolved.handler(botMock, { text: 'ABC' });
@@ -829,17 +829,17 @@ describe('pendingReplyRegistry', () => {
 
     describe('buildValidate', () => {
       it('accepts non-empty text', () => {
-        const resolved = resolveCommand('register_league', 1);
+        const resolved = resolveCommand('follow_league', 1);
         expect(resolved.validate({ text: 'ABC' })).toBe(true);
       });
 
       it('rejects empty text', () => {
-        const resolved = resolveCommand('register_league', 1);
+        const resolved = resolveCommand('follow_league', 1);
         expect(resolved.validate({ text: '  ' })).toBe(false);
       });
 
       it('rejects missing text', () => {
-        const resolved = resolveCommand('register_league', 1);
+        const resolved = resolveCommand('follow_league', 1);
         expect(resolved.validate({})).toBe(false);
       });
     });

--- a/src/textMessageHandler.js
+++ b/src/textMessageHandler.js
@@ -37,8 +37,8 @@ const {
   handleSetBestTeamRanking,
   handleLiveScoreCommand,
   handleDeadlineCommand,
-  handleRegisterLeagueCommand,
-  handleUnregisterLeagueCommand,
+  handleFollowLeagueCommand,
+  handleUnfollowLeagueCommand,
   handleLeaderboardCommand,
 } = require('./commandsHandler');
 
@@ -79,8 +79,8 @@ const {
   COMMAND_SET_BEST_TEAM_RANKING,
   COMMAND_LIVE_SCORE,
   COMMAND_DEADLINE,
-  COMMAND_REGISTER_LEAGUE,
-  COMMAND_UNREGISTER_LEAGUE,
+  COMMAND_FOLLOW_LEAGUE,
+  COMMAND_UNFOLLOW_LEAGUE,
   COMMAND_LEADERBOARD,
 } = require('./constants');
 
@@ -168,10 +168,10 @@ exports.handleTextMessage = async function (bot, msg) {
       return await handleLiveScoreCommand(bot, msg);
     case msg.text === COMMAND_DEADLINE:
       return await handleDeadlineCommand(bot, msg);
-    case msg.text === COMMAND_REGISTER_LEAGUE:
-      return await handleRegisterLeagueCommand(bot, msg);
-    case msg.text === COMMAND_UNREGISTER_LEAGUE:
-      return await handleUnregisterLeagueCommand(bot, msg);
+    case msg.text === COMMAND_FOLLOW_LEAGUE:
+      return await handleFollowLeagueCommand(bot, msg);
+    case msg.text === COMMAND_UNFOLLOW_LEAGUE:
+      return await handleUnfollowLeagueCommand(bot, msg);
     case msg.text === COMMAND_LEADERBOARD:
       return await handleLeaderboardCommand(bot, msg);
     default:

--- a/src/textMessageHandler.test.js
+++ b/src/textMessageHandler.test.js
@@ -25,8 +25,8 @@ const {
   COMMAND_SET_BEST_TEAM_RANKING,
   COMMAND_LIVE_SCORE,
   COMMAND_DEADLINE,
-  COMMAND_REGISTER_LEAGUE,
-  COMMAND_UNREGISTER_LEAGUE,
+  COMMAND_FOLLOW_LEAGUE,
+  COMMAND_UNFOLLOW_LEAGUE,
   COMMAND_LEADERBOARD,
 } = require('./constants');
 
@@ -99,11 +99,11 @@ const {
   handleDeadlineCommand,
 } = require('./commandsHandler/deadlineHandler');
 const {
-  handleRegisterLeagueCommand,
-} = require('./commandsHandler/registerLeagueHandler');
+  handleFollowLeagueCommand,
+} = require('./commandsHandler/followLeagueHandler');
 const {
-  handleUnregisterLeagueCommand,
-} = require('./commandsHandler/unregisterLeagueHandler');
+  handleUnfollowLeagueCommand,
+} = require('./commandsHandler/unfollowLeagueHandler');
 const {
   handleLeaderboardCommand,
 } = require('./commandsHandler/leaderboardHandler');
@@ -136,8 +136,8 @@ jest.mock('./commandsHandler/uploadConstructorsPhotoHandler');
 jest.mock('./commandsHandler/setBestTeamRankingHandler');
 jest.mock('./commandsHandler/liveScoreHandler');
 jest.mock('./commandsHandler/deadlineHandler');
-jest.mock('./commandsHandler/registerLeagueHandler');
-jest.mock('./commandsHandler/unregisterLeagueHandler');
+jest.mock('./commandsHandler/followLeagueHandler');
+jest.mock('./commandsHandler/unfollowLeagueHandler');
 jest.mock('./commandsHandler/leaderboardHandler');
 
 const { handleTextMessage } = require('./textMessageHandler');
@@ -261,29 +261,29 @@ describe('handleTextMessage', () => {
       expect(handleJsonMessage).not.toHaveBeenCalled();
     });
 
-    it('should route /register_league command to handleRegisterLeagueCommand', async () => {
+    it('should route /follow_league command to handleFollowLeagueCommand', async () => {
       const msgMock = {
         chat: { id: KILZI_CHAT_ID },
-        text: COMMAND_REGISTER_LEAGUE,
+        text: COMMAND_FOLLOW_LEAGUE,
       };
 
       await handleTextMessage(botMock, msgMock);
 
-      expect(handleRegisterLeagueCommand).toHaveBeenCalledWith(
+      expect(handleFollowLeagueCommand).toHaveBeenCalledWith(
         botMock,
         msgMock,
       );
     });
 
-    it('should route /unregister_league command to handleUnregisterLeagueCommand', async () => {
+    it('should route /unfollow_league command to handleUnfollowLeagueCommand', async () => {
       const msgMock = {
         chat: { id: KILZI_CHAT_ID },
-        text: COMMAND_UNREGISTER_LEAGUE,
+        text: COMMAND_UNFOLLOW_LEAGUE,
       };
 
       await handleTextMessage(botMock, msgMock);
 
-      expect(handleUnregisterLeagueCommand).toHaveBeenCalledWith(
+      expect(handleUnfollowLeagueCommand).toHaveBeenCalledWith(
         botMock,
         msgMock,
       );

--- a/src/translations.js
+++ b/src/translations.js
@@ -422,27 +422,27 @@ const translations = {
     'Selected Team: {TEAM}': 'קבוצה נבחרת: {TEAM}',
     '🔀 Select Team': '🔀 בחירת קבוצה',
     'Switch between your fantasy teams': 'מעבר בין הקבוצות שלך',
-    'Please enter the league code you want to register to:':
-      'אנא הזן את קוד הליגה שברצונך להירשם אליה:',
+    'Please enter the league code you want to follow:':
+      'אנא הזן את קוד הליגה שברצונך לעקוב אחריה:',
     'We support only text. Please enter the league code:':
       'אנחנו תומכים רק בטקסט. אנא הזן את קוד הליגה:',
     'League "{CODE}" not found. Please enter a valid league code:':
       'ליגה "{CODE}" לא נמצאה. אנא הזן קוד ליגה תקין:',
     '❌ Failed to load league data: {ERROR}':
       '❌ טעינת נתוני הליגה נכשלה: {ERROR}',
-    '❌ Failed to register league: {ERROR}':
-      '❌ רישום הליגה נכשל: {ERROR}',
-    'Registered to league "{NAME}" ({CODE}).':
-      'נרשמת לליגה "{NAME}" ({CODE}).',
-    'You are not registered to any league. Run {CMD} to register to one first.':
-      'אינך רשום לאף ליגה. הפעל {CMD} כדי להירשם לליגה.',
+    '❌ Failed to follow league: {ERROR}':
+      '❌ מעקב אחר הליגה נכשל: {ERROR}',
+    'Now following league "{NAME}" ({CODE}).':
+      'עוקב כעת אחר הליגה "{NAME}" ({CODE}).',
+    'You are not following any league. Run {CMD} to follow one first.':
+      'אינך עוקב אחר אף ליגה. הפעל {CMD} כדי לעקוב אחר ליגה.',
     'Which league leaderboard do you want to see?':
       'איזו טבלת ליגה ברצונך לראות?',
-    'Which league do you want to unregister from?':
-      'מאיזו ליגה ברצונך להתנתק?',
-    'Unregistered from league {CODE}.': 'התנתקת מהליגה {CODE}.',
-    '❌ Failed to unregister league: {ERROR}':
-      '❌ ביטול רישום הליגה נכשל: {ERROR}',
+    'Which league do you want to unfollow?':
+      'איזו ליגה להפסיק לעקוב?',
+    'Unfollowed league {CODE}.': 'הופסק המעקב אחר הליגה {CODE}.',
+    '❌ Failed to unfollow league: {ERROR}':
+      '❌ הפסקת המעקב אחר הליגה נכשלה: {ERROR}',
     '❌ Failed to load your leagues: {ERROR}':
       '❌ טעינת הליגות שלך נכשלה: {ERROR}',
     'No leaderboard data is available yet for this league. Please try again later.':
@@ -450,22 +450,23 @@ const translations = {
     'No teams in this league yet.': 'אין עדיין קבוצות בליגה הזו.',
     '👥 {COUNT} teams · updated {TIME}':
       '👥 {COUNT} קבוצות · עודכן {TIME}',
-    '➕ Register League': '➕ רישום ליגה',
-    'Register to an F1 Fantasy league by its code':
-      'הירשם לליגת F1 Fantasy לפי קוד',
-    '➖ Unregister League': '➖ ביטול רישום ליגה',
-    'Remove a registered F1 Fantasy league': 'הסר ליגת F1 Fantasy רשומה',
+    '➕ Follow League': '➕ מעקב אחר ליגה',
+    'Follow an F1 Fantasy league by its code':
+      'עקוב אחר ליגת F1 Fantasy לפי קוד',
+    '➖ Unfollow League': '➖ הפסקת מעקב אחר ליגה',
+    'Unfollow an F1 Fantasy league': 'הפסק לעקוב אחר ליגת F1 Fantasy',
     '🏆 Leaderboard': '🏆 טבלת ליגה',
-    'View the leaderboard of a registered league': 'צפה בטבלה של ליגה רשומה',
+    'View the leaderboard of a followed league':
+      'צפה בטבלה של ליגה שאתה עוקב אחריה',
     '🏁 League Management': '🏁 ניהול ליגות',
-    'Register and view F1 Fantasy leagues':
-      'רישום וצפייה בליגות F1 Fantasy',
-    'To find your league code: go to the F1 Fantasy website, open the league you want to register to, click the share button, and copy the league code from there.':
-      'כדי למצוא את קוד הליגה: היכנס לאתר \u2066F1 Fantasy\u2069, פתח את הליגה שברצונך להירשם אליה, לחץ על כפתור השיתוף והעתק את קוד הליגה משם.',
+    'Follow and view F1 Fantasy leagues':
+      'עקוב וצפה בליגות F1 Fantasy',
+    'To find your league code: go to the F1 Fantasy website, open the league you want to follow, click the share button, and copy the league code from there.':
+      'כדי למצוא את קוד הליגה: היכנס לאתר \u2066F1 Fantasy\u2069, פתח את הליגה שברצונך לעקוב אחריה, לחץ על כפתור השיתוף והעתק את קוד הליגה משם.',
     '📩 If the code is correct but the league is not yet tracked, please report it to the admins via /report_bug with the league code and we will add the bot to the league as soon as possible.':
       '📩\u200F אם הקוד תקין אך הליגה עדיין לא מנוטרת, דווח לאדמינים עם קוד הליגה באמצעות \u2066/report_bug\u2069 ונוסיף את הבוט לליגה בהקדם האפשרי.',
-    '💡 Send /cancel at any time to abort the registration.':
-      '💡\u200F שלח \u2066/cancel\u2069 בכל רגע כדי לבטל את הרישום.',
+    '💡 Send /cancel at any time to abort.':
+      '💡\u200F שלח \u2066/cancel\u2069 בכל רגע כדי לבטל.',
     'Operation cancelled.': 'הפעולה בוטלה.',
   },
 };


### PR DESCRIPTION
## Summary

Switches the admin league commands to a more natural vocabulary:

- `/register_league` → **`/follow_league`**
- `/unregister_league` → **`/unfollow_league`**
- `/leaderboard` unchanged

User-facing strings now read *'Now following league …'*, *'Unfollowed league …'*, *'You are not following any league …'*, etc. Menu entries are also relabelled (➕ Follow League / ➖ Unfollow League). Hebrew translations updated to use *מעקב* / *הפסקת מעקב*.

## Internal renames

- Files: `registerLeagueHandler``.{js,test.js}` → `followLeagueHandler``.{js,test.js}`; same for unregister→unfollow.
- Constants: `COMMAND_REGISTER_LEAGUE` → `COMMAND_FOLLOW_LEAGUE` etc.
- Callback type: `LEAGUE_UNREGISTER` → `LEAGUE_UNFOLLOW` (both constant name and wire value).
- Pending-reply registry id: `register_league` → `follow_league`.
- Handler function, comments and log messages updated.

## Preserved (no data migration)

- Azure Table name `UserLeagues`
- Field name `registeredAt`

## Tests & lint

- `npm test` → **504 passing** (all suites green)
- `npm run lint` → clean

## Docs

- `AGENTS.md` — *League Registry* section rewritten with follow/unfollow wording; admin command list updated.
- `readme.md` — feature bullets renamed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>