### PR TITLE
refactor: read league data from league-standings.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,7 +286,7 @@ The table is **extensible** — new attributes can be added at any time without 
 
 ## League Registry
 
-`src/leagueRegistryService.js` tracks league follows in an Azure Table Storage table (`UserLeagues`). Data is produced by the sibling repo `f1-fantasy-api-data`, which writes league blobs to Azure Blob Storage at `leagues/{leagueCode}/f1-fantasy-api-data.json` in the same container (`AZURE_STORAGE_CONTAINER_NAME`) used by the bot.
+`src/leagueRegistryService.js` tracks league follows in an Azure Table Storage table (`UserLeagues`). Data is produced by the sibling repo `f1-fantasy-api-data`, which writes league blobs to Azure Blob Storage at `leagues/{leagueCode}/league-standings.json` in the same container (`AZURE_STORAGE_CONTAINER_NAME`) used by the bot.
 
 ### How It Works
 

--- a/src/azureStorageService.js
+++ b/src/azureStorageService.js
@@ -374,7 +374,7 @@ async function deletePendingTeamAssignment(chatId, uniqueKey) {
 /**
  * Get the league leaderboard data for a given league code from Azure Blob Storage.
  * Blob path mirrors the writer in the sibling f1-fantasy-api-data repo:
- *   leagues/{leagueCode}/f1-fantasy-api-data.json
+ *   leagues/{leagueCode}/league-standings.json
  * @param {string} leagueCode
  * @returns {Promise<Object|null>} Parsed league data, or null if the blob does not exist.
  * @throws {Error} If the blob exists but can not be retrieved/parsed.
@@ -385,7 +385,7 @@ async function getLeagueData(leagueCode) {
       initializeAzureStorage();
     }
 
-    const blobName = `leagues/${leagueCode}/f1-fantasy-api-data.json`;
+    const blobName = `leagues/${leagueCode}/league-standings.json`;
     const blockBlobClient = containerClient.getBlockBlobClient(blobName);
 
     const exists = await blockBlobClient.exists();


### PR DESCRIPTION
## Summary

Companion to [f1-fantasy-api-data#6](https://github.com/F1-fantazy-bot/f1-fantasy-api-data/pull/6). The producer repo renamed its main league blob from `f1-fantasy-api-data.json` to `league-standings.json` (team composition now lives in a separate `teams-data.json` blob). This PR updates the bot to read the new path.

## Changes

- `src/azureStorageService.js` — `getLeagueData()` now reads `leagues/<code>/league-standings.json`.
- `AGENTS.md` — updated path reference.

## Verification

- `npm test` for `src/azureStorageService.test.js` — all 13 tests pass.
- No behavioral changes to the returned shape; only the blob path changed.

## Coordination

Merge ordering: deploy the producer (`f1-fantasy-api-data` PR #6) first so the new blob exists, then merge this PR. During the window, the bot's `getLeagueData` will return `null` for any league until the new blob is written — same behavior as a missing blob today.