### PR TITLE
feat: read scraping trigger URL from Azure Key Vault

### DIFF
--- a/local.settings.json
+++ b/local.settings.json
@@ -6,6 +6,7 @@
     "AZURE_SUBSCRIPTION_ID": "your-azure-subscription-id",
     "AZURE_CLIENT_ID": "your-azure-client-id",
     "AZURE_CLIENT_SECRET": "your-azure-client-secret",
-    "AZURE_TENANT_ID": "your-azure-tenant-id"
+    "AZURE_TENANT_ID": "your-azure-tenant-id",
+    "AZURE_KEY_VAULT_URL": "https://f1-fantasy-kv.vault.azure.net/"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@azure/arm-costmanagement": "^1.0.0-beta.1",
         "@azure/data-tables": "^13.3.2",
         "@azure/identity": "^4.10.0",
+        "@azure/keyvault-secrets": "^4.11.1",
         "@azure/storage-blob": "^12.27.0",
         "dotenv": "^16.4.7",
         "node-telegram-bot-api": "^0.66.0",
@@ -42,6 +43,23 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@azure-rest/core-client": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-2.6.0.tgz",
+      "integrity": "sha512-iuFKDm8XPzNxPfRjhyU5/xKZmcRDzSuEghXDHHk4MjBV/wFL34GmYVBZnn9wmuoLBeS1qAw9ceMdaeJBPcB1QQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -87,17 +105,17 @@
       }
     },
     "node_modules/@azure/core-auth": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.9.0.tgz",
