### PR TITLE
feat: allow users to follow up to 6 league teams

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ This repository contains a Telegram bot that helps manage F1 Fantasy teams. The 
 - `/menu`, `/help`, `/lang`
 - `/report_bug` _(reply-based — uses pending reply manager)_
 
-**Admin-only:** `/trigger_scraping`, `/get_botfather_commands`, `/billing_stats`, `/version`, `/list_users`, `/send_message_to_user`, `/broadcast`, `/set_nickname`, `/live_score`, `/follow_league`, `/unfollow_league`, `/leaderboard`, `/select_team_from_league`, `/league_graph`
+**Admin-only:** `/trigger_scraping`, `/get_botfather_commands`, `/billing_stats`, `/version`, `/list_users`, `/send_message_to_user`, `/broadcast`, `/set_nickname`, `/live_score`, `/follow_league`, `/unfollow_league`, `/leaderboard`, `/select_team_from_league`, `/unfollow_team`, `/league_graph`
 
 ---
 
@@ -301,7 +301,7 @@ The table is **extensible** — new attributes can be added at any time without 
    - 1 league → auto-fetch blob and render leaderboard.
    - 2+ leagues → inline keyboard (`LEAGUE_CALLBACK_TYPE`) showing each league by name; on selection, callback handler fetches the blob and renders.
 5. `/unfollow_league` shows an inline keyboard (`LEAGUE_UNFOLLOW_CALLBACK_TYPE`) with all followed leagues; selection calls `removeUserLeague(chatId, leagueCode)`.
-6. `/select_team_from_league` (admin-only) lets the admin pick a league (auto-picked when only one) and then a team within it. The selected team replaces **all** previously cached teams for the user — both in-memory (`currentTeamCache`, `bestTeamsCache`, `selectedChipCache`, `selectedBestTeamByTeam`) and in blob storage (`deleteAllUserTeams`). The loaded team is keyed by `teamId = ${leagueCode}_${sanitized(teamName)}` and becomes the active `selectedTeam`. League `teams-data.json` is fetched via `getLeagueTeamsData(leagueCode)` and cached in memory per leagueCode (`leagueTeamsDataCache`). Callback types: `LEAGUE_TEAM_SELECT_CALLBACK_TYPE` (league picker) and `LEAGUE_TEAM_PICK_CALLBACK_TYPE` (team picker; payload `...:<leagueCode>:<position>` so the actual team is resolved server-side from the cached blob to keep callback data short).
+6. `/select_team_from_league` (admin-only) lets the admin pick a league (auto-picked when only one) and then a team within it. The picked team is **added** to the user's followed league teams (up to `MAX_FOLLOWED_LEAGUE_TEAMS = 6`); existing followed league teams are preserved. Any pre-existing screenshot teams (`T1`/`T2`/`T3`) are wiped first via `ensureSourceIsScreenshot`→`ensureSourceIsLeague` so the two sources never coexist. If the user is already at the cap, the add is stashed in `pending-league-team-adds/{chatId}.json` and an inline unfollow-and-add picker is shown (`UFTA` callback). The loaded team is keyed by `teamId = ${leagueCode}_${sanitized(teamName)}` and becomes the active `selectedTeam`. League `teams-data.json` is fetched via `getLeagueTeamsData(leagueCode)` and cached in memory per leagueCode (`leagueTeamsDataCache`). Callback types: `LEAGUE_TEAM_SELECT_CALLBACK_TYPE` (league picker), `LEAGUE_TEAM_PICK_CALLBACK_TYPE` (team picker; payload `...:<leagueCode>:<position>`), `LEAGUE_TEAM_UNFOLLOW_CALLBACK_TYPE = 'UFT'` (plain unfollow via `/unfollow_team`), `LEAGUE_TEAM_UNFOLLOW_AND_ADD_CALLBACK_TYPE = 'UFTA'` (unfollow then resume the stashed add).
 7. `/league_graph` (admin-only) renders a line chart of each team's **gap to the leader** per race in a followed league (leader sits on 0; everyone else is at or below 0). Same 0/1/N league-selection flow as `/leaderboard` (callback type `LEAGUE_GRAPH_CALLBACK_TYPE`). Chart rendering is delegated to [`quickchart-js`](https://quickchart.io) — the handler builds a Chart.js config via `buildChartConfig(leagueData, { roundToRaceName })`, calls `chart.getShortUrl()`, and sends the URL via `bot.sendPhoto` (Telegram fetches the PNG itself, no native `canvas` dep). Chip usage is drawn as an emoji + chip-name label on the specific data point using the `chartjs-plugin-datalabels` plugin (bundled with QuickChart). X-axis labels use the short race name (e.g. `Chinese GP`) — `matchday_N` is mapped to round `N` in the current Jolpica/Ergast season schedule (`fetchCurrentSeasonRaces`) and `raceName` is shortened (`Grand Prix` → `GP`); falls back to `R{N}` if the mapping can't be resolved. Chip → emoji mapping lives in `src/utils/chipEmojis.js`.
 
 The leaderboard is rendered compactly (position, team name, total score) with a header showing league name, member count, and fetch time. Teams from the blob are already sorted by `position`.
@@ -364,7 +364,18 @@ The bot supports **multiple teams per user**. Teams are keyed by a `teamId` stri
 - **Screenshot flow:** `T1`, `T2`, `T3` — extracted from the colored-square icon in the team photo by `EXTRACT_JSON_FROM_CURRENT_TEAM_PHOTO_SYSTEM_PROMPT`.
 - **League flow:** `{leagueCode}_{sanitizedTeamName}` — created by `/select_team_from_league`. `sanitizedTeamName` strips unsafe characters (only word chars and `-` survive) and is truncated to 40 chars to keep the blob path (`user-teams/{chatId}_{teamId}.json`) and callback data short.
 
-Picking a team from a league always **replaces all** existing cached teams for that user (both screenshot and league teams, in memory and in blob storage). The screenshot-upload flow is unchanged; the two sources cannot coexist for the same user.
+Picking a team from a league **adds it** to the user's followed league teams (up to `MAX_FOLLOWED_LEAGUE_TEAMS = 6`, in `constants.js`). The two sources still cannot coexist:
+
+- **Following a league team** wipes any screenshot teams (`T1`/`T2`/`T3`) first.
+- **Uploading/assigning a screenshot team** wipes any followed league teams first.
+
+Cross-source wiping is centralized in `src/utils/teamSourceSwitcher.js` (`ensureSourceIsLeague`, `ensureSourceIsScreenshot`).
+
+**Over the cap:** if the user is already following 6 league teams and picks another, `/select_team_from_league` stashes the pending add in Azure Blob Storage (`pending-league-team-adds/{chatId}.json` — helpers `savePendingLeagueTeamAdd` / `getPendingLeagueTeamAdd` / `deletePendingLeagueTeamAdd` in `azureStorageService.js`) and shows an inline "unfollow-and-add" picker (`LEAGUE_TEAM_UNFOLLOW_AND_ADD_CALLBACK_TYPE = 'UFTA'`). Picking a button removes that team and resumes the pending add automatically.
+
+**`/unfollow_team`** (admin-only, `src/commandsHandler/unfollowTeamHandler.js`): shows an inline picker (`LEAGUE_TEAM_UNFOLLOW_CALLBACK_TYPE = 'UFT'`) of the user's currently-followed league teams. Selecting one calls `removeFollowedTeam(bot, chatId, teamId)` — the shared removal helper also used by the `UFTA` resume-add flow. It deletes the blob, clears the per-team entries in `currentTeamCache`/`bestTeamsCache`/`selectedChipCache`/`selectedBestTeamByTeam`, and if the removed team was active promotes the first remaining league team (or clears `selectedTeam` when none remain). Running `/unfollow_team` also deletes any dangling pending-add blob so an abandoned over-cap flow doesn't accidentally resume.
+
+Short callback-data type names (`UFT`, `UFTA`) keep `UFT:{teamId}` / `UFTA:{teamId}` under Telegram's 64-byte `callback_data` limit (league `teamId` length ≤ ~55 chars).
 
 Each team has its own cached data, chip selection, and best-teams calculation. A `selectedTeam` preference determines which team context commands operate on.
 

