### PR TITLE
feat: add /select_team_from_league + refresh league teams on startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ This repository contains a Telegram bot that helps manage F1 Fantasy teams. The 
 - `/menu`, `/help`, `/lang`
 - `/report_bug` _(reply-based — uses pending reply manager)_
 
-**Admin-only:** `/trigger_scraping`, `/get_botfather_commands`, `/billing_stats`, `/version`, `/list_users`, `/send_message_to_user`, `/broadcast`, `/set_nickname`, `/live_score`, `/follow_league`, `/unfollow_league`, `/leaderboard`
+**Admin-only:** `/trigger_scraping`, `/get_botfather_commands`, `/billing_stats`, `/version`, `/list_users`, `/send_message_to_user`, `/broadcast`, `/set_nickname`, `/live_score`, `/follow_league`, `/unfollow_league`, `/leaderboard`, `/select_team_from_league`
 
 ---
 
@@ -286,7 +286,10 @@ The table is **extensible** — new attributes can be added at any time without 
 
 ## League Registry
 
-`src/leagueRegistryService.js` tracks league follows in an Azure Table Storage table (`UserLeagues`). Data is produced by the sibling repo `f1-fantasy-api-data`, which writes league blobs to Azure Blob Storage at `leagues/{leagueCode}/league-standings.json` in the same container (`AZURE_STORAGE_CONTAINER_NAME`) used by the bot.
+`src/leagueRegistryService.js` tracks league follows in an Azure Table Storage table (`UserLeagues`). Data is produced by the sibling repo `f1-fantasy-api-data`, which writes two blobs per league to Azure Blob Storage in the same container (`AZURE_STORAGE_CONTAINER_NAME`) used by the bot:
+
+- `leagues/{leagueCode}/league-standings.json` — header + `teams: [{ teamName, userName, position, totalScore, raceScores, chipsUsed }]`. Used by `/leaderboard`.
+- `leagues/{leagueCode}/teams-data.json` — header + `teams: [{ teamName, userName, position, budget, transfersRemaining, drivers, constructors }]` where each roster entry is `{ id, name, price, isCaptain, isMegaCaptain, isFinal }`. Used by `/select_team_from_league` to load a team from the league directly into the bot's cache.
 
 ### How It Works
 
@@ -298,27 +301,29 @@ The table is **extensible** — new attributes can be added at any time without 
    - 1 league → auto-fetch blob and render leaderboard.
    - 2+ leagues → inline keyboard (`LEAGUE_CALLBACK_TYPE`) showing each league by name; on selection, callback handler fetches the blob and renders.
 5. `/unfollow_league` shows an inline keyboard (`LEAGUE_UNFOLLOW_CALLBACK_TYPE`) with all followed leagues; selection calls `removeUserLeague(chatId, leagueCode)`.
+6. `/select_team_from_league` (admin-only) lets the admin pick a league (auto-picked when only one) and then a team within it. The selected team replaces **all** previously cached teams for the user — both in-memory (`currentTeamCache`, `bestTeamsCache`, `selectedChipCache`, `selectedBestTeamByTeam`) and in blob storage (`deleteAllUserTeams`). The loaded team is keyed by `teamId = ${leagueCode}_${sanitized(teamName)}` and becomes the active `selectedTeam`. League `teams-data.json` is fetched via `getLeagueTeamsData(leagueCode)` and cached in memory per leagueCode (`leagueTeamsDataCache`). Callback types: `LEAGUE_TEAM_SELECT_CALLBACK_TYPE` (league picker) and `LEAGUE_TEAM_PICK_CALLBACK_TYPE` (team picker; payload `...:<leagueCode>:<position>` so the actual team is resolved server-side from the cached blob to keep callback data short).
 
 The leaderboard is rendered compactly (position, team name, total score) with a header showing league name, member count, and fetch time. Teams from the blob are already sorted by `position`.
 
 ### Table Schema
 
-| Field          | Type     | Description                                          |
-| -------------- | -------- | ---------------------------------------------------- |
-| `partitionKey` | `string` | The `chatId` (stringified)                           |
-| `rowKey`       | `string` | The league code (e.g., `C8EFGOXCB04`)                |
-| `leagueName`   | `string` | League display name captured when the user followed  |
-| `registeredAt` | `string` | ISO timestamp — set when the league was followed     |
+| Field          | Type     | Description                                         |
+| -------------- | -------- | --------------------------------------------------- |
+| `partitionKey` | `string` | The `chatId` (stringified)                          |
+| `rowKey`       | `string` | The league code (e.g., `C8EFGOXCB04`)               |
+| `leagueName`   | `string` | League display name captured when the user followed |
+| `registeredAt` | `string` | ISO timestamp — set when the league was followed    |
 
 ### API Reference
 
-| Method             | Signature                                                          | Purpose                                                                                            |
-| ------------------ | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
-| `addUserLeague`    | `addUserLeague(chatId, leagueCode, leagueName) → Promise`          | Upsert a league follow (Merge mode).                                                               |
-| `removeUserLeague` | `removeUserLeague(chatId, leagueCode) → Promise`                   | Delete a league follow. 404 is ignored (idempotent).                                               |
-| `listUserLeagues`  | `listUserLeagues(chatId) → Promise<Array<{leagueCode, leagueName, registeredAt}>>` | Partition-scoped query returning all leagues a user follows.                       |
-| `getUserLeague`    | `getUserLeague(chatId, leagueCode) → Promise<Object\|null>`        | Point lookup for a specific league follow.                                                         |
-| `getLeagueData`    | `getLeagueData(leagueCode) → Promise<Object\|null>`                | (in `azureStorageService.js`) Fetches the league blob. Returns `null` when the blob does not exist. |
+| Method             | Signature                                                                          | Purpose                                                                                             |
+| ------------------ | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `addUserLeague`    | `addUserLeague(chatId, leagueCode, leagueName) → Promise`                          | Upsert a league follow (Merge mode).                                                                |
+| `removeUserLeague` | `removeUserLeague(chatId, leagueCode) → Promise`                                   | Delete a league follow. 404 is ignored (idempotent).                                                |
+| `listUserLeagues`  | `listUserLeagues(chatId) → Promise<Array<{leagueCode, leagueName, registeredAt}>>` | Partition-scoped query returning all leagues a user follows.                                        |
+| `getUserLeague`    | `getUserLeague(chatId, leagueCode) → Promise<Object\|null>`                        | Point lookup for a specific league follow.                                                          |
+| `getLeagueData`       | `getLeagueData(leagueCode) → Promise<Object\|null>`                                | (in `azureStorageService.js`) Fetches `leagues/{code}/league-standings.json`. Returns `null` when the blob does not exist. |
+| `getLeagueTeamsData`  | `getLeagueTeamsData(leagueCode) → Promise<Object\|null>`                           | (in `azureStorageService.js`) Fetches `leagues/{code}/teams-data.json` (per-team budget, transfers, roster). Returns `null` when the blob does not exist. |
 
 ---
 
@@ -353,7 +358,14 @@ The nickname system allows admins to assign custom display names to users that r
 
 ## Multi-Team System
 
-The bot supports **multiple teams per user** (e.g., T1, T2, T3). Each team has its own cached data, chip selection, and best-teams calculation. A `selectedTeam` preference determines which team context commands operate on.
+The bot supports **multiple teams per user**. Teams are keyed by a `teamId` string inside each chat's nested caches. Two `teamId` formats are in use:
+
+- **Screenshot flow:** `T1`, `T2`, `T3` — extracted from the colored-square icon in the team photo by `EXTRACT_JSON_FROM_CURRENT_TEAM_PHOTO_SYSTEM_PROMPT`.
+- **League flow:** `{leagueCode}_{sanitizedTeamName}` — created by `/select_team_from_league`. `sanitizedTeamName` strips unsafe characters (only word chars and `-` survive) and is truncated to 40 chars to keep the blob path (`user-teams/{chatId}_{teamId}.json`) and callback data short.
+
+Picking a team from a league always **replaces all** existing cached teams for that user (both screenshot and league teams, in memory and in blob storage). The screenshot-upload flow is unchanged; the two sources cannot coexist for the same user.
+
+Each team has its own cached data, chip selection, and best-teams calculation. A `selectedTeam` preference determines which team context commands operate on.
 
 ### Cache Structure
 