-      "integrity": "sha512-FPwHpZywuyasDSLMqJ6fhbOK3TqUdviZNF8OqRGA4W5Ewib2lEEZ+pBsYcBa88B2NGO/SEnYPGhyBqNlE8ilSw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-util": "^1.11.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/core-client": {
@@ -160,47 +178,47 @@
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.20.0.tgz",
-      "integrity": "sha512-ASoP8uqZBS3H/8N8at/XwFr6vYrRP3syTK0EUjDXQy0Y1/AUS+QeIRThKmTNJO2RggvBBxaXDPM7YoIwDGeA0g==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+      "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-auth": "^1.8.0",
-        "@azure/core-tracing": "^1.0.1",
-        "@azure/core-util": "^1.11.0",
-        "@azure/logger": "^1.0.0",
-        "@typespec/ts-http-runtime": "^0.2.2",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/core-tracing": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.2.0.tgz",
-      "integrity": "sha512-UKTiEJPkWcESPYJz3X5uKRYyOcJD+4nYph+KpfdPRnQJVrZfk0KJgdnaAWKfhsBBtAf/D58Az4AvCJEmWgIBAg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/core-util": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.12.0.tgz",
-      "integrity": "sha512-13IyjTQgABPARvG90+N2dXpC+hwp466XCdQXPCRlbWHgd3SJd5Q1VvaBGv6k1BIa4MQm6hAF1UBU1m8QUxV8sQ==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@typespec/ts-http-runtime": "^0.2.2",
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/core-xml": {
@@ -258,17 +276,58 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/logger": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.2.0.tgz",
-      "integrity": "sha512-0hKEzLhpw+ZTAfNJyRrn6s+V0nDWzXk9OjBr2TiGIu0OfMr5s2V4FpKLTAK3Ca5r5OKLbf4hkOGDPyiRjie/jA==",
+    "node_modules/@azure/keyvault-common": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-common/-/keyvault-common-2.1.0.tgz",
+      "integrity": "sha512-aCDidWuKY06LWQ4x7/8TIXK6iRqTaRWRL3t7T+LC+j1b07HtoIsOxP/tU90G4jCSBn5TAyUTCtA4MS/y5Hudaw==",
       "license": "MIT",
       "dependencies": {
-        "@typespec/ts-http-runtime": "^0.2.2",
+        "@azure-rest/core-client": "^2.3.3",
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.8.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.10.0",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/keyvault-secrets": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-secrets/-/keyvault-secrets-4.11.1.tgz",
+      "integrity": "sha512-tLBcPeJX4s95Whe0t1G1dM8lBDmmuz7qBh8WN0PAQ8vBVFTUb5sZsf8fRXNejEZPYS7sND/PesJnAMIXs9mFyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure-rest/core-client": "^2.3.3",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-lro": "^2.7.2",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.0",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/keyvault-common": "^2.1.0",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/msal-browser": {
@@ -1757,9 +1816,9 @@
       "license": "MIT"
     },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.2.2.tgz",
-      "integrity": "sha512-Gz/Sm64+Sq/vklJu1tt9t+4R2lvnud8NbTD/ZfpZtMiUX7YeVpCA8j6NSW8ptwcoLL+NmYANwqP8DV0q/bwl2w==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
+      "integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
       "license": "MIT",
       "dependencies": {
         "http-proxy-agent": "^7.0.0",
@@ -1767,7 +1826,7 @@
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -8401,29 +8460,6 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -8481,17 +8517,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zod": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
-      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@azure/arm-costmanagement": "^1.0.0-beta.1",
     "@azure/data-tables": "^13.3.2",
     "@azure/identity": "^4.10.0",
+    "@azure/keyvault-secrets": "^4.11.1",
     "@azure/storage-blob": "^12.27.0",
     "dotenv": "^16.4.7",
     "node-telegram-bot-api": "^0.66.0",

--- a/src/commandsHandler/scrapingTriggerHandler.js
+++ b/src/commandsHandler/scrapingTriggerHandler.js
@@ -10,7 +10,7 @@ async function handleScrapingTrigger(bot, msg) {
     return;
   }
 
-  const result = await triggerScraping(bot);
+  const result = await triggerScraping();
   if (result.success) {
     await bot.sendMessage(chatId, t('Web scraping triggered successfully.', chatId));
   } else {

--- a/src/commandsHandler/scrapingTriggerHandler.test.js
+++ b/src/commandsHandler/scrapingTriggerHandler.test.js
@@ -51,7 +51,7 @@ describe('handleScrapingTrigger', () => {
     await handleScrapingTrigger(botMock, msgMock);
 
     expect(mockIsAdminMessage).toHaveBeenCalledWith(msgMock);
-    expect(mockTriggerScraping).toHaveBeenCalledWith(botMock);
+    expect(mockTriggerScraping).toHaveBeenCalledWith();
     expect(botMock.sendMessage).toHaveBeenCalledWith(
       KILZI_CHAT_ID,
       'Web scraping triggered successfully.'
@@ -73,7 +73,7 @@ describe('handleScrapingTrigger', () => {
     await handleScrapingTrigger(botMock, msgMock);
 
     expect(mockIsAdminMessage).toHaveBeenCalledWith(msgMock);
-    expect(mockTriggerScraping).toHaveBeenCalledWith(botMock);
+    expect(mockTriggerScraping).toHaveBeenCalledWith();
     expect(botMock.sendMessage).toHaveBeenCalledWith(
       KILZI_CHAT_ID,
       `Failed to trigger web scraping: ${errorMessage}`
@@ -93,7 +93,7 @@ describe('handleScrapingTrigger', () => {
     );
 
     expect(mockIsAdminMessage).toHaveBeenCalledWith(msgMock);
-    expect(mockTriggerScraping).toHaveBeenCalledWith(botMock);
+    expect(mockTriggerScraping).toHaveBeenCalledWith();
   });
 
   it('should work with different chat IDs for admin users', async () => {

--- a/src/keyVaultService.js
+++ b/src/keyVaultService.js
@@ -1,0 +1,57 @@
+const { SecretClient } = require('@azure/keyvault-secrets');
+const { DefaultAzureCredential } = require('@azure/identity');
+
+const SCRAPER_RUNNER_URL_SECRET = 'f1-fantasy-scraper-runner-url';
+
+let secretClient;
+const secretCache = new Map();
+
+function getSecretClient() {
+  if (secretClient) {
+    return secretClient;
+  }
+
+  const vaultUrl = process.env.AZURE_KEY_VAULT_URL;
+  if (!vaultUrl) {
+    throw new Error(
+      'Missing required Azure configuration: AZURE_KEY_VAULT_URL',
+    );
+  }
+
+  const credential = new DefaultAzureCredential();
+  secretClient = new SecretClient(vaultUrl, credential);
+
+  return secretClient;
+}
+
+/**
+ * Fetch a secret from the configured Azure Key Vault. Values are cached
+ * for the lifetime of the Node process to avoid hitting KV on every call.
+ * To force a refresh (e.g. after rotation) pass { forceRefresh: true }.
+ *
+ * @param {string} secretName
+ * @param {{ forceRefresh?: boolean }} [options]
+ * @returns {Promise<string>}
+ */
+async function getSecret(secretName, { forceRefresh = false } = {}) {
+  if (!forceRefresh && secretCache.has(secretName)) {
+    return secretCache.get(secretName);
+  }
+
+  const client = getSecretClient();
+  const secret = await client.getSecret(secretName);
+  secretCache.set(secretName, secret.value);
+
+  return secret.value;
+}
+
+function _resetForTests() {
+  secretClient = undefined;
+  secretCache.clear();
+}
+
+module.exports = {
+  getSecret,
+  SCRAPER_RUNNER_URL_SECRET,
+  _resetForTests,
+};

--- a/src/keyVaultService.test.js
+++ b/src/keyVaultService.test.js
@@ -1,0 +1,91 @@
+const mockGetSecret = jest.fn();
+
+jest.mock('@azure/keyvault-secrets', () => ({
+  SecretClient: jest.fn().mockImplementation(() => ({
+    getSecret: mockGetSecret,
+  })),
+}));
+
+jest.mock('@azure/identity', () => ({
+  DefaultAzureCredential: jest.fn(),
+}));
+
+const { SecretClient } = require('@azure/keyvault-secrets');
+const { DefaultAzureCredential } = require('@azure/identity');
+const keyVaultService = require('./keyVaultService');
+
+describe('keyVaultService', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      AZURE_KEY_VAULT_URL: 'https://example-kv.vault.azure.net/',
+    };
+    mockGetSecret.mockReset();
+    SecretClient.mockClear();
+    DefaultAzureCredential.mockClear();
+    keyVaultService._resetForTests();
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('fetches a secret from Key Vault and returns its value', async () => {
+    mockGetSecret.mockResolvedValueOnce({ value: 'my-secret-value' });
+
+    const value = await keyVaultService.getSecret('some-secret');
+
+    expect(value).toBe('my-secret-value');
+    expect(mockGetSecret).toHaveBeenCalledWith('some-secret');
+    expect(SecretClient).toHaveBeenCalledWith(
+      'https://example-kv.vault.azure.net/',
+      expect.anything()
+    );
+  });
+
+  it('caches secrets across calls and hits KV only once', async () => {
+    mockGetSecret.mockResolvedValueOnce({ value: 'cached-value' });
+
+    const a = await keyVaultService.getSecret('same-secret');
+    const b = await keyVaultService.getSecret('same-secret');
+
+    expect(a).toBe('cached-value');
+    expect(b).toBe('cached-value');
+    expect(mockGetSecret).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches when forceRefresh is true', async () => {
+    mockGetSecret
+      .mockResolvedValueOnce({ value: 'v1' })
+      .mockResolvedValueOnce({ value: 'v2' });
+
+    const first = await keyVaultService.getSecret('rot');
+    const second = await keyVaultService.getSecret('rot', { forceRefresh: true });
+
+    expect(first).toBe('v1');
+    expect(second).toBe('v2');
+    expect(mockGetSecret).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws if AZURE_KEY_VAULT_URL is not set', async () => {
+    delete process.env.AZURE_KEY_VAULT_URL;
+
+    await expect(keyVaultService.getSecret('anything')).rejects.toThrow(
+      /AZURE_KEY_VAULT_URL/
+    );
+  });
+
+  it('propagates errors thrown by the Key Vault client', async () => {
+    mockGetSecret.mockRejectedValueOnce(new Error('Forbidden'));
+
+    await expect(keyVaultService.getSecret('boom')).rejects.toThrow('Forbidden');
+  });
+
+  it('exports the scraper runner URL secret name', () => {
+    expect(keyVaultService.SCRAPER_RUNNER_URL_SECRET).toBe(
+      'f1-fantasy-scraper-runner-url'
+    );
+  });
+});

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -377,7 +377,11 @@ exports.triggerScraping = async function () {
   }
 
   try {
-    const response = await fetch(url);
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -24,6 +24,10 @@ const {
 } = require('../prompts');
 const { t, getLocale } = require('../i18n');
 const { userCache } = require('../cache');
+const {
+  getSecret,
+  SCRAPER_RUNNER_URL_SECRET,
+} = require('../keyVaultService');
 
 const normalizePrice = function (value) {
   return Math.round(value * 10) / 10;
@@ -354,15 +358,22 @@ exports.calculateTeamInfo = function (team, drivers, constructors) {
 
 exports.normalizePrice = normalizePrice;
 
-exports.triggerScraping = async function (bot, chatId) {
-  const url = process.env.AZURE_LOGICAPP_TRIGGER_URL;
-  if (!url) {
-    await bot.sendMessage(
-      chatId,
-      t('Error: Scraping trigger URL is not configured.', chatId),
-    );
+exports.triggerScraping = async function () {
+  let url;
+  try {
+    url = await getSecret(SCRAPER_RUNNER_URL_SECRET);
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to read scraping trigger URL from Key Vault: ${error.message}`,
+    };
+  }
 
-    return;
+  if (!url) {
+    return {
+      success: false,
+      error: 'Scraping trigger URL is not configured.',
+    };
   }
 
   try {


### PR DESCRIPTION
Previously the '/trigger_scraping' admin command read the runner Logic App's SAS-signed callback URL from env var AZURE_LOGICAPP_TRIGGER_URL. That URL is a secret (anyone holding it can invoke the scraper) and baking it into app settings makes rotation a deployment, not a config change.

- New src/keyVaultService.js wraps @azure/keyvault-secrets with DefaultAzureCredential (same pattern as azureBillingService). Values are cached in-process; forceRefresh option supports rotation.
- src/utils/utils.js: triggerScraping() now fetches the URL from the 'f1-fantasy-scraper-runner-url' secret in AZURE_KEY_VAULT_URL. Also fixed a latent bug where the missing-URL path returned undefined and crashed the caller.
- src/commandsHandler/scrapingTriggerHandler.js updated to new signature (no args).
- local.settings.json: add AZURE_KEY_VAULT_URL placeholder.
- Tests: 13 new/updated cases for the KV service and handler.

Deployment: set AZURE_KEY_VAULT_URL in the Function App settings and grant the Function's managed identity 'get' on secrets in f1-fantasy-kv.