--- a/src/azureStorageService.js
+++ b/src/azureStorageService.js
@@ -446,6 +446,85 @@ async function getLeagueTeamsData(leagueCode) {
   }
 }
 
+/**
+ * Save a pending "follow league team" request for a user.
+ * Used when the user has hit the 6-team cap in /select_team_from_league and
+ * must first unfollow an existing team before the new one can be added.
+ * @param {string|number} chatId
+ * @param {{leagueCode: string, position: number}} pendingAdd
+ */
+async function savePendingLeagueTeamAdd(chatId, pendingAdd) {
+  try {
+    if (!containerClient) {
+      initializeAzureStorage();
+    }
+
+    const blobName = `pending-league-team-adds/${chatId}.json`;
+    const blockBlobClient = containerClient.getBlockBlobClient(blobName);
+    const content = JSON.stringify(pendingAdd, null, 2);
+
+    await blockBlobClient.upload(content, content.length, {
+      blobHTTPHeaders: { blobContentType: 'application/json' },
+    });
+  } catch (error) {
+    throw new Error(
+      `Failed to save pending league team add for ${chatId}: ${error.message}`,
+    );
+  }
+}
+
+/**
+ * Read a pending "follow league team" request for a user.
+ * @param {string|number} chatId
+ * @returns {Promise<{leagueCode: string, position: number}|null>}
+ */
+async function getPendingLeagueTeamAdd(chatId) {
+  try {
+    if (!containerClient) {
+      initializeAzureStorage();
+    }
+
+    const blobName = `pending-league-team-adds/${chatId}.json`;
+    const blockBlobClient = containerClient.getBlockBlobClient(blobName);
+
+    const exists = await blockBlobClient.exists();
+    if (!exists) {
+      return null;
+    }
+
+    const downloadResponse = await blockBlobClient.download();
+    const jsonString = await streamToString(
+      downloadResponse.readableStreamBody,
+    );
+
+    return JSON.parse(jsonString);
+  } catch (error) {
+    throw new Error(
+      `Failed to get pending league team add for ${chatId}: ${error.message}`,
+    );
+  }
+}
+
+/**
+ * Delete a pending "follow league team" request for a user.
+ * @param {string|number} chatId
+ */
+async function deletePendingLeagueTeamAdd(chatId) {
+  try {
+    if (!containerClient) {
+      initializeAzureStorage();
+    }
+
+    const blobName = `pending-league-team-adds/${chatId}.json`;
+    const blockBlobClient = containerClient.getBlockBlobClient(blobName);
+    await blockBlobClient.deleteIfExists();
+  } catch (error) {
+    console.error(
+      `Failed to delete pending league team add for ${chatId}: ${error.message}`,
+    );
+  }
+}
+
 module.exports = {
   getFantasyData,
   getUserTeam,
@@ -458,6 +537,9 @@ module.exports = {
   savePendingTeamAssignment,
   getPendingTeamAssignment,
   deletePendingTeamAssignment,
+  savePendingLeagueTeamAdd,
+  getPendingLeagueTeamAdd,
+  deletePendingLeagueTeamAdd,
   getLeagueData,
   getLeagueTeamsData,
 };

--- a/src/cache.js
+++ b/src/cache.js
@@ -163,6 +163,25 @@ exports.getUserTeamIds = function (chatId) {
   return Object.keys(currentTeamCache[chatId] || {});
 };
 
+/**
+ * A league-loaded teamId has the shape `{leagueCode}_{sanitizedTeamName}`
+ * (always contains `_`), while screenshot teamIds are the short labels
+ * `T1`, `T2`, `T3` (no `_`).
+ */
+exports.isLeagueTeamId = function (teamId) {
+  return typeof teamId === 'string' && teamId.includes('_');
+};
+
+exports.getUserLeagueTeamIds = function (chatId) {
+  return exports.getUserTeamIds(chatId).filter(exports.isLeagueTeamId);
+};
+
+exports.getUserScreenshotTeamIds = function (chatId) {
+  return exports
+    .getUserTeamIds(chatId)
+    .filter((teamId) => !exports.isLeagueTeamId(teamId));
+};
+
 exports.getBestTeamBudgetChangePointsPerMillion = function (chatId, teamId) {
   const key = String(chatId);
   const bestTeamBudgetChangePointsPerMillion =

--- a/src/callbackQueryHandler.js
+++ b/src/callbackQueryHandler.js
@@ -23,6 +23,8 @@ const {
   LEAGUE_UNFOLLOW_CALLBACK_TYPE,
   LEAGUE_TEAM_SELECT_CALLBACK_TYPE,
   LEAGUE_TEAM_PICK_CALLBACK_TYPE,
+  LEAGUE_TEAM_UNFOLLOW_CALLBACK_TYPE,
+  LEAGUE_TEAM_UNFOLLOW_AND_ADD_CALLBACK_TYPE,
   LEAGUE_GRAPH_CALLBACK_TYPE,
 } = require('./constants');
 
@@ -30,6 +32,9 @@ const {
   sendLogMessage,
   sendMessageToUser,
 } = require('./utils');
+const {
+  ensureSourceIsScreenshot,
+} = require('./utils/teamSourceSwitcher');
 const { handleMenuCallback } = require('./commandsHandler/menuHandler');
 const { t, setLanguage, getLanguageName } = require('./i18n');
 const {
@@ -50,6 +55,9 @@ const {
   promptTeamPick,
   applyLeagueTeamSelection,
 } = require('./commandsHandler/selectTeamFromLeagueHandler');
+const {
+  removeFollowedTeam,
+} = require('./commandsHandler/unfollowTeamHandler');
 
 exports.handleCallbackQuery = async function (bot, query) {
   const callbackType = query.data.split(':')[0];
@@ -77,6 +85,10 @@ exports.handleCallbackQuery = async function (bot, query) {
       return await handleLeagueTeamSelectCallback(bot, query);
     case LEAGUE_TEAM_PICK_CALLBACK_TYPE:
       return await handleLeagueTeamPickCallback(bot, query);
+    case LEAGUE_TEAM_UNFOLLOW_CALLBACK_TYPE:
+      return await handleLeagueTeamUnfollowCallback(bot, query);
+    case LEAGUE_TEAM_UNFOLLOW_AND_ADD_CALLBACK_TYPE:
+      return await handleLeagueTeamUnfollowAndAddCallback(bot, query);
     case LEAGUE_GRAPH_CALLBACK_TYPE:
       return await handleLeagueGraphCallback(bot, query);
     default:
@@ -286,6 +298,9 @@ async function handleTeamAssignCallback(bot, query) {
   }
   await azureStorageService.deletePendingTeamAssignment(chatId, uniqueKey);
 
+  // Cross-source rule: adding a screenshot team wipes any followed league teams.
+  await ensureSourceIsScreenshot(bot, chatId);
+
   // Store in cache (team-scoped)
   if (!currentTeamCache[chatId]) {
     currentTeamCache[chatId] = {};
@@ -395,5 +410,93 @@ async function handleLeagueGraphCallback(bot, query) {
   const leagueCode = query.data.split(':')[1];
 
   await sendLeagueGraph(bot, chatId, leagueCode);
+  await bot.answerCallbackQuery(query.id);
+}
+
+async function handleLeagueTeamUnfollowCallback(bot, query) {
+  const chatId = query.message.chat.id;
+  const messageId = query.message.message_id;
+  const teamId = query.data.substring(query.data.indexOf(':') + 1);
+
+  try {
+    const { removed } = await removeFollowedTeam(bot, chatId, teamId);
+    if (!removed) {
+      await bot.editMessageText(
+        t('❌ That followed team no longer exists.', chatId),
+        { chat_id: chatId, message_id: messageId },
+      );
+    } else {
+      await bot.editMessageText(
+        t('✅ Stopped following team {TEAM}.', chatId, { TEAM: teamId }),
+        { chat_id: chatId, message_id: messageId },
+      );
+    }
+  } catch (err) {
+    console.error('Error in unfollow-team callback:', err);
+    await bot.editMessageText(
+      t('❌ Failed to stop following team: {ERROR}', chatId, {
+        ERROR: err.message,
+      }),
+      { chat_id: chatId, message_id: messageId },
+    );
+  }
+
+  await bot.answerCallbackQuery(query.id);
+}
+
+async function handleLeagueTeamUnfollowAndAddCallback(bot, query) {
+  const chatId = query.message.chat.id;
+  const messageId = query.message.message_id;
+  const teamId = query.data.substring(query.data.indexOf(':') + 1);
+
+  let pendingAdd;
+  try {
+    pendingAdd = await azureStorageService.getPendingLeagueTeamAdd(chatId);
+  } catch (err) {
+    console.error('Error reading pending league team add:', err);
+  }
+
+  try {
+    await removeFollowedTeam(bot, chatId, teamId);
+  } catch (err) {
+    console.error('Error removing team during over-cap unfollow:', err);
+    await bot.editMessageText(
+      t('❌ Failed to stop following team: {ERROR}', chatId, {
+        ERROR: err.message,
+      }),
+      { chat_id: chatId, message_id: messageId },
+    );
+    await bot.answerCallbackQuery(query.id);
+
+    return;
+  }
+
+  if (!pendingAdd || !pendingAdd.leagueCode) {
+    await bot.editMessageText(
+      t(
+        '❌ The pending team to follow was lost. Please try /select_team_from_league again.',
+        chatId,
+      ),
+      { chat_id: chatId, message_id: messageId },
+    );
+    await bot.answerCallbackQuery(query.id);
+
+    return;
+  }
+
+  await azureStorageService.deletePendingLeagueTeamAdd(chatId);
+
+  await bot.editMessageText(
+    t('✅ Stopped following team {TEAM}.', chatId, { TEAM: teamId }),
+    { chat_id: chatId, message_id: messageId },
+  );
+
+  await applyLeagueTeamSelection(
+    bot,
+    chatId,
+    pendingAdd.leagueCode,
+    pendingAdd.position,
+  );
+
   await bot.answerCallbackQuery(query.id);
 }

--- a/src/callbackQueryHandler.test.js
+++ b/src/callbackQueryHandler.test.js
@@ -79,7 +79,13 @@ jest.mock('./cache', () => ({
   getPrintableCache: jest.fn(() => 'printable cache'),
   normalizeBestTeamBudgetChangePointsPerMillion: jest.fn(() => ({})),
   clearSelectedBestTeam: jest.fn(() => ({})),
+  clearAllSelectedBestTeams: jest.fn(() => ({})),
   serializeSelectedBestTeamByTeam: jest.fn(() => null),
+  getUserLeagueTeamIds: jest.fn(() => []),
+  getUserScreenshotTeamIds: jest.fn(() => []),
+  getUserTeamIds: jest.fn(() => []),
+  getSelectedTeam: jest.fn(() => null),
+  isLeagueTeamId: jest.fn((id) => typeof id === 'string' && id.includes('_')),
 }));
 
 describe('handleCallbackQuery', () => {

--- a/src/commandsHandler/commandHandlers.js
+++ b/src/commandsHandler/commandHandlers.js
@@ -38,6 +38,7 @@ const {
   COMMAND_UNFOLLOW_LEAGUE,
   COMMAND_LEADERBOARD,
   COMMAND_SELECT_TEAM_FROM_LEAGUE,
+  COMMAND_UNFOLLOW_TEAM,
   COMMAND_LEAGUE_GRAPH,
 } = require('../constants');
 
@@ -89,6 +90,9 @@ const { handleLeaderboardCommand } = require('./leaderboardHandler');
 const {
   handleSelectTeamFromLeagueCommand,
 } = require('./selectTeamFromLeagueHandler');
+const {
+  handleUnfollowTeamCommand,
+} = require('./unfollowTeamHandler');
 const { handleLeagueGraphCommand } = require('./leagueGraphHandler');
 
 // Mapping of command constants to their handler functions
@@ -132,6 +136,7 @@ const COMMAND_HANDLERS = {
   [COMMAND_UNFOLLOW_LEAGUE]: handleUnfollowLeagueCommand,
   [COMMAND_LEADERBOARD]: handleLeaderboardCommand,
   [COMMAND_SELECT_TEAM_FROM_LEAGUE]: handleSelectTeamFromLeagueCommand,
+  [COMMAND_UNFOLLOW_TEAM]: handleUnfollowTeamCommand,
   [COMMAND_LEAGUE_GRAPH]: handleLeagueGraphCommand,
 };
 

--- a/src/commandsHandler/index.js
+++ b/src/commandsHandler/index.js
@@ -50,6 +50,9 @@ const { handleLeaderboardCommand } = require('./leaderboardHandler');
 const {
   handleSelectTeamFromLeagueCommand,
 } = require('./selectTeamFromLeagueHandler');
+const {
+  handleUnfollowTeamCommand,
+} = require('./unfollowTeamHandler');
 const { handleLeagueGraphCommand } = require('./leagueGraphHandler');
 
 module.exports = {
@@ -94,5 +97,6 @@ module.exports = {
   handleUnfollowLeagueCommand,
   handleLeaderboardCommand,
   handleSelectTeamFromLeagueCommand,
+  handleUnfollowTeamCommand,
   handleLeagueGraphCommand,
 };

--- a/src/commandsHandler/selectTeamFromLeagueHandler.js
+++ b/src/commandsHandler/selectTeamFromLeagueHandler.js
@@ -9,15 +9,19 @@ const {
   selectedChipCache,
   userCache,
   leagueTeamsDataCache,
-  clearAllSelectedBestTeams,
+  clearSelectedBestTeam,
   serializeSelectedBestTeamByTeam,
   getPrintableCache,
+  getUserLeagueTeamIds,
 } = require('../cache');
+const { ensureSourceIsLeague } = require('../utils/teamSourceSwitcher');
 const {
   COMMAND_FOLLOW_LEAGUE,
   CURRENT_TEAM_PHOTO_TYPE,
   LEAGUE_TEAM_SELECT_CALLBACK_TYPE,
   LEAGUE_TEAM_PICK_CALLBACK_TYPE,
+  LEAGUE_TEAM_UNFOLLOW_AND_ADD_CALLBACK_TYPE,
+  MAX_FOLLOWED_LEAGUE_TEAMS,
   NAME_TO_CODE_MAPPING,
 } = require('../constants');
 
@@ -168,9 +172,12 @@ async function promptTeamPick(bot, chatId, leagueCode, replyToMessageId) {
 
 /**
  * Apply the user's league team selection:
- * - Remove all existing cached teams (blob + in-memory) for the user
- * - Load the selected league team as the sole active team
- * - Update selectedTeam and persist preferences
+ * - If the user had any screenshot teams, wipe them (cross-source rule).
+ * - If the team is already followed, just switch selectedTeam and notify.
+ * - If the user is at the 6-team cap, stash the pending add and show a picker
+ *   so the user can unfollow one existing team.
+ * - Otherwise, add the team to the existing cache (keeping other followed
+ *   teams intact) and set it as the active team.
  */
 async function applyLeagueTeamSelection(bot, chatId, leagueCode, position) {
   let data;
@@ -212,27 +219,90 @@ async function applyLeagueTeamSelection(bot, chatId, leagueCode, position) {
   }
 
   const teamId = buildTeamId(leagueCode, leagueTeam.teamName);
-  const teamData = mapLeagueTeamToBotTeam(leagueTeam);
+  const leagueLabel = data.leagueName || leagueCode;
+  const teamLabel = leagueTeam.teamName || leagueTeam.userName || teamId;
 
-  // Drop every previously cached team (screenshot or prior league) so the league
-  // team becomes the single active team, matching the rule "work with one source
-  // at a time".
-  try {
-    await azureStorageService.deleteAllUserTeams(bot, chatId);
-  } catch (err) {
-    console.error('Error deleting existing user teams:', err);
+  // If the user already follows this exact team, just switch to it — no
+  // unfollow / cap dance needed.
+  const existingLeagueTeamIds = getUserLeagueTeamIds(chatId);
+  if (existingLeagueTeamIds.includes(teamId)) {
+    const key = String(chatId);
+    if (!userCache[key]) {
+      userCache[key] = {};
+    }
+    userCache[key].selectedTeam = teamId;
+    await updateUserAttributes(chatId, { selectedTeam: teamId });
+
+    await bot.sendMessage(
+      chatId,
+      t('ℹ️ You are already following team {TEAM}. Switched to it.', chatId, {
+        TEAM: teamLabel,
+      }),
+    );
+
+    return;
   }
 
-  delete currentTeamCache[chatId];
-  delete bestTeamsCache[chatId];
-  delete selectedChipCache[chatId];
+  // Cross-source rule: uploading/selecting a league team drops any
+  // screenshot teams so the two sources never coexist.
+  const wipedScreenshotTeams = await ensureSourceIsLeague(bot, chatId);
 
-  currentTeamCache[chatId] = { [teamId]: teamData };
+  // At the cap → stash pending add and show unfollow picker.
+  const leagueTeamIdsAfterWipe = getUserLeagueTeamIds(chatId);
+  if (leagueTeamIdsAfterWipe.length >= MAX_FOLLOWED_LEAGUE_TEAMS) {
+    try {
+      await azureStorageService.savePendingLeagueTeamAdd(chatId, {
+        leagueCode,
+        position: positionNum,
+      });
+    } catch (err) {
+      console.error('Error saving pending league team add:', err);
+      await bot.sendMessage(
+        chatId,
+        t('❌ Failed to save league team: {ERROR}', chatId, {
+          ERROR: err.message,
+        }),
+      );
+
+      return;
+    }
+
+    await promptUnfollowToMakeRoom(bot, chatId, teamLabel);
+
+    return;
+  }
+
+  await followLeagueTeam(bot, chatId, {
+    teamId,
+    leagueTeam,
+    leagueLabel,
+    teamLabel,
+    notifyScreenshotWipe: wipedScreenshotTeams,
+  });
+}
+
+/**
+ * Internal helper: persist and cache a league team as a new followed team,
+ * set it as the active team, and notify the user. Assumes any cap / source /
+ * duplicate checks were already done by the caller.
+ */
+async function followLeagueTeam(
+  bot,
+  chatId,
+  { teamId, leagueTeam, leagueLabel, teamLabel, notifyScreenshotWipe = false },
+) {
+  const teamData = mapLeagueTeamToBotTeam(leagueTeam);
+
+  if (!currentTeamCache[chatId]) {
+    currentTeamCache[chatId] = {};
+  }
+  currentTeamCache[chatId][teamId] = teamData;
 
   try {
     await azureStorageService.saveUserTeam(bot, chatId, teamId, teamData);
   } catch (err) {
     console.error('Error saving league-loaded team:', err);
+    delete currentTeamCache[chatId][teamId];
     await bot.sendMessage(
       chatId,
       t('❌ Failed to save league team: {ERROR}', chatId, {
@@ -248,7 +318,15 @@ async function applyLeagueTeamSelection(bot, chatId, leagueCode, position) {
     userCache[key] = {};
   }
   userCache[key].selectedTeam = teamId;
-  const selectedBestTeamByTeam = clearAllSelectedBestTeams(chatId);
+
+  // Ensure we don't inherit stale best-team / chip state for this teamId.
+  if (bestTeamsCache[chatId]) {
+    delete bestTeamsCache[chatId][teamId];
+  }
+  if (selectedChipCache[chatId]) {
+    delete selectedChipCache[chatId][teamId];
+  }
+  const selectedBestTeamByTeam = clearSelectedBestTeam(chatId, teamId);
 
   await updateUserAttributes(chatId, {
     selectedTeam: teamId,
@@ -257,17 +335,18 @@ async function applyLeagueTeamSelection(bot, chatId, leagueCode, position) {
     ),
   });
 
-  const leagueLabel = data.leagueName || leagueCode;
-  const teamLabel = leagueTeam.teamName || leagueTeam.userName || teamId;
+  const confirmation = notifyScreenshotWipe
+    ? t(
+        '✅ Now following team {TEAM} from league {LEAGUE}. Your previous photo-uploaded teams were cleared.',
+        chatId,
+        { TEAM: teamLabel, LEAGUE: leagueLabel },
+      )
+    : t('✅ Now following team {TEAM} from league {LEAGUE}.', chatId, {
+        TEAM: teamLabel,
+        LEAGUE: leagueLabel,
+      });
 
-  await bot.sendMessage(
-    chatId,
-    t(
-      '✅ Loaded team {TEAM} from league {LEAGUE}. Previous teams have been cleared.',
-      chatId,
-      { TEAM: teamLabel, LEAGUE: leagueLabel },
-    ),
-  );
+  await bot.sendMessage(chatId, confirmation);
 
   await sendMessageToUser(
     bot,
@@ -278,6 +357,50 @@ async function applyLeagueTeamSelection(bot, chatId, leagueCode, position) {
       errorMessageToLog: 'Error sending loaded league team data to user',
     },
   );
+}
+
+async function promptUnfollowToMakeRoom(bot, chatId, newTeamLabel) {
+  const teamIds = getUserLeagueTeamIds(chatId);
+  const keyboard = teamIds.map((teamId) => {
+    const label = formatFollowedTeamLabel(chatId, teamId);
+
+    return [
+      {
+        text: label,
+        callback_data: `${LEAGUE_TEAM_UNFOLLOW_AND_ADD_CALLBACK_TYPE}:${teamId}`,
+      },
+    ];
+  });
+
+  await bot.sendMessage(
+    chatId,
+    t(
+      'You are already following {MAX} league teams. Pick one to unfollow so you can follow {TEAM}:',
+      chatId,
+      { MAX: MAX_FOLLOWED_LEAGUE_TEAMS, TEAM: newTeamLabel },
+    ),
+    { reply_markup: { inline_keyboard: keyboard } },
+  );
+}
+
+/**
+ * Build a human-readable label for a followed league team id.
+ * Falls back gracefully when no league team roster is cached.
+ */
+function formatFollowedTeamLabel(chatId, teamId) {
+  const separatorIdx = teamId.indexOf('_');
+  if (separatorIdx === -1) {
+    return teamId;
+  }
+
+  const leagueCode = teamId.substring(0, separatorIdx);
+  const cachedLeague = leagueTeamsDataCache[leagueCode];
+  const leagueLabel = cachedLeague?.leagueName || leagueCode;
+
+  const teamData = currentTeamCache[chatId]?.[teamId];
+  const teamName = teamData?.teamName || teamId.substring(separatorIdx + 1);
+
+  return `${teamName} — ${leagueLabel}`;
 }
 
 async function handleSelectTeamFromLeagueCommand(bot, msg) {
@@ -351,4 +474,6 @@ module.exports = {
   mapNameToCode,
   buildTeamId,
   sanitizeTeamName,
+  formatFollowedTeamLabel,
+  loadLeagueTeamsData,
 };

--- a/src/commandsHandler/selectTeamFromLeagueHandler.test.js
+++ b/src/commandsHandler/selectTeamFromLeagueHandler.test.js
@@ -22,6 +22,10 @@ jest.mock('../azureStorageService', () => ({
   getLeagueTeamsData: jest.fn(),
   saveUserTeam: jest.fn().mockResolvedValue(),
   deleteAllUserTeams: jest.fn().mockResolvedValue(),
+  deleteUserTeam: jest.fn().mockResolvedValue(),
+  savePendingLeagueTeamAdd: jest.fn().mockResolvedValue(),
+  getPendingLeagueTeamAdd: jest.fn().mockResolvedValue(null),
+  deletePendingLeagueTeamAdd: jest.fn().mockResolvedValue(),
 }));
 
 jest.mock('../userRegistryService', () => ({
@@ -328,19 +332,28 @@ describe('selectTeamFromLeagueHandler', () => {
             { name: 'FER', price: 1 },
           ],
         },
+        {
+          teamName: 'Other',
+          userName: 'Bob',
+          position: 2,
+          budget: 100,
+          transfersRemaining: 0,
+          drivers: [{ name: 'LAW', price: 10, isCaptain: true }],
+          constructors: [],
+        },
       ],
     };
 
     beforeEach(() => {
       azureStorageService.getLeagueTeamsData.mockResolvedValue(leagueData);
-      // Preload existing cached team + selection to prove it's wiped
+    });
+
+    it('wipes screenshot teams and follows the league team when user had only screenshots', async () => {
       cache.currentTeamCache[1] = { T1: { drivers: ['OLD'] } };
       cache.bestTeamsCache[1] = { T1: { bestTeams: [] } };
       cache.selectedChipCache[1] = { T1: 'EXTRA_BOOST' };
       cache.userCache['1'] = { selectedTeam: 'T1' };
-    });
 
-    it('deletes existing teams, loads the picked team, and updates selectedTeam', async () => {
       await applyLeagueTeamSelection(botMock, 1, 'ABC', 1);
 
       expect(azureStorageService.deleteAllUserTeams).toHaveBeenCalledWith(
@@ -372,11 +385,105 @@ describe('selectTeamFromLeagueHandler', () => {
       );
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         1,
-        expect.stringContaining('Loaded team My Team from league Amba'),
+        expect.stringContaining('Now following team My Team from league Amba'),
+      );
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining('photo-uploaded teams were cleared'),
       );
     });
 
+    it('adds the new team WITHOUT wiping existing followed league teams (under the cap)', async () => {
+      cache.currentTeamCache[1] = {
+        XYZ_Existing: { drivers: ['KEEP'] },
+      };
+      cache.userCache['1'] = { selectedTeam: 'XYZ_Existing' };
+
+      await applyLeagueTeamSelection(botMock, 1, 'ABC', 1);
+
+      expect(azureStorageService.deleteAllUserTeams).not.toHaveBeenCalled();
+      // Existing league team still there, new team appended.
+      expect(Object.keys(cache.currentTeamCache[1]).sort()).toEqual(
+        ['ABC_My-Team', 'XYZ_Existing'].sort(),
+      );
+      expect(cache.currentTeamCache[1].XYZ_Existing).toEqual({
+        drivers: ['KEEP'],
+      });
+      expect(cache.userCache['1'].selectedTeam).toBe('ABC_My-Team');
+
+      expect(azureStorageService.saveUserTeam).toHaveBeenCalledWith(
+        botMock,
+        1,
+        'ABC_My-Team',
+        expect.objectContaining({ boost: 'VER' }),
+      );
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining('Now following team My Team from league Amba'),
+      );
+      // The screenshot-wipe notice must NOT appear when we only had league teams.
+      expect(botMock.sendMessage).not.toHaveBeenCalledWith(
+        1,
+        expect.stringContaining('photo-uploaded teams were cleared'),
+      );
+    });
+
+    it('switches to the team (no save/add) when already followed', async () => {
+      cache.currentTeamCache[1] = {
+        'ABC_My-Team': { drivers: ['VER'] },
+        XYZ_Existing: { drivers: ['KEEP'] },
+      };
+      cache.userCache['1'] = { selectedTeam: 'XYZ_Existing' };
+
+      await applyLeagueTeamSelection(botMock, 1, 'ABC', 1);
+
+      expect(azureStorageService.saveUserTeam).not.toHaveBeenCalled();
+      expect(azureStorageService.deleteAllUserTeams).not.toHaveBeenCalled();
+      expect(cache.userCache['1'].selectedTeam).toBe('ABC_My-Team');
+      expect(updateUserAttributes).toHaveBeenCalledWith(1, {
+        selectedTeam: 'ABC_My-Team',
+      });
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining('already following team My Team'),
+      );
+    });
+
+    it('stashes pending add and shows unfollow picker when at the cap', async () => {
+      cache.currentTeamCache[1] = {
+        'L1_A': { drivers: [] },
+        'L1_B': { drivers: [] },
+        'L1_C': { drivers: [] },
+        'L1_D': { drivers: [] },
+        'L1_E': { drivers: [] },
+        'L1_F': { drivers: [] },
+      };
+      cache.userCache['1'] = { selectedTeam: 'L1_A' };
+
+      await applyLeagueTeamSelection(botMock, 1, 'ABC', 1);
+
+      expect(azureStorageService.savePendingLeagueTeamAdd).toHaveBeenCalledWith(
+        1,
+        { leagueCode: 'ABC', position: 1 },
+      );
+      expect(azureStorageService.saveUserTeam).not.toHaveBeenCalled();
+      expect(cache.currentTeamCache[1]['ABC_My-Team']).toBeUndefined();
+
+      // Shows picker with all 6 currently followed teams as UFTA callbacks.
+      const [, , options] = botMock.sendMessage.mock.calls.find(
+        ([, text]) =>
+          typeof text === 'string' &&
+          text.startsWith('You are already following'),
+      );
+      expect(options.reply_markup.inline_keyboard).toHaveLength(6);
+      for (const [button] of options.reply_markup.inline_keyboard) {
+        expect(button.callback_data).toMatch(/^UFTA:L1_/);
+      }
+    });
+
     it('errors gracefully when position does not exist in league', async () => {
+      cache.currentTeamCache[1] = { T1: { drivers: ['OLD'] } };
+
       await applyLeagueTeamSelection(botMock, 1, 'ABC', 99);
 
       expect(botMock.sendMessage).toHaveBeenCalledWith(

--- a/src/commandsHandler/unfollowTeamHandler.js
+++ b/src/commandsHandler/unfollowTeamHandler.js
@@ -1,0 +1,195 @@
+const { t } = require('../i18n');
+const { isAdminMessage, sendLogMessage } = require('../utils/utils');
+const azureStorageService = require('../azureStorageService');
+const { listUserLeagues } = require('../leagueRegistryService');
+const { updateUserAttributes } = require('../userRegistryService');
+const {
+  currentTeamCache,
+  bestTeamsCache,
+  selectedChipCache,
+  userCache,
+  clearSelectedBestTeam,
+  serializeSelectedBestTeamByTeam,
+  getUserLeagueTeamIds,
+  getSelectedTeam,
+} = require('../cache');
+const {
+  COMMAND_SELECT_TEAM_FROM_LEAGUE,
+  COMMAND_UNFOLLOW_TEAM,
+  LEAGUE_TEAM_UNFOLLOW_CALLBACK_TYPE,
+} = require('../constants');
+
+function buildLeagueNameMap(leagues) {
+  const map = {};
+  for (const league of leagues || []) {
+    map[league.leagueCode] = league.leagueName || league.leagueCode;
+  }
+
+  return map;
+}
+
+function extractLeagueCode(teamId) {
+  const separatorIdx = teamId.indexOf('_');
+
+  return separatorIdx === -1 ? null : teamId.substring(0, separatorIdx);
+}
+
+function buildTeamLabel(chatId, teamId, leagueNameByCode) {
+  const leagueCode = extractLeagueCode(teamId);
+  const leagueLabel =
+    (leagueCode && leagueNameByCode[leagueCode]) || leagueCode || '';
+  const teamData = currentTeamCache[chatId]?.[teamId];
+  const fallbackName = leagueCode
+    ? teamId.substring(leagueCode.length + 1)
+    : teamId;
+  const teamName = teamData?.teamName || fallbackName;
+
+  return leagueLabel ? `${teamName} — ${leagueLabel}` : teamName;
+}
+
+async function handleUnfollowTeamCommand(bot, msg) {
+  const chatId = msg.chat.id;
+
+  if (!isAdminMessage(msg)) {
+    await bot.sendMessage(
+      chatId,
+      t('Sorry, only admins can use this command.', chatId),
+    );
+
+    return;
+  }
+
+  // Running /unfollow_team clears any dangling pending-add from an aborted
+  // /select_team_from_league over-cap flow, so subsequent unfollows don't
+  // accidentally resume it.
+  await azureStorageService.deletePendingLeagueTeamAdd(chatId);
+
+  const teamIds = getUserLeagueTeamIds(chatId);
+  if (teamIds.length === 0) {
+    await bot.sendMessage(
+      chatId,
+      t(
+        'You are not following any league teams yet. Run {CMD} to follow one.',
+        chatId,
+        { CMD: COMMAND_SELECT_TEAM_FROM_LEAGUE },
+      ),
+    );
+
+    return;
+  }
+
+  let leagues = [];
+  try {
+    leagues = await listUserLeagues(chatId);
+  } catch (err) {
+    console.error('Error listing user leagues in /unfollow_team:', err);
+  }
+  const leagueNameByCode = buildLeagueNameMap(leagues);
+
+  const keyboard = teamIds.map((teamId) => [
+    {
+      text: buildTeamLabel(chatId, teamId, leagueNameByCode),
+      callback_data: `${LEAGUE_TEAM_UNFOLLOW_CALLBACK_TYPE}:${teamId}`,
+    },
+  ]);
+
+  await bot.sendMessage(
+    chatId,
+    t('Which team do you want to stop following?', chatId),
+    {
+      reply_to_message_id: msg.message_id,
+      reply_markup: { inline_keyboard: keyboard },
+    },
+  );
+}
+
+/**
+ * Remove a followed league team from cache + blob storage and fix up
+ * selectedTeam / best-team state. Shared between the /unfollow_team callback
+ * and the /select_team_from_league over-cap "unfollow-then-add" flow.
+ *
+ * @returns {Promise<{removed: boolean, fallbackSelectedTeam: string|null}>}
+ */
+async function removeFollowedTeam(bot, chatId, teamId) {
+  const teamIds = getUserLeagueTeamIds(chatId);
+  if (!teamIds.includes(teamId)) {
+    return { removed: false, fallbackSelectedTeam: null };
+  }
+
+  try {
+    await azureStorageService.deleteUserTeam(bot, chatId, teamId);
+  } catch (err) {
+    console.error(`Error deleting user team ${teamId} for ${chatId}:`, err);
+    throw err;
+  }
+
+  if (currentTeamCache[chatId]) {
+    delete currentTeamCache[chatId][teamId];
+    if (Object.keys(currentTeamCache[chatId]).length === 0) {
+      delete currentTeamCache[chatId];
+    }
+  }
+  if (bestTeamsCache[chatId]) {
+    delete bestTeamsCache[chatId][teamId];
+    if (Object.keys(bestTeamsCache[chatId]).length === 0) {
+      delete bestTeamsCache[chatId];
+    }
+  }
+  if (selectedChipCache[chatId]) {
+    delete selectedChipCache[chatId][teamId];
+    if (Object.keys(selectedChipCache[chatId]).length === 0) {
+      delete selectedChipCache[chatId];
+    }
+  }
+  const selectedBestTeamByTeam = clearSelectedBestTeam(chatId, teamId);
+
+  // If the removed team was the active one, promote another followed team (or
+  // clear the selection entirely if none remain).
+  let fallbackSelectedTeam = getSelectedTeam(chatId);
+  if (fallbackSelectedTeam === teamId) {
+    const remaining = getUserLeagueTeamIds(chatId);
+    fallbackSelectedTeam = remaining[0] || null;
+
+    const key = String(chatId);
+    if (!userCache[key]) {
+      userCache[key] = {};
+    }
+    if (fallbackSelectedTeam) {
+      userCache[key].selectedTeam = fallbackSelectedTeam;
+    } else {
+      delete userCache[key].selectedTeam;
+    }
+  }
+
+  try {
+    await updateUserAttributes(chatId, {
+      selectedTeam: fallbackSelectedTeam,
+      selectedBestTeamByTeam: serializeSelectedBestTeamByTeam(
+        selectedBestTeamByTeam,
+      ),
+    });
+  } catch (err) {
+    console.error(
+      `Error persisting user attributes after unfollow for ${chatId}:`,
+      err,
+    );
+  }
+
+  await sendLogMessage(
+    bot,
+    `User ${chatId} stopped following team ${teamId}. Active team: ${
+      fallbackSelectedTeam || 'none'
+    }.`,
+  );
+
+  return { removed: true, fallbackSelectedTeam };
+}
+
+module.exports = {
+  handleUnfollowTeamCommand,
+  removeFollowedTeam,
+  buildTeamLabel,
+  buildLeagueNameMap,
+  extractLeagueCode,
+  COMMAND_UNFOLLOW_TEAM,
+};

--- a/src/commandsHandler/unfollowTeamHandler.test.js
+++ b/src/commandsHandler/unfollowTeamHandler.test.js
@@ -1,0 +1,185 @@
+jest.mock('../i18n', () => ({
+  t: jest.fn((key, _chatId, vars) =>
+    vars
+      ? Object.entries(vars).reduce(
+          (acc, [k, v]) => acc.replace(`{${k}}`, v),
+          key,
+        )
+      : key,
+  ),
+}));
+
+jest.mock('../utils/utils', () => ({
+  isAdminMessage: jest.fn(),
+  sendLogMessage: jest.fn().mockResolvedValue(),
+}));
+
+jest.mock('../azureStorageService', () => ({
+  deleteUserTeam: jest.fn().mockResolvedValue(),
+  deletePendingLeagueTeamAdd: jest.fn().mockResolvedValue(),
+}));
+
+jest.mock('../leagueRegistryService', () => ({
+  listUserLeagues: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../userRegistryService', () => ({
+  updateUserAttributes: jest.fn().mockResolvedValue(),
+}));
+
+const {
+  handleUnfollowTeamCommand,
+  removeFollowedTeam,
+} = require('./unfollowTeamHandler');
+const { isAdminMessage } = require('../utils/utils');
+const azureStorageService = require('../azureStorageService');
+const { listUserLeagues } = require('../leagueRegistryService');
+const { updateUserAttributes } = require('../userRegistryService');
+const cache = require('../cache');
+
+describe('unfollowTeamHandler', () => {
+  let botMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    botMock = { sendMessage: jest.fn().mockResolvedValue() };
+    for (const obj of [
+      cache.currentTeamCache,
+      cache.bestTeamsCache,
+      cache.selectedChipCache,
+      cache.userCache,
+    ]) {
+      Object.keys(obj).forEach((k) => delete obj[k]);
+    }
+  });
+
+  describe('handleUnfollowTeamCommand', () => {
+    it('rejects non-admins', async () => {
+      isAdminMessage.mockReturnValue(false);
+
+      await handleUnfollowTeamCommand(botMock, { chat: { id: 9 } });
+
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        9,
+        'Sorry, only admins can use this command.',
+      );
+      expect(azureStorageService.deletePendingLeagueTeamAdd).not.toHaveBeenCalled();
+    });
+
+    it('clears stale pending-add and tells user when no league teams are followed', async () => {
+      isAdminMessage.mockReturnValue(true);
+
+      await handleUnfollowTeamCommand(botMock, { chat: { id: 1 } });
+
+      expect(
+        azureStorageService.deletePendingLeagueTeamAdd,
+      ).toHaveBeenCalledWith(1);
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining('not following any league teams'),
+      );
+    });
+
+    it('ignores screenshot teams and shows picker only for league teams', async () => {
+      isAdminMessage.mockReturnValue(true);
+      cache.currentTeamCache[1] = {
+        T1: { drivers: [] },
+        ABC_My_Team: { teamName: 'My Team' },
+        XYZ_Other: { teamName: 'Other' },
+      };
+      listUserLeagues.mockResolvedValueOnce([
+        { leagueCode: 'ABC', leagueName: 'Amba' },
+        { leagueCode: 'XYZ', leagueName: 'Xander' },
+      ]);
+
+      await handleUnfollowTeamCommand(botMock, {
+        chat: { id: 1 },
+        message_id: 42,
+      });
+
+      const call = botMock.sendMessage.mock.calls.find(
+        ([, text]) =>
+          typeof text === 'string' && text.includes('stop following'),
+      );
+      expect(call).toBeDefined();
+      const [, , options] = call;
+      const rows = options.reply_markup.inline_keyboard;
+      expect(rows).toHaveLength(2);
+      const buttons = rows.map((r) => r[0]);
+      expect(buttons.map((b) => b.callback_data).sort()).toEqual(
+        ['UFT:ABC_My_Team', 'UFT:XYZ_Other'].sort(),
+      );
+      expect(buttons.find((b) => b.callback_data === 'UFT:ABC_My_Team').text)
+        .toContain('My Team');
+      expect(buttons.find((b) => b.callback_data === 'UFT:ABC_My_Team').text)
+        .toContain('Amba');
+    });
+  });
+
+  describe('removeFollowedTeam', () => {
+    it('no-ops when teamId is not followed', async () => {
+      cache.currentTeamCache[1] = { ABC_Other: {} };
+
+      const result = await removeFollowedTeam(botMock, 1, 'XYZ_Missing');
+
+      expect(result.removed).toBe(false);
+      expect(azureStorageService.deleteUserTeam).not.toHaveBeenCalled();
+    });
+
+    it('removes the team, picks a fallback, and persists', async () => {
+      cache.currentTeamCache[1] = {
+        ABC_A: { teamName: 'A' },
+        XYZ_B: { teamName: 'B' },
+      };
+      cache.bestTeamsCache[1] = { ABC_A: {} };
+      cache.selectedChipCache[1] = { ABC_A: 'EXTRA_BOOST' };
+      cache.userCache['1'] = { selectedTeam: 'ABC_A' };
+
+      const result = await removeFollowedTeam(botMock, 1, 'ABC_A');
+
+      expect(result.removed).toBe(true);
+      expect(result.fallbackSelectedTeam).toBe('XYZ_B');
+      expect(azureStorageService.deleteUserTeam).toHaveBeenCalledWith(
+        botMock,
+        1,
+        'ABC_A',
+      );
+      expect(cache.currentTeamCache[1]).toEqual({ XYZ_B: { teamName: 'B' } });
+      expect(cache.bestTeamsCache[1]).toBeUndefined();
+      expect(cache.selectedChipCache[1]).toBeUndefined();
+      expect(cache.userCache['1'].selectedTeam).toBe('XYZ_B');
+      expect(updateUserAttributes).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ selectedTeam: 'XYZ_B' }),
+      );
+    });
+
+    it('clears selectedTeam when the last followed team is removed', async () => {
+      cache.currentTeamCache[1] = { ABC_A: {} };
+      cache.userCache['1'] = { selectedTeam: 'ABC_A' };
+
+      const result = await removeFollowedTeam(botMock, 1, 'ABC_A');
+
+      expect(result.removed).toBe(true);
+      expect(result.fallbackSelectedTeam).toBeNull();
+      expect(cache.currentTeamCache[1]).toBeUndefined();
+      expect(cache.userCache['1'].selectedTeam).toBeUndefined();
+      expect(updateUserAttributes).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ selectedTeam: null }),
+      );
+    });
+
+    it('keeps the existing selectedTeam when removing a non-active team', async () => {
+      cache.currentTeamCache[1] = {
+        ABC_A: {},
+        XYZ_B: {},
+      };
+      cache.userCache['1'] = { selectedTeam: 'XYZ_B' };
+
+      await removeFollowedTeam(botMock, 1, 'ABC_A');
+
+      expect(cache.userCache['1'].selectedTeam).toBe('XYZ_B');
+    });
+  });
+});

--- a/src/constants.js
+++ b/src/constants.js
@@ -36,6 +36,13 @@ exports.LEAGUE_UNFOLLOW_CALLBACK_TYPE = 'LEAGUE_UNFOLLOW';
 exports.LEAGUE_TEAM_SELECT_CALLBACK_TYPE = 'LEAGUE_TEAM_SELECT';
 exports.LEAGUE_TEAM_PICK_CALLBACK_TYPE = 'LEAGUE_TEAM_PICK';
 exports.LEAGUE_GRAPH_CALLBACK_TYPE = 'LEAGUE_GRAPH';
+// Kept short (3 chars) so the callback data stays under the 64-byte Telegram
+// limit even when teamIds are near their max of `{leagueCode}_{sanitizedName}`
+// (leagueCode up to ~15 chars, sanitized name up to 40 chars).
+exports.LEAGUE_TEAM_UNFOLLOW_CALLBACK_TYPE = 'UFT';
+exports.LEAGUE_TEAM_UNFOLLOW_AND_ADD_CALLBACK_TYPE = 'UFTA';
+
+exports.MAX_FOLLOWED_LEAGUE_TEAMS = 6;
 
 exports.MAX_TELEGRAM_MESSAGE_LENGTH = 4096;
 exports.BEST_TEAMS_RESULT_COUNT = 15;
@@ -79,6 +86,7 @@ exports.COMMAND_FOLLOW_LEAGUE = '/follow_league';
 exports.COMMAND_UNFOLLOW_LEAGUE = '/unfollow_league';
 exports.COMMAND_LEADERBOARD = '/leaderboard';
 exports.COMMAND_SELECT_TEAM_FROM_LEAGUE = '/select_team_from_league';
+exports.COMMAND_UNFOLLOW_TEAM = '/unfollow_team';
 exports.COMMAND_LEAGUE_GRAPH = '/league_graph';
 
 // Menu configuration for interactive menu command
@@ -301,7 +309,12 @@ exports.MENU_CATEGORIES = {
         constant: exports.COMMAND_SELECT_TEAM_FROM_LEAGUE,
         title: '🎯 Select Team From League',
         description:
-          'Load a team roster from a followed league as your active team (replaces existing teams)',
+          'Follow a team roster from a followed league (up to 6 followed teams)',
+      },
+      {
+        constant: exports.COMMAND_UNFOLLOW_TEAM,
+        title: '🗑️ Unfollow Team',
+        description: 'Stop following a league team',
       },
       {
         constant: exports.COMMAND_LEAGUE_GRAPH,

--- a/src/photoProcessingService.js
+++ b/src/photoProcessingService.js
@@ -20,6 +20,9 @@ const {
 } = require('./constants');
 const { sendLogMessage, sendMessageToUser } = require('./utils');
 const { t } = require('./i18n');
+const {
+  ensureSourceIsScreenshot,
+} = require('./utils/teamSourceSwitcher');
 
 async function processPhotoByType(
   bot,
@@ -126,6 +129,10 @@ async function storeInCache(bot, chatId, type, extractedData, fileUniqueId) {
 
       return null;
     }
+
+    // Cross-source rule: uploading a screenshot drops any previously
+    // followed league teams so the two sources never coexist.
+    await ensureSourceIsScreenshot(bot, chatId);
 
     if (!currentTeamCache[chatId]) {
       currentTeamCache[chatId] = {};

--- a/src/textMessageHandler.js
+++ b/src/textMessageHandler.js
@@ -41,6 +41,7 @@ const {
   handleUnfollowLeagueCommand,
   handleLeaderboardCommand,
   handleSelectTeamFromLeagueCommand,
+  handleUnfollowTeamCommand,
   handleLeagueGraphCommand,
 } = require('./commandsHandler');
 
@@ -85,6 +86,7 @@ const {
   COMMAND_UNFOLLOW_LEAGUE,
   COMMAND_LEADERBOARD,
   COMMAND_SELECT_TEAM_FROM_LEAGUE,
+  COMMAND_UNFOLLOW_TEAM,
   COMMAND_LEAGUE_GRAPH,
 } = require('./constants');
 
@@ -180,6 +182,8 @@ exports.handleTextMessage = async function (bot, msg) {
       return await handleLeaderboardCommand(bot, msg);
     case msg.text === COMMAND_SELECT_TEAM_FROM_LEAGUE:
       return await handleSelectTeamFromLeagueCommand(bot, msg);
+    case msg.text === COMMAND_UNFOLLOW_TEAM:
+      return await handleUnfollowTeamCommand(bot, msg);
     case msg.text === COMMAND_LEAGUE_GRAPH:
       return await handleLeagueGraphCommand(bot, msg);
     default:

--- a/src/translations.js
+++ b/src/translations.js
@@ -462,8 +462,10 @@ const translations = {
     'Follow and view F1 Fantasy leagues':
       'עקוב וצפה בליגות F1 Fantasy',
     '🎯 Select Team From League': '🎯 בחר קבוצה מליגה',
-    'Load a team roster from a followed league as your active team (replaces existing teams)':
-      'טען הרכב של קבוצה מליגה שאתה עוקב אחריה ככבוצה הפעילה שלך (מוחק את הקבוצות הקיימות)',
+    'Follow a team roster from a followed league (up to 6 followed teams)':
+      'עקוב אחר קבוצה מליגה שאתה עוקב אחריה (עד 6 קבוצות במקביל)',
+    '🗑️ Unfollow Team': '🗑️ הפסק לעקוב אחר קבוצה',
+    'Stop following a league team': 'הפסק לעקוב אחר קבוצת ליגה',
     'Which league do you want to select a team from?':
       'מאיזו ליגה ברצונך לבחור קבוצה?',
     'Which team do you want to load?': 'איזו קבוצה ברצונך לטעון?',
@@ -475,8 +477,25 @@ const translations = {
       '❌ לא הצלחתי למצוא את הקבוצה הזו בליגה יותר.',
     '❌ Failed to save league team: {ERROR}':
       '❌ שמירת קבוצת הליגה נכשלה: {ERROR}',
-    '✅ Loaded team {TEAM} from league {LEAGUE}. Previous teams have been cleared.':
-      '✅ נטענה הקבוצה {TEAM} מהליגה {LEAGUE}. הקבוצות הקודמות נמחקו.',
+    '✅ Now following team {TEAM} from league {LEAGUE}.':
+      '✅ כעת עוקב אחר הקבוצה {TEAM} מהליגה {LEAGUE}.',
+    '✅ Now following team {TEAM} from league {LEAGUE}. Your previous photo-uploaded teams were cleared.':
+      '✅ כעת עוקב אחר הקבוצה {TEAM} מהליגה {LEAGUE}. הקבוצות שהועלו מתמונות נמחקו.',
+    'ℹ️ You are already following team {TEAM}. Switched to it.':
+      'ℹ️ אתה כבר עוקב אחר הקבוצה {TEAM}. עברתי אליה.',
+    'You are already following {MAX} league teams. Pick one to unfollow so you can follow {TEAM}:':
+      'אתה עוקב כבר אחר {MAX} קבוצות ליגה. בחר אחת להפסיק לעקוב כדי לעקוב אחר {TEAM}:',
+    'Which team do you want to stop following?':
+      'איזו קבוצה ברצונך להפסיק לעקוב אחריה?',
+    'You are not following any league teams yet. Run {CMD} to follow one.':
+      'אתה עדיין לא עוקב אחר אף קבוצת ליגה. הפעל {CMD} כדי לעקוב אחר קבוצה.',
+    '✅ Stopped following team {TEAM}.': '✅ הפסקת לעקוב אחר הקבוצה {TEAM}.',
+    '❌ Failed to stop following team: {ERROR}':
+      '❌ הפסקת המעקב אחר הקבוצה נכשלה: {ERROR}',
+    '❌ That followed team no longer exists.':
+      '❌ הקבוצה שעקבת אחריה כבר לא קיימת.',
+    '❌ The pending team to follow was lost. Please try /select_team_from_league again.':
+      '❌ הקבוצה שהמתנת להוסיף אבדה. אנא נסה שוב את /select_team_from_league.',
     'To find your league code: go to the F1 Fantasy website, open the league you want to follow, click the share button, and copy the league code from there.':
       'כדי למצוא את קוד הליגה: היכנס לאתר \u2066F1 Fantasy\u2069, פתח את הליגה שברצונך לעקוב אחריה, לחץ על כפתור השיתוף והעתק את קוד הליגה משם.',
     '📩 If the code is correct but the league is not yet tracked, please report it to the admins via /report_bug with the league code and we will add the bot to the league as soon as possible.':

--- a/src/utils/teamSourceSwitcher.js
+++ b/src/utils/teamSourceSwitcher.js
@@ -1,0 +1,81 @@
+const azureStorageService = require('../azureStorageService');
+const {
+  currentTeamCache,
+  bestTeamsCache,
+  selectedChipCache,
+  userCache,
+  clearAllSelectedBestTeams,
+  getUserLeagueTeamIds,
+  getUserScreenshotTeamIds,
+} = require('../cache');
+
+/**
+ * Wipe every cached team for a user (blob + in-memory), including chip,
+ * best-team and selected-best-team state. Also clears selectedTeam in
+ * userCache. Caller is responsible for persisting userCache via
+ * updateUserAttributes() afterwards if needed.
+ *
+ * @param {Object} bot - Telegram bot instance (required for blob delete logs)
+ * @param {string|number} chatId
+ */
+async function wipeAllTeams(bot, chatId) {
+  try {
+    await azureStorageService.deleteAllUserTeams(bot, chatId);
+  } catch (err) {
+    console.error('Error deleting existing user teams:', err);
+  }
+
+  delete currentTeamCache[chatId];
+  delete bestTeamsCache[chatId];
+  delete selectedChipCache[chatId];
+
+  const key = String(chatId);
+  if (userCache[key]) {
+    delete userCache[key].selectedTeam;
+  }
+  clearAllSelectedBestTeams(chatId);
+}
+
+/**
+ * Ensure the user's cache only contains league-sourced teams. If any
+ * screenshot (T1/T2/T3) team is present, wipe everything. Returns true when
+ * a wipe happened.
+ *
+ * @param {Object} bot
+ * @param {string|number} chatId
+ * @returns {Promise<boolean>}
+ */
+async function ensureSourceIsLeague(bot, chatId) {
+  if (getUserScreenshotTeamIds(chatId).length === 0) {
+    return false;
+  }
+
+  await wipeAllTeams(bot, chatId);
+
+  return true;
+}
+
+/**
+ * Ensure the user's cache only contains screenshot-sourced teams. If any
+ * league team is present, wipe everything. Returns true when a wipe
+ * happened.
+ *
+ * @param {Object} bot
+ * @param {string|number} chatId
+ * @returns {Promise<boolean>}
+ */
+async function ensureSourceIsScreenshot(bot, chatId) {
+  if (getUserLeagueTeamIds(chatId).length === 0) {
+    return false;
+  }
+
+  await wipeAllTeams(bot, chatId);
+
+  return true;
+}
+
+module.exports = {
+  wipeAllTeams,
+  ensureSourceIsLeague,
+  ensureSourceIsScreenshot,
+};


### PR DESCRIPTION
## Summary

Users can now follow **up to 6 league teams** simultaneously (same or different leagues), with a new `/unfollow_team` command to stop following one.

## Behavior changes

- **`/select_team_from_league`** now **adds** the picked team to the user's followed league teams instead of replacing all existing teams.
  - Cap: `MAX_FOLLOWED_LEAGUE_TEAMS = 6`.
  - If already followed → just switches `selectedTeam` to it.
  - If at cap → stashes the pending add in `pending-league-team-adds/{chatId}.json` and shows an inline unfollow-and-add picker (`UFTA` callback); picking a team unfollows it and resumes the add.
- **`/unfollow_team`** (admin-only, new): shows an inline picker of the user's followed league teams. Selecting one removes it from cache + blob storage; if it was the active team, the next remaining league team is promoted (or `selectedTeam` cleared when none remain).
- **Cross-source exclusivity preserved:** league teams and screenshot teams (`T1`/`T2`/`T3`) still cannot coexist. Adding a team from either source wipes the other source first, centralized in `src/utils/teamSourceSwitcher.js`.

## Implementation highlights

- Short callback-data type names (`UFT` / `UFTA`) to stay under Telegram's 64-byte `callback_data` limit given league `teamId`s can reach ~55 chars.
- New cache helpers: `isLeagueTeamId`, `getUserLeagueTeamIds`, `getUserScreenshotTeamIds`.
- Shared `removeFollowedTeam` helper used by both the plain `UFT` and the `UFTA` resume-add flow.
- Running `/unfollow_team` clears any dangling pending-add blob so an abandoned over-cap flow doesn't accidentally resume.

## Tests

- Rewrote `selectTeamFromLeagueHandler.test.js` for the new add-without-replace behavior, duplicate-switch, screenshot-source-wipe, and cap-hit pending-add flow.
- Added `unfollowTeamHandler.test.js` (7 new tests covering admin guard, empty state, picker rendering, and `removeFollowedTeam` edge cases).
- Updated `callbackQueryHandler.test.js` mock for new cache helpers.

**60 test suites, 571 tests passing · lint clean.**

## Docs

- `AGENTS.md` updated: 6-team cap, cross-source wipe rule, `/unfollow_team`, new callback types, pending-add blob.