@@ -428,7 +440,7 @@ Blob naming includes the team ID:
 | Write      | `user-teams/{chatId}_{teamId}.json`        | `saveUserTeam(bot, chatId, teamId, teamData)`                                  |
 | Delete one | `user-teams/{chatId}_{teamId}.json`        | `deleteUserTeam(bot, chatId, teamId)`                                          |
 | Delete all | `user-teams/{chatId}_*.json`               | `deleteAllUserTeams(bot, chatId)` — deletes all team blobs for a user.         |
-| List all   | Parses `{chatId}_{teamId}` from blob names | `listAllUserTeamData()` — returns nested `{ chatId: { T1: data, T2: data } }`. |
+| List all   | Parses `{chatId}_{teamId}` from blob names (splits on the **first** `_` so teamIds containing underscores — e.g. league teams — round-trip correctly; `chatId` is always numeric) | `listAllUserTeamData()` — returns nested `{ chatId: { teamId: data } }`. |
 
 ### Image Extraction — Team Identifier
 

--- a/src/azureStorageService.js
+++ b/src/azureStorageService.js
@@ -267,8 +267,13 @@ async function listAllUserTeamData() {
     // List all blobs in the user-teams directory
     for await (const blob of containerClient.listBlobsFlat({ prefix })) {
       // Extract chatId and teamId from the blob name (format: user-teams/{chatId}_{teamId}.json)
+      // chatId is always numeric, so the first `_` is the separator. teamId itself
+      // can contain underscores (e.g. `{leagueCode}_{teamName}` for league-loaded teams).
       const fileName = blob.name.substring(prefix.length).replace('.json', '');
-      const separatorIdx = fileName.lastIndexOf('_');
+      const separatorIdx = fileName.indexOf('_');
+      if (separatorIdx === -1) {
+        continue;
+      }
       const chatId = fileName.substring(0, separatorIdx);
       const teamId = fileName.substring(separatorIdx + 1);
 
@@ -406,6 +411,41 @@ async function getLeagueData(leagueCode) {
   }
 }
 
+/**
+ * Get the teams-data (per-team roster, budget, transfers) for a given league code
+ * from Azure Blob Storage. Blob path mirrors the writer in the sibling
+ * f1-fantasy-api-data repo: leagues/{leagueCode}/teams-data.json
+ * @param {string} leagueCode
+ * @returns {Promise<Object|null>} Parsed teams-data, or null if the blob does not exist.
+ * @throws {Error} If the blob exists but cannot be retrieved/parsed.
+ */
+async function getLeagueTeamsData(leagueCode) {
+  try {
+    if (!containerClient) {
+      initializeAzureStorage();
+    }
+
+    const blobName = `leagues/${leagueCode}/teams-data.json`;
+    const blockBlobClient = containerClient.getBlockBlobClient(blobName);
+
+    const exists = await blockBlobClient.exists();
+    if (!exists) {
+      return null;
+    }
+
+    const downloadResponse = await blockBlobClient.download();
+    const jsonString = await streamToString(
+      downloadResponse.readableStreamBody,
+    );
+
+    return JSON.parse(jsonString);
+  } catch (error) {
+    throw new Error(
+      `Failed to get league teams data for ${leagueCode}: ${error.message}`,
+    );
+  }
+}
+
 module.exports = {
   getFantasyData,
   getUserTeam,
@@ -419,4 +459,5 @@ module.exports = {
   getPendingTeamAssignment,
   deletePendingTeamAssignment,
   getLeagueData,
+  getLeagueTeamsData,
 };

--- a/src/azureStorageService.test.js
+++ b/src/azureStorageService.test.js
@@ -314,4 +314,77 @@ describe('azureStorageService', () => {
       ).rejects.toThrow('Failed to get league data for ABC: boom');
     });
   });
+
+  describe('getLeagueTeamsData', () => {
+    it('downloads and parses the teams-data blob when it exists', async () => {
+      const mockData = {
+        leagueName: 'Amba',
+        leagueCode: 'ABC',
+        teams: [{ teamName: 'Racers', position: 1 }],
+      };
+
+      mockExists.mockResolvedValueOnce(true);
+      mockDownload.mockResolvedValueOnce({
+        readableStreamBody: createMockStream(mockData),
+      });
+
+      const result = await azureStorageService.getLeagueTeamsData('ABC');
+
+      expect(result).toEqual(mockData);
+    });
+
+    it('returns null when the teams-data blob does not exist', async () => {
+      mockExists.mockResolvedValueOnce(false);
+
+      const result = await azureStorageService.getLeagueTeamsData('MISSING');
+
+      expect(result).toBeNull();
+      expect(mockDownload).not.toHaveBeenCalled();
+    });
+
+    it('wraps real errors', async () => {
+      mockExists.mockRejectedValueOnce(new Error('boom'));
+
+      await expect(
+        azureStorageService.getLeagueTeamsData('ABC'),
+      ).rejects.toThrow('Failed to get league teams data for ABC: boom');
+    });
+  });
+
+  describe('listAllUserTeamData parser (underscore-safe)', () => {
+    it('splits on the first underscore so teamIds may contain underscores', async () => {
+      const mockBlobs = [
+        { name: 'user-teams/123_ABC_Team-One.json' },
+        { name: 'user-teams/123_T1.json' },
+      ];
+
+      const mockTeam1 = { drivers: ['VER'] };
+      const mockTeam2 = { drivers: ['HAM'] };
+
+      mockListBlobsFlat.mockReturnValueOnce({
+        [Symbol.asyncIterator]: async function* () {
+          yield* mockBlobs;
+        },
+      });
+
+      mockExists.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
+
+      mockDownload
+        .mockResolvedValueOnce({
+          readableStreamBody: createMockStream(mockTeam1),
+        })
+        .mockResolvedValueOnce({
+          readableStreamBody: createMockStream(mockTeam2),
+        });
+
+      const result = await azureStorageService.listAllUserTeamData();
+
+      expect(result).toEqual({
+        123: {
+          'ABC_Team-One': mockTeam1,
+          T1: mockTeam2,
+        },
+      });
+    });
+  });
 });

--- a/src/cache.js
+++ b/src/cache.js
@@ -39,6 +39,10 @@ exports.weatherForecastCache = {};
 
 // Shared in-memory cache for remaining upcoming Grand Prix count
 exports.remainingRaceCountCache = {};
+// In-memory cache for league teams-data.json blobs by leagueCode
+// Structure: leagueTeamsDataCache[leagueCode] = { fetchedAt, leagueName, leagueCode, teams: [...] }
+exports.leagueTeamsDataCache = {};
+
 const DEFAULT_BEST_TEAM_BUDGET_CHANGE_POINTS_PER_MILLION = 0;
 
 exports.DEFAULT_BEST_TEAM_BUDGET_CHANGE_POINTS_PER_MILLION =

--- a/src/cacheInitializer.js
+++ b/src/cacheInitializer.js
@@ -25,9 +25,15 @@ const {
   getFantasyData,
   listAllUserTeamData,
   getNextRaceInfoData,
+  getLeagueTeamsData,
+  saveUserTeam,
 } = require('./azureStorageService');
 const { listAllUsers } = require('./userRegistryService');
 const { fetchRemainingRaceCount } = require('./raceScheduleService');
