### PR TITLE
Clarify League Graph text and add Hebrew translations

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -320,7 +320,7 @@ exports.MENU_CATEGORIES = {
         constant: exports.COMMAND_LEAGUE_GRAPH,
         title: '📈 League Graph',
         description:
-          'Render a line chart of cumulative score per race for every team in a followed league',
+          'Render a line chart of gap to leader per race for every team in a followed league',
       },
     ],
   },

--- a/src/translations.js
+++ b/src/translations.js
@@ -466,6 +466,9 @@ const translations = {
       'עקוב אחר קבוצה מליגה שאתה עוקב אחריה (עד 6 קבוצות במקביל)',
     '🗑️ Unfollow Team': '🗑️ הפסק לעקוב אחר קבוצה',
     'Stop following a league team': 'הפסק לעקוב אחר קבוצת ליגה',
+    '📈 League Graph': '📈 גרף ליגה',
+    'Render a line chart of gap to leader per race for every team in a followed league':
+      'צייר גרף קווי של הפער מהמוביל בכל מרוץ עבור כל קבוצה בליגה במעקב',
     'Which league do you want to select a team from?':
       'מאיזו ליגה ברצונך לבחור קבוצה?',
     'Which team do you want to load?': 'איזו קבוצה ברצונך לטעון?',


### PR DESCRIPTION
### Motivation
- Clarify the intent of the `📈 League Graph` menu item to indicate it shows the gap-to-leader per race and provide matching Hebrew translations.

### Description
- Update `src/constants.js` to change the `📈 League Graph` description from a cumulative score chart to a gap-to-leader per race chart and add corresponding Hebrew entries in `src/translations.js` for the menu title and description.

### Testing
- Ran the existing automated test suite with `npm test` and project linters with `npm run lint`, and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7dc5a3bc832fb303e1c661320a13)