+const {
+  mapLeagueTeamToBotTeam,
+  sanitizeTeamName,
+} = require('./commandsHandler/selectTeamFromLeagueHandler');
 
 /**
  * Initialize all application caches with data from Azure Storage
@@ -71,6 +77,10 @@ async function initializeCaches(bot) {
     bot,
     `Loaded ${Object.keys(userTeams).length} user teams from storage`
   );
+
+  // Refresh any league-sourced teams from the latest league teams-data blob so
+  // rosters/budgets/transfers stay in sync between restarts.
+  await refreshLeagueSourcedTeams(bot);
 
   // Load all user data into userCache (from UserRegistry table)
   const users = await listAllUsers();
@@ -196,7 +206,83 @@ Constructors not found in mapping: ${notFounds.constructors.join(', ')}
   );
 }
 
+/**
+ * For any cached team whose id is in league format ("{leagueCode}_{slug}"),
+ * re-fetch the league's teams-data.json and replace the cached data (and the
+ * persisted blob) with the latest roster/budget/transfers for that team.
+ *
+ * Best-effort: errors for individual leagues or teams are logged but do not
+ * abort cache initialization.
+ */
+async function refreshLeagueSourcedTeams(bot) {
+  const leagueTeamsByCode = {};
+  let refreshed = 0;
+  let missing = 0;
+  let failed = 0;
+
+  for (const [chatId, teamsById] of Object.entries(currentTeamCache)) {
+    if (!teamsById || typeof teamsById !== 'object') {continue;}
+
+    for (const teamId of Object.keys(teamsById)) {
+      const underscoreIdx = teamId.indexOf('_');
+      if (underscoreIdx <= 0) {continue;}
+
+      const leagueCode = teamId.slice(0, underscoreIdx);
+      const sanitizedSlug = teamId.slice(underscoreIdx + 1);
+
+      try {
+        if (!(leagueCode in leagueTeamsByCode)) {
+          leagueTeamsByCode[leagueCode] = await getLeagueTeamsData(leagueCode);
+        }
+        const data = leagueTeamsByCode[leagueCode];
+
+        if (!data || !Array.isArray(data.teams)) {
+          missing += 1;
+          continue;
+        }
+
+        const match = data.teams.find(
+          (team) => sanitizeTeamName(team.teamName) === sanitizedSlug,
+        );
+
+        if (!match) {
+          missing += 1;
+          continue;
+        }
+
+        const refreshedTeam = mapLeagueTeamToBotTeam(match);
+        currentTeamCache[chatId][teamId] = refreshedTeam;
+
+        try {
+          await saveUserTeam(bot, chatId, teamId, refreshedTeam);
+        } catch (saveErr) {
+          console.error(
+            `Failed to persist refreshed league team ${teamId} for ${chatId}:`,
+            saveErr,
+          );
+        }
+
+        refreshed += 1;
+      } catch (err) {
+        failed += 1;
+        console.error(
+          `Failed to refresh league-sourced team ${teamId} for ${chatId}:`,
+          err,
+        );
+      }
+    }
+  }
+
+  if (refreshed > 0 || missing > 0 || failed > 0) {
+    await sendLogMessage(
+      bot,
+      `League-sourced teams refresh: ${refreshed} refreshed, ${missing} missing in league, ${failed} failed`,
+    );
+  }
+}
+
 module.exports = {
   initializeCaches,
   loadSimulationData,
+  refreshLeagueSourcedTeams,
 };

--- a/src/cacheInitializer.test.js
+++ b/src/cacheInitializer.test.js
@@ -13,9 +13,15 @@ const {
   getFantasyData,
   listAllUserTeamData,
   getNextRaceInfoData,
+  getLeagueTeamsData,
+  saveUserTeam,
 } = require('./azureStorageService');
 const { listAllUsers } = require('./userRegistryService');
-const { initializeCaches, loadSimulationData } = require('./cacheInitializer');
+const {
+  initializeCaches,
+  loadSimulationData,
+  refreshLeagueSourcedTeams,
+} = require('./cacheInitializer');
 const { fetchRemainingRaceCount } = require('./raceScheduleService');
 
 // Mock dependencies
@@ -32,6 +38,8 @@ jest.mock('./azureStorageService', () => ({
   getFantasyData: jest.fn(),
   listAllUserTeamData: jest.fn(),
   getNextRaceInfoData: jest.fn(),
+  getLeagueTeamsData: jest.fn(),
+  saveUserTeam: jest.fn(),
 }));
 
 jest.mock('./userRegistryService', () => ({
@@ -291,5 +299,98 @@ describe('cacheInitializer', () => {
     await expect(loadSimulationData(mockBot)).rejects.toThrow(
       'Fantasy data validation failed'
     );
+  });
+
+  describe('refreshLeagueSourcedTeams', () => {
+    beforeEach(() => {
+      getLeagueTeamsData.mockReset();
+      saveUserTeam.mockReset().mockResolvedValue(undefined);
+    });
+
+    it('refreshes league-sourced teams (ids containing "_") from the latest league blob', async () => {
+      currentTeamCache[111] = {
+        T1: { drivers: ['OLD'], constructors: ['OLD'] },
+        'ABC_My-Team': { drivers: ['STALE'], constructors: ['STALE'] },
+      };
+      currentTeamCache[222] = {
+        ABC_Other: { drivers: ['STALE'], constructors: ['STALE'] },
+      };
+
+      getLeagueTeamsData.mockResolvedValue({
+        leagueName: 'League ABC',
+        teams: [
+          {
+            teamName: 'My Team',
+            position: 1,
+            budget: 100,
+            transfersRemaining: 2,
+            drivers: [
+              { name: 'M. Verstappen', price: 30, isCaptain: true },
+              { name: 'L. Norris', price: 25 },
+            ],
+            constructors: [{ name: 'Red Bull Racing', price: 20 }],
+          },
+          {
+            teamName: 'Other',
+            position: 2,
+            budget: 90,
+            transfersRemaining: 1,
+            drivers: [{ name: 'O. Bearman', price: 10, isCaptain: true }],
+            constructors: [{ name: 'Racing Bulls', price: 5 }],
+          },
+        ],
+      });
+
+      await refreshLeagueSourcedTeams(mockBot);
+
+      // Non-league id is untouched
+      expect(currentTeamCache[111].T1).toEqual({
+        drivers: ['OLD'],
+        constructors: ['OLD'],
+      });
+      // League-sourced teams are rebuilt with mapped codes
+      expect(currentTeamCache[111]['ABC_My-Team']).toEqual(
+        expect.objectContaining({
+          drivers: ['VER', 'NOR'],
+          constructors: ['RED'],
+          boost: 'VER',
+          freeTransfers: 2,
+        }),
+      );
+      expect(currentTeamCache[222].ABC_Other).toEqual(
+        expect.objectContaining({
+          drivers: ['BEA'],
+          constructors: ['VRB'],
+          boost: 'BEA',
+        }),
+      );
+      // League blob fetched once per league (cached within the function)
+      expect(getLeagueTeamsData).toHaveBeenCalledTimes(1);
+      expect(getLeagueTeamsData).toHaveBeenCalledWith('ABC');
+      // Persisted back to storage
+      expect(saveUserTeam).toHaveBeenCalledTimes(2);
+    });
+
+    it('is a no-op for users with only T1/T2/T3 style ids', async () => {
+      currentTeamCache[111] = { T1: { drivers: ['OLD'] } };
+
+      await refreshLeagueSourcedTeams(mockBot);
+
+      expect(getLeagueTeamsData).not.toHaveBeenCalled();
+      expect(saveUserTeam).not.toHaveBeenCalled();
+      expect(currentTeamCache[111]).toEqual({ T1: { drivers: ['OLD'] } });
+    });
+
+    it('leaves cached data untouched when the team is missing in the league blob', async () => {
+      currentTeamCache[111] = {
+        ABC_Gone: { drivers: ['STALE'] },
+      };
+      getLeagueTeamsData.mockResolvedValue({ teams: [] });
+
+      await refreshLeagueSourcedTeams(mockBot);
+
+      expect(currentTeamCache[111].ABC_Gone).toEqual({ drivers: ['STALE'] });
+      expect(saveUserTeam).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/callbackQueryHandler.js
+++ b/src/callbackQueryHandler.js
@@ -21,6 +21,8 @@ const {
   DEADLINE_CALLBACK_TYPE,
   LEAGUE_CALLBACK_TYPE,
   LEAGUE_UNFOLLOW_CALLBACK_TYPE,
+  LEAGUE_TEAM_SELECT_CALLBACK_TYPE,
+  LEAGUE_TEAM_PICK_CALLBACK_TYPE,
 } = require('./constants');
 
 const {
@@ -40,6 +42,10 @@ const {
   sendLeaderboard,
 } = require('./commandsHandler/leaderboardHandler');
 const { removeUserLeague } = require('./leagueRegistryService');
+const {
+  promptTeamPick,
+  applyLeagueTeamSelection,
+} = require('./commandsHandler/selectTeamFromLeagueHandler');
 
 exports.handleCallbackQuery = async function (bot, query) {
   const callbackType = query.data.split(':')[0];
@@ -63,6 +69,10 @@ exports.handleCallbackQuery = async function (bot, query) {
       return await handleLeagueCallback(bot, query);
     case LEAGUE_UNFOLLOW_CALLBACK_TYPE:
       return await handleLeagueUnfollowCallback(bot, query);
+    case LEAGUE_TEAM_SELECT_CALLBACK_TYPE:
+      return await handleLeagueTeamSelectCallback(bot, query);
+    case LEAGUE_TEAM_PICK_CALLBACK_TYPE:
+      return await handleLeagueTeamPickCallback(bot, query);
     default:
       await sendLogMessage(bot, `Unknown callback type: ${callbackType}`);
   }
@@ -355,5 +365,21 @@ async function handleLeagueUnfollowCallback(bot, query) {
     );
   }
 
+  await bot.answerCallbackQuery(query.id);
+}
+
+async function handleLeagueTeamSelectCallback(bot, query) {
+  const chatId = query.message.chat.id;
+  const leagueCode = query.data.split(':')[1];
+
+  await promptTeamPick(bot, chatId, leagueCode);
+  await bot.answerCallbackQuery(query.id);
+}
+
+async function handleLeagueTeamPickCallback(bot, query) {
+  const chatId = query.message.chat.id;
+  const [, leagueCode, position] = query.data.split(':');
+
+  await applyLeagueTeamSelection(bot, chatId, leagueCode, position);
   await bot.answerCallbackQuery(query.id);
 }

--- a/src/commandsHandler/commandHandlers.js
+++ b/src/commandsHandler/commandHandlers.js
@@ -37,6 +37,7 @@ const {
   COMMAND_FOLLOW_LEAGUE,
   COMMAND_UNFOLLOW_LEAGUE,
   COMMAND_LEADERBOARD,
+  COMMAND_SELECT_TEAM_FROM_LEAGUE,
 } = require('../constants');
 
 const { handleBestTeamsMessage } = require('./bestTeamsHandler');
@@ -84,6 +85,9 @@ const {
   handleUnfollowLeagueCommand,
 } = require('./unfollowLeagueHandler');
 const { handleLeaderboardCommand } = require('./leaderboardHandler');
+const {
+  handleSelectTeamFromLeagueCommand,
+} = require('./selectTeamFromLeagueHandler');
 
 // Mapping of command constants to their handler functions
 const COMMAND_HANDLERS = {
@@ -125,6 +129,7 @@ const COMMAND_HANDLERS = {
   [COMMAND_FOLLOW_LEAGUE]: handleFollowLeagueCommand,
   [COMMAND_UNFOLLOW_LEAGUE]: handleUnfollowLeagueCommand,
   [COMMAND_LEADERBOARD]: handleLeaderboardCommand,
+  [COMMAND_SELECT_TEAM_FROM_LEAGUE]: handleSelectTeamFromLeagueCommand,
 };
 
 async function executeCommand(bot, msg, command) {

--- a/src/commandsHandler/index.js
+++ b/src/commandsHandler/index.js
@@ -47,6 +47,9 @@ const {
   handleUnfollowLeagueCommand,
 } = require('./unfollowLeagueHandler');
 const { handleLeaderboardCommand } = require('./leaderboardHandler');
+const {
+  handleSelectTeamFromLeagueCommand,
+} = require('./selectTeamFromLeagueHandler');
 
 module.exports = {
   handleBestTeamsMessage,
@@ -89,4 +92,5 @@ module.exports = {
   handleFollowLeagueCommand,
   handleUnfollowLeagueCommand,
   handleLeaderboardCommand,
+  handleSelectTeamFromLeagueCommand,
 };

--- a/src/commandsHandler/selectTeamFromLeagueHandler.js
+++ b/src/commandsHandler/selectTeamFromLeagueHandler.js
@@ -1,0 +1,354 @@
+const { t } = require('../i18n');
+const { isAdminMessage, sendMessageToUser } = require('../utils/utils');
+const { listUserLeagues } = require('../leagueRegistryService');
+const azureStorageService = require('../azureStorageService');
+const { updateUserAttributes } = require('../userRegistryService');
+const {
+  currentTeamCache,
+  bestTeamsCache,
+  selectedChipCache,
+  userCache,
+  leagueTeamsDataCache,
+  clearAllSelectedBestTeams,
+  serializeSelectedBestTeamByTeam,
+  getPrintableCache,
+} = require('../cache');
+const {
+  COMMAND_FOLLOW_LEAGUE,
+  CURRENT_TEAM_PHOTO_TYPE,
+  LEAGUE_TEAM_SELECT_CALLBACK_TYPE,
+  LEAGUE_TEAM_PICK_CALLBACK_TYPE,
+  NAME_TO_CODE_MAPPING,
+} = require('../constants');
+
+function mapNameToCode(name) {
+  if (name === null || name === undefined) {
+    return name;
+  }
+
+  const key = String(name).toLowerCase().trim();
+
+  return NAME_TO_CODE_MAPPING[key] || name;
+}
+
+/**
+ * Sanitize a team name so it can be safely embedded into blob paths.
+ * Keeps the result short and readable.
+ */
+function sanitizeTeamName(name) {
+  const base = String(name || 'team')
+    .normalize('NFKD')
+    .replace(/[^\w-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+
+  const trimmed = base.length > 0 ? base : 'team';
+
+  return trimmed.slice(0, 40);
+}
+
+function buildTeamId(leagueCode, teamName) {
+  return `${leagueCode}_${sanitizeTeamName(teamName)}`;
+}
+
+/**
+ * Map one league team entry (from teams-data.json) to the bot's team cache shape.
+ */
+function mapLeagueTeamToBotTeam(leagueTeam) {
+  const drivers = Array.isArray(leagueTeam.drivers) ? leagueTeam.drivers : [];
+  const constructors = Array.isArray(leagueTeam.constructors)
+    ? leagueTeam.constructors
+    : [];
+
+  const sumPrices = (items) =>
+    items.reduce((acc, item) => acc + (Number(item.price) || 0), 0);
+
+  // Pick the "boost" driver: prefer isCaptain, then isMegaCaptain, else first driver.
+  const captain =
+    drivers.find((d) => d.isCaptain) ||
+    drivers.find((d) => d.isMegaCaptain) ||
+    drivers[0];
+  const boost = captain ? mapNameToCode(captain.name) : null;
+
+  const budget = Number(leagueTeam.budget);
+  const costCapRemaining = Number.isFinite(budget)
+    ? Math.round((budget - sumPrices(drivers) - sumPrices(constructors)) * 100) /
+      100
+    : 0;
+
+  const transfersRemainingRaw = Number(leagueTeam.transfersRemaining);
+  const freeTransfers = Number.isFinite(transfersRemainingRaw)
+    ? Math.max(0, transfersRemainingRaw)
+    : 0;
+
+  return {
+    drivers: drivers.map((d) => mapNameToCode(d.name)),
+    constructors: constructors.map((c) => mapNameToCode(c.name)),
+    boost,
+    freeTransfers,
+    costCapRemaining,
+  };
+}
+
+async function loadLeagueTeamsData(leagueCode) {
+  if (leagueTeamsDataCache[leagueCode]) {
+    return leagueTeamsDataCache[leagueCode];
+  }
+
+  const data = await azureStorageService.getLeagueTeamsData(leagueCode);
+  if (data) {
+    leagueTeamsDataCache[leagueCode] = data;
+  }
+
+  return data;
+}
+
+function sortTeamsByPosition(teams) {
+  return [...teams].sort(
+    (a, b) => (a.position || 0) - (b.position || 0),
+  );
+}
+
+/**
+ * Send an inline keyboard so the admin can pick which team from the league to load.
+ * Exported for reuse from the league-choice callback.
+ */
+async function promptTeamPick(bot, chatId, leagueCode, replyToMessageId) {
+  let data;
+  try {
+    data = await loadLeagueTeamsData(leagueCode);
+  } catch (err) {
+    console.error('Error fetching league teams data:', err);
+    await bot.sendMessage(
+      chatId,
+      t('❌ Failed to load league teams data: {ERROR}', chatId, {
+        ERROR: err.message,
+      }),
+    );
+
+    return;
+  }
+
+  if (!data || !Array.isArray(data.teams) || data.teams.length === 0) {
+    await bot.sendMessage(
+      chatId,
+      t(
+        'No team roster is available yet for this league. Please try again later.',
+        chatId,
+      ),
+    );
+
+    return;
+  }
+
+  const sortedTeams = sortTeamsByPosition(data.teams);
+  const keyboard = sortedTeams.map((team) => {
+    const pos = team.position ?? '?';
+    const label = `${pos}. ${team.teamName || team.userName || '—'}`;
+
+    return [
+      {
+        text: label,
+        callback_data: `${LEAGUE_TEAM_PICK_CALLBACK_TYPE}:${leagueCode}:${team.position}`,
+      },
+    ];
+  });
+
+  const options = { reply_markup: { inline_keyboard: keyboard } };
+  if (replyToMessageId) {
+    options.reply_to_message_id = replyToMessageId;
+  }
+
+  await bot.sendMessage(
+    chatId,
+    t('Which team do you want to load?', chatId),
+    options,
+  );
+}
+
+/**
+ * Apply the user's league team selection:
+ * - Remove all existing cached teams (blob + in-memory) for the user
+ * - Load the selected league team as the sole active team
+ * - Update selectedTeam and persist preferences
+ */
+async function applyLeagueTeamSelection(bot, chatId, leagueCode, position) {
+  let data;
+  try {
+    data = await loadLeagueTeamsData(leagueCode);
+  } catch (err) {
+    console.error('Error fetching league teams data:', err);
+    await bot.sendMessage(
+      chatId,
+      t('❌ Failed to load league teams data: {ERROR}', chatId, {
+        ERROR: err.message,
+      }),
+    );
+
+    return;
+  }
+
+  if (!data || !Array.isArray(data.teams)) {
+    await bot.sendMessage(
+      chatId,
+      t(
+        'No team roster is available yet for this league. Please try again later.',
+        chatId,
+      ),
+    );
+
+    return;
+  }
+
+  const positionNum = Number(position);
+  const leagueTeam = data.teams.find((team) => team.position === positionNum);
+  if (!leagueTeam) {
+    await bot.sendMessage(
+      chatId,
+      t('❌ Could not find that team in the league anymore.', chatId),
+    );
+
+    return;
+  }
+
+  const teamId = buildTeamId(leagueCode, leagueTeam.teamName);
+  const teamData = mapLeagueTeamToBotTeam(leagueTeam);
+
+  // Drop every previously cached team (screenshot or prior league) so the league
+  // team becomes the single active team, matching the rule "work with one source
+  // at a time".
+  try {
+    await azureStorageService.deleteAllUserTeams(bot, chatId);
+  } catch (err) {
+    console.error('Error deleting existing user teams:', err);
+  }
+
+  delete currentTeamCache[chatId];
+  delete bestTeamsCache[chatId];
+  delete selectedChipCache[chatId];
+
+  currentTeamCache[chatId] = { [teamId]: teamData };
+
+  try {
+    await azureStorageService.saveUserTeam(bot, chatId, teamId, teamData);
+  } catch (err) {
+    console.error('Error saving league-loaded team:', err);
+    await bot.sendMessage(
+      chatId,
+      t('❌ Failed to save league team: {ERROR}', chatId, {
+        ERROR: err.message,
+      }),
+    );
+
+    return;
+  }
+
+  const key = String(chatId);
+  if (!userCache[key]) {
+    userCache[key] = {};
+  }
+  userCache[key].selectedTeam = teamId;
+  const selectedBestTeamByTeam = clearAllSelectedBestTeams(chatId);
+
+  await updateUserAttributes(chatId, {
+    selectedTeam: teamId,
+    selectedBestTeamByTeam: serializeSelectedBestTeamByTeam(
+      selectedBestTeamByTeam,
+    ),
+  });
+
+  const leagueLabel = data.leagueName || leagueCode;
+  const teamLabel = leagueTeam.teamName || leagueTeam.userName || teamId;
+
+  await bot.sendMessage(
+    chatId,
+    t(
+      '✅ Loaded team {TEAM} from league {LEAGUE}. Previous teams have been cleared.',
+      chatId,
+      { TEAM: teamLabel, LEAGUE: leagueLabel },
+    ),
+  );
+
+  await sendMessageToUser(
+    bot,
+    chatId,
+    getPrintableCache(chatId, CURRENT_TEAM_PHOTO_TYPE),
+    {
+      useMarkdown: true,
+      errorMessageToLog: 'Error sending loaded league team data to user',
+    },
+  );
+}
+
+async function handleSelectTeamFromLeagueCommand(bot, msg) {
+  const chatId = msg.chat.id;
+
+  if (!isAdminMessage(msg)) {
+    await bot.sendMessage(
+      chatId,
+      t('Sorry, only admins can use this command.', chatId),
+    );
+
+    return;
+  }
+
+  let leagues;
+  try {
+    leagues = await listUserLeagues(chatId);
+  } catch (err) {
+    console.error('Error listing user leagues:', err);
+    await bot.sendMessage(
+      chatId,
+      t('❌ Failed to load your leagues: {ERROR}', chatId, {
+        ERROR: err.message,
+      }),
+    );
+
+    return;
+  }
+
+  if (!leagues || leagues.length === 0) {
+    await bot.sendMessage(
+      chatId,
+      t(
+        'You are not following any league. Run {CMD} to follow one first.',
+        chatId,
+        { CMD: COMMAND_FOLLOW_LEAGUE },
+      ),
+    );
+
+    return;
+  }
+
+  if (leagues.length === 1) {
+    await promptTeamPick(bot, chatId, leagues[0].leagueCode, msg.message_id);
+
+    return;
+  }
+
+  const keyboard = leagues.map((league) => [
+    {
+      text: league.leagueName || league.leagueCode,
+      callback_data: `${LEAGUE_TEAM_SELECT_CALLBACK_TYPE}:${league.leagueCode}`,
+    },
+  ]);
+
+  await bot.sendMessage(
+    chatId,
+    t('Which league do you want to select a team from?', chatId),
+    {
+      reply_to_message_id: msg.message_id,
+      reply_markup: { inline_keyboard: keyboard },
+    },
+  );
+}
+
+module.exports = {
+  handleSelectTeamFromLeagueCommand,
+  promptTeamPick,
+  applyLeagueTeamSelection,
+  mapLeagueTeamToBotTeam,
+  mapNameToCode,
+  buildTeamId,
+  sanitizeTeamName,
+};

--- a/src/commandsHandler/selectTeamFromLeagueHandler.test.js
+++ b/src/commandsHandler/selectTeamFromLeagueHandler.test.js
@@ -1,0 +1,391 @@
+jest.mock('../i18n', () => ({
+  t: jest.fn((key, _chatId, vars) =>
+    vars
+      ? Object.entries(vars).reduce(
+          (acc, [k, v]) => acc.replace(`{${k}}`, v),
+          key,
+        )
+      : key,
+  ),
+}));
+
+jest.mock('../utils/utils', () => ({
+  isAdminMessage: jest.fn(),
+  sendMessageToUser: jest.fn().mockResolvedValue(),
+}));
+
+jest.mock('../leagueRegistryService', () => ({
+  listUserLeagues: jest.fn(),
+}));
+
+jest.mock('../azureStorageService', () => ({
+  getLeagueTeamsData: jest.fn(),
+  saveUserTeam: jest.fn().mockResolvedValue(),
+  deleteAllUserTeams: jest.fn().mockResolvedValue(),
+}));
+
+jest.mock('../userRegistryService', () => ({
+  updateUserAttributes: jest.fn().mockResolvedValue(),
+}));
+
+const {
+  handleSelectTeamFromLeagueCommand,
+  promptTeamPick,
+  applyLeagueTeamSelection,
+  mapLeagueTeamToBotTeam,
+  buildTeamId,
+  sanitizeTeamName,
+} = require('./selectTeamFromLeagueHandler');
+
+const { isAdminMessage } = require('../utils/utils');
+const { listUserLeagues } = require('../leagueRegistryService');
+const azureStorageService = require('../azureStorageService');
+const { updateUserAttributes } = require('../userRegistryService');
+const cache = require('../cache');
+
+describe('selectTeamFromLeagueHandler', () => {
+  let botMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    botMock = { sendMessage: jest.fn().mockResolvedValue() };
+
+    // Reset caches
+    Object.keys(cache.currentTeamCache).forEach(
+      (k) => delete cache.currentTeamCache[k],
+    );
+    Object.keys(cache.bestTeamsCache).forEach(
+      (k) => delete cache.bestTeamsCache[k],
+    );
+    Object.keys(cache.selectedChipCache).forEach(
+      (k) => delete cache.selectedChipCache[k],
+    );
+    Object.keys(cache.userCache).forEach(
+      (k) => delete cache.userCache[k],
+    );
+    Object.keys(cache.leagueTeamsDataCache).forEach(
+      (k) => delete cache.leagueTeamsDataCache[k],
+    );
+  });
+
+  describe('sanitizeTeamName', () => {
+    it('replaces unsafe characters with dashes', () => {
+      expect(sanitizeTeamName('Fast & Furious / Team')).toBe(
+        'Fast-Furious-Team',
+      );
+    });
+
+    it('falls back to "team" for empty input', () => {
+      expect(sanitizeTeamName('')).toBe('team');
+      expect(sanitizeTeamName(null)).toBe('team');
+    });
+
+    it('truncates overly long names', () => {
+      const name = 'a'.repeat(200);
+      expect(sanitizeTeamName(name).length).toBe(40);
+    });
+  });
+
+  describe('buildTeamId', () => {
+    it('combines leagueCode and sanitized teamName', () => {
+      expect(buildTeamId('ABC', 'My Team!')).toBe('ABC_My-Team');
+    });
+  });
+
+  describe('mapLeagueTeamToBotTeam', () => {
+    const leagueTeam = {
+      teamName: 'Racers',
+      userName: 'Alice',
+      position: 1,
+      budget: 110.5,
+      transfersRemaining: 3,
+      drivers: [
+        { id: 1, name: 'VER', price: 30, isCaptain: true },
+        { id: 2, name: 'NOR', price: 28 },
+        { id: 3, name: 'HAM', price: 25 },
+        { id: 4, name: 'PIA', price: 15 },
+        { id: 5, name: 'RUS', price: 8 },
+      ],
+      constructors: [
+        { id: 10, name: 'Red Bull', price: 2 },
+        { id: 11, name: 'Ferrari', price: 1 },
+      ],
+    };
+
+    it('maps drivers/constructors to name arrays', () => {
+      const team = mapLeagueTeamToBotTeam(leagueTeam);
+      expect(team.drivers).toEqual(['VER', 'NOR', 'HAM', 'PIA', 'RUS']);
+      expect(team.constructors).toEqual(['Red Bull', 'FER']);
+    });
+
+    it('uses isCaptain for boost', () => {
+      expect(mapLeagueTeamToBotTeam(leagueTeam).boost).toBe('VER');
+    });
+
+    it('falls back to isMegaCaptain when no isCaptain', () => {
+      const team = mapLeagueTeamToBotTeam({
+        ...leagueTeam,
+        drivers: [
+          { name: 'A', price: 10 },
+          { name: 'B', price: 10, isMegaCaptain: true },
+        ],
+        constructors: [],
+        budget: 100,
+      });
+      expect(team.boost).toBe('B');
+    });
+
+    it('falls back to the first driver when no captain flags', () => {
+      const team = mapLeagueTeamToBotTeam({
+        ...leagueTeam,
+        drivers: [
+          { name: 'A', price: 10 },
+          { name: 'B', price: 10 },
+        ],
+        constructors: [],
+        budget: 100,
+      });
+      expect(team.boost).toBe('A');
+    });
+
+    it('computes costCapRemaining as budget minus sum of prices', () => {
+      // sum = 30+28+25+15+8 + 2+1 = 109.  109.5 budget => 1.5 remaining.
+      const team = mapLeagueTeamToBotTeam({ ...leagueTeam, budget: 110.5 });
+      expect(team.costCapRemaining).toBeCloseTo(1.5, 2);
+    });
+
+    it('maps transfersRemaining to freeTransfers (clamped to >= 0)', () => {
+      expect(mapLeagueTeamToBotTeam(leagueTeam).freeTransfers).toBe(3);
+      expect(
+        mapLeagueTeamToBotTeam({ ...leagueTeam, transfersRemaining: -2 })
+          .freeTransfers,
+      ).toBe(0);
+    });
+
+    it('maps league display names (e.g. "O. Bearman", "Racing Bulls") to codes', () => {
+      const team = mapLeagueTeamToBotTeam({
+        teamName: 'Roster',
+        budget: 100,
+        transfersRemaining: 1,
+        drivers: [
+          { name: 'O. Bearman', price: 10, isCaptain: true },
+          { name: 'M. Verstappen', price: 30 },
+          { name: 'Unknown Driver', price: 5 },
+        ],
+        constructors: [
+          { name: 'Racing Bulls', price: 3 },
+          { name: 'Red Bull Racing', price: 20 },
+        ],
+      });
+      expect(team.drivers).toEqual(['BEA', 'VER', 'Unknown Driver']);
+      expect(team.constructors).toEqual(['VRB', 'RED']);
+      expect(team.boost).toBe('BEA');
+    });
+  });
+
+  describe('handleSelectTeamFromLeagueCommand', () => {
+    it('rejects non-admins', async () => {
+      isAdminMessage.mockReturnValue(false);
+
+      await handleSelectTeamFromLeagueCommand(botMock, { chat: { id: 9 } });
+
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        9,
+        'Sorry, only admins can use this command.',
+      );
+      expect(listUserLeagues).not.toHaveBeenCalled();
+    });
+
+    it('tells the user to follow a league if they have none', async () => {
+      isAdminMessage.mockReturnValue(true);
+      listUserLeagues.mockResolvedValueOnce([]);
+
+      await handleSelectTeamFromLeagueCommand(botMock, { chat: { id: 1 } });
+
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        1,
+        'You are not following any league. Run /follow_league to follow one first.',
+      );
+    });
+
+    it('prompts team pick when user has exactly one league', async () => {
+      isAdminMessage.mockReturnValue(true);
+      listUserLeagues.mockResolvedValueOnce([
+        { leagueCode: 'ABC', leagueName: 'Amba' },
+      ]);
+      azureStorageService.getLeagueTeamsData.mockResolvedValueOnce({
+        teams: [
+          { teamName: 'A', userName: 'Alice', position: 1 },
+          { teamName: 'B', userName: 'Bob', position: 2 },
+        ],
+      });
+
+      await handleSelectTeamFromLeagueCommand(botMock, {
+        chat: { id: 1 },
+        message_id: 7,
+      });
+
+      expect(azureStorageService.getLeagueTeamsData).toHaveBeenCalledWith(
+        'ABC',
+      );
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        1,
+        'Which team do you want to load?',
+        expect.objectContaining({
+          reply_markup: {
+            inline_keyboard: [
+              [{ text: '1. A', callback_data: 'LEAGUE_TEAM_PICK:ABC:1' }],
+              [{ text: '2. B', callback_data: 'LEAGUE_TEAM_PICK:ABC:2' }],
+            ],
+          },
+          reply_to_message_id: 7,
+        }),
+      );
+    });
+
+    it('shows league picker when user has multiple leagues', async () => {
+      isAdminMessage.mockReturnValue(true);
+      listUserLeagues.mockResolvedValueOnce([
+        { leagueCode: 'ABC', leagueName: 'Amba' },
+        { leagueCode: 'XYZ', leagueName: 'Other' },
+      ]);
+
+      await handleSelectTeamFromLeagueCommand(botMock, {
+        chat: { id: 1 },
+        message_id: 3,
+      });
+
+      expect(azureStorageService.getLeagueTeamsData).not.toHaveBeenCalled();
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        1,
+        'Which league do you want to select a team from?',
+        expect.objectContaining({
+          reply_to_message_id: 3,
+          reply_markup: {
+            inline_keyboard: [
+              [{ text: 'Amba', callback_data: 'LEAGUE_TEAM_SELECT:ABC' }],
+              [{ text: 'Other', callback_data: 'LEAGUE_TEAM_SELECT:XYZ' }],
+            ],
+          },
+        }),
+      );
+    });
+
+    it('reports when teams-data blob is missing', async () => {
+      isAdminMessage.mockReturnValue(true);
+      listUserLeagues.mockResolvedValueOnce([
+        { leagueCode: 'ABC', leagueName: 'Amba' },
+      ]);
+      azureStorageService.getLeagueTeamsData.mockResolvedValueOnce(null);
+
+      await handleSelectTeamFromLeagueCommand(botMock, {
+        chat: { id: 1 },
+        message_id: 1,
+      });
+
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        1,
+        'No team roster is available yet for this league. Please try again later.',
+      );
+    });
+  });
+
+  describe('promptTeamPick — caching', () => {
+    it('caches teams-data per league and does not refetch on second call', async () => {
+      const data = {
+        leagueName: 'Amba',
+        teams: [{ teamName: 'A', position: 1 }],
+      };
+      azureStorageService.getLeagueTeamsData.mockResolvedValueOnce(data);
+
+      await promptTeamPick(botMock, 1, 'ABC');
+      await promptTeamPick(botMock, 1, 'ABC');
+
+      expect(azureStorageService.getLeagueTeamsData).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('applyLeagueTeamSelection', () => {
+    const leagueData = {
+      leagueName: 'Amba',
+      leagueCode: 'ABC',
+      teams: [
+        {
+          teamName: 'My Team',
+          userName: 'Alice',
+          position: 1,
+          budget: 110,
+          transfersRemaining: 2,
+          drivers: [
+            { name: 'VER', price: 30, isCaptain: true },
+            { name: 'NOR', price: 28 },
+            { name: 'HAM', price: 25 },
+            { name: 'PIA', price: 15 },
+            { name: 'RUS', price: 8 },
+          ],
+          constructors: [
+            { name: 'RB', price: 2 },
+            { name: 'FER', price: 1 },
+          ],
+        },
+      ],
+    };
+
+    beforeEach(() => {
+      azureStorageService.getLeagueTeamsData.mockResolvedValue(leagueData);
+      // Preload existing cached team + selection to prove it's wiped
+      cache.currentTeamCache[1] = { T1: { drivers: ['OLD'] } };
+      cache.bestTeamsCache[1] = { T1: { bestTeams: [] } };
+      cache.selectedChipCache[1] = { T1: 'EXTRA_BOOST' };
+      cache.userCache['1'] = { selectedTeam: 'T1' };
+    });
+
+    it('deletes existing teams, loads the picked team, and updates selectedTeam', async () => {
+      await applyLeagueTeamSelection(botMock, 1, 'ABC', 1);
+
+      expect(azureStorageService.deleteAllUserTeams).toHaveBeenCalledWith(
+        botMock,
+        1,
+      );
+
+      expect(cache.currentTeamCache[1]).toEqual({
+        'ABC_My-Team': expect.objectContaining({
+          drivers: ['VER', 'NOR', 'HAM', 'PIA', 'RUS'],
+          constructors: ['RB', 'FER'],
+          boost: 'VER',
+          freeTransfers: 2,
+        }),
+      });
+      expect(cache.bestTeamsCache[1]).toBeUndefined();
+      expect(cache.selectedChipCache[1]).toBeUndefined();
+      expect(cache.userCache['1'].selectedTeam).toBe('ABC_My-Team');
+
+      expect(azureStorageService.saveUserTeam).toHaveBeenCalledWith(
+        botMock,
+        1,
+        'ABC_My-Team',
+        expect.objectContaining({ boost: 'VER' }),
+      );
+      expect(updateUserAttributes).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ selectedTeam: 'ABC_My-Team' }),
+      );
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining('Loaded team My Team from league Amba'),
+      );
+    });
+
+    it('errors gracefully when position does not exist in league', async () => {
+      await applyLeagueTeamSelection(botMock, 1, 'ABC', 99);
+
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        1,
+        '❌ Could not find that team in the league anymore.',
+      );
+      expect(azureStorageService.saveUserTeam).not.toHaveBeenCalled();
+      // Existing cached team is untouched on the no-op path
+      expect(cache.currentTeamCache[1]).toEqual({ T1: { drivers: ['OLD'] } });
+    });
+  });
+});

--- a/src/constants.js
+++ b/src/constants.js
@@ -33,6 +33,8 @@ exports.BEST_TEAM_WEIGHTS_CALLBACK_TYPE = 'BEST_TEAM_WEIGHTS';
 exports.DEADLINE_CALLBACK_TYPE = 'DEADLINE';
 exports.LEAGUE_CALLBACK_TYPE = 'LEAGUE';
 exports.LEAGUE_UNFOLLOW_CALLBACK_TYPE = 'LEAGUE_UNFOLLOW';
+exports.LEAGUE_TEAM_SELECT_CALLBACK_TYPE = 'LEAGUE_TEAM_SELECT';
+exports.LEAGUE_TEAM_PICK_CALLBACK_TYPE = 'LEAGUE_TEAM_PICK';
 
 exports.MAX_TELEGRAM_MESSAGE_LENGTH = 4096;
 exports.BEST_TEAMS_RESULT_COUNT = 15;
@@ -75,6 +77,7 @@ exports.COMMAND_DEADLINE = '/deadline';
 exports.COMMAND_FOLLOW_LEAGUE = '/follow_league';
 exports.COMMAND_UNFOLLOW_LEAGUE = '/unfollow_league';
 exports.COMMAND_LEADERBOARD = '/leaderboard';
+exports.COMMAND_SELECT_TEAM_FROM_LEAGUE = '/select_team_from_league';
 
 // Menu configuration for interactive menu command
 exports.MENU_CATEGORIES = {
@@ -291,6 +294,12 @@ exports.MENU_CATEGORIES = {
         constant: exports.COMMAND_LEADERBOARD,
         title: '🏆 Leaderboard',
         description: 'View the leaderboard of a followed league',
+      },
+      {
+        constant: exports.COMMAND_SELECT_TEAM_FROM_LEAGUE,
+        title: '🎯 Select Team From League',
+        description:
+          'Load a team roster from a followed league as your active team (replaces existing teams)',
       },
     ],
   },

--- a/src/textMessageHandler.js
+++ b/src/textMessageHandler.js
@@ -40,6 +40,7 @@ const {
   handleFollowLeagueCommand,
   handleUnfollowLeagueCommand,
   handleLeaderboardCommand,
+  handleSelectTeamFromLeagueCommand,
 } = require('./commandsHandler');
 
 // Import constants
@@ -82,6 +83,7 @@ const {
   COMMAND_FOLLOW_LEAGUE,
   COMMAND_UNFOLLOW_LEAGUE,
   COMMAND_LEADERBOARD,
+  COMMAND_SELECT_TEAM_FROM_LEAGUE,
 } = require('./constants');
 
 exports.handleTextMessage = async function (bot, msg) {
@@ -174,6 +176,8 @@ exports.handleTextMessage = async function (bot, msg) {
       return await handleUnfollowLeagueCommand(bot, msg);
     case msg.text === COMMAND_LEADERBOARD:
       return await handleLeaderboardCommand(bot, msg);
+    case msg.text === COMMAND_SELECT_TEAM_FROM_LEAGUE:
+      return await handleSelectTeamFromLeagueCommand(bot, msg);
     default:
       try {
         const jsonData = JSON.parse(textTrimmed);

--- a/src/translations.js
+++ b/src/translations.js
@@ -461,6 +461,22 @@ const translations = {
     '🏁 League Management': '🏁 ניהול ליגות',
     'Follow and view F1 Fantasy leagues':
       'עקוב וצפה בליגות F1 Fantasy',
+    '🎯 Select Team From League': '🎯 בחר קבוצה מליגה',
+    'Load a team roster from a followed league as your active team (replaces existing teams)':
+      'טען הרכב של קבוצה מליגה שאתה עוקב אחריה ככבוצה הפעילה שלך (מוחק את הקבוצות הקיימות)',
+    'Which league do you want to select a team from?':
+      'מאיזו ליגה ברצונך לבחור קבוצה?',
+    'Which team do you want to load?': 'איזו קבוצה ברצונך לטעון?',
+    'No team roster is available yet for this league. Please try again later.':
+      'עדיין אין נתוני הרכב קבוצות עבור הליגה הזו. נסה שוב מאוחר יותר.',
+    '❌ Failed to load league teams data: {ERROR}':
+      '❌ טעינת נתוני הקבוצות של הליגה נכשלה: {ERROR}',
+    '❌ Could not find that team in the league anymore.':
+      '❌ לא הצלחתי למצוא את הקבוצה הזו בליגה יותר.',
+    '❌ Failed to save league team: {ERROR}':
+      '❌ שמירת קבוצת הליגה נכשלה: {ERROR}',
+    '✅ Loaded team {TEAM} from league {LEAGUE}. Previous teams have been cleared.':
+      '✅ נטענה הקבוצה {TEAM} מהליגה {LEAGUE}. הקבוצות הקודמות נמחקו.',
     'To find your league code: go to the F1 Fantasy website, open the league you want to follow, click the share button, and copy the league code from there.':
       'כדי למצוא את קוד הליגה: היכנס לאתר \u2066F1 Fantasy\u2069, פתח את הליגה שברצונך לעקוב אחריה, לחץ על כפתור השיתוף והעתק את קוד הליגה משם.',
     '📩 If the code is correct but the league is not yet tracked, please report it to the admins via /report_bug with the league code and we will add the bot to the league as soon as possible.':


### PR DESCRIPTION
## Summary

Adds a new admin-only command `/select_team_from_league` that loads a team roster directly from a followed league's `teams-data.json` blob (produced by the `f1-fantasy-api-data` scraper) into the bot's team cache, plus a **startup refresh** that keeps league-sourced teams in sync with the scraper on every restart.

The league flow and the screenshot-upload flow are **mutually exclusive** per user — picking a league team wipes all previously cached teams (blobs + in-memory) and installs the new one as the active team.

## Flow

1. Admin runs `/select_team_from_league`.
2. If 0 leagues → prompted to `/follow_league`. If 1 league → auto-picked. If 2+ → inline keyboard to pick league.
3. Inline keyboard of all teams in the league (position + team name).
4. On selection: all prior teams wiped, selected league team installed, `selectedTeam` set, a `/print_cache`-style confirmation is sent.
5. On every app startup, any cached team whose id is in league format is automatically refreshed from the latest `teams-data.json`.

## Key details

- **teamId format:** `{leagueCode}_{sanitizedTeamName}` — coexists with `T1/T2/T3` from the screenshot flow. Fixed `listAllUserTeamData` to split on the **first** `_` (chatId is always numeric) so league teamIds with underscores round-trip correctly.
- **Name mapping:** league display names (e.g. `"O. Bearman"`, `"Racing Bulls"`, `"Red Bull Racing"`) are mapped through `NAME_TO_CODE_MAPPING` → `BEA` / `VRB` / `RED`, matching the screenshot flow convention.
- **New service:** `getLeagueTeamsData(leagueCode)` fetches `leagues/{code}/teams-data.json`.
- **New cache:** `leagueTeamsDataCache` (in-memory, per-leagueCode).
- **Callback types:** `LEAGUE_TEAM_SELECT` (league picker), `LEAGUE_TEAM_PICK` (team picker). Pick payload uses position (not team name) so `callback_data` stays within Telegram's 64-byte limit.
- **Mapping from league team → bot team shape:** boost = first driver with `isCaptain` (fallback `isMegaCaptain`, then first driver). `costCapRemaining = budget − Σ prices`. `freeTransfers = max(transfersRemaining, 0)`.
- **Startup refresh (`refreshLeagueSourcedTeams`):** after loading cached teams from blob storage, iterates league-format ids (`{code}_{slug}`), fetches each league's `teams-data.json` **once**, matches by sanitized team name, rebuilds the team data, updates the cache, and persists back to the blob. Non-league ids are skipped; teams missing from the blob are left as-is.

## Tests

- All 530 tests passing (+26 new).
- Lint clean (no new warnings).
- New coverage: sanitizer, teamId builder, mapper (incl. explicit `"O. Bearman"` / `"Racing Bulls"` → code mapping), admin gate, 0/1/many-league paths, teams-data cache memoization, apply-selection happy path, unknown-position error path, `getLeagueTeamsData` (200/404/error), `listAllUserTeamData` underscore-safe parser, and `refreshLeagueSourcedTeams` (refresh happy path + skip T1-style ids + missing-in-league no-op).

## Docs

`AGENTS.md` updated: League Registry section, admin command list, Multi-Team System teamId formats, and the underscore-safe parser note.
