### PR TITLE
Bold selected team row in league leaderboard

### DIFF
--- a/src/cacheInitializer.js
+++ b/src/cacheInitializer.js
@@ -30,10 +30,8 @@ const {
 } = require('./azureStorageService');
 const { listAllUsers } = require('./userRegistryService');
 const { fetchRemainingRaceCount } = require('./raceScheduleService');
-const {
-  mapLeagueTeamToBotTeam,
-  sanitizeTeamName,
-} = require('./commandsHandler/selectTeamFromLeagueHandler');
+const { sanitizeTeamName } = require('./utils/teamId');
+const { mapLeagueTeamToBotTeam } = require('./commandsHandler/selectTeamFromLeagueHandler');
 
 /**
  * Initialize all application caches with data from Azure Storage

--- a/src/commandsHandler/leaderboardHandler.js
+++ b/src/commandsHandler/leaderboardHandler.js
@@ -3,26 +3,11 @@ const { isAdminMessage } = require('../utils/utils');
 const { listUserLeagues } = require('../leagueRegistryService');
 const { getLeagueData } = require('../azureStorageService');
 const { getSelectedTeam } = require('../cache');
+const { buildTeamId } = require('../utils/teamId');
 const {
   LEAGUE_CALLBACK_TYPE,
   COMMAND_FOLLOW_LEAGUE,
 } = require('../constants');
-
-function sanitizeTeamName(name) {
-  const base = String(name || 'team')
-    .normalize('NFKD')
-    .replace(/[^\w-]+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
-
-  const trimmed = base.length > 0 ? base : 'team';
-
-  return trimmed.slice(0, 40);
-}
-
-function buildTeamId(leagueCode, teamName) {
-  return `${leagueCode}_${sanitizeTeamName(teamName)}`;
-}
 
 function escapeHtml(value) {
   return String(value)

--- a/src/commandsHandler/leaderboardHandler.js
+++ b/src/commandsHandler/leaderboardHandler.js
@@ -2,10 +2,34 @@ const { t } = require('../i18n');
 const { isAdminMessage } = require('../utils/utils');
 const { listUserLeagues } = require('../leagueRegistryService');
 const { getLeagueData } = require('../azureStorageService');
+const { getSelectedTeam } = require('../cache');
 const {
   LEAGUE_CALLBACK_TYPE,
   COMMAND_FOLLOW_LEAGUE,
 } = require('../constants');
+
+function sanitizeTeamName(name) {
+  const base = String(name || 'team')
+    .normalize('NFKD')
+    .replace(/[^\w-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+
+  const trimmed = base.length > 0 ? base : 'team';
+
+  return trimmed.slice(0, 40);
+}
+
+function buildTeamId(leagueCode, teamName) {
+  return `${leagueCode}_${sanitizeTeamName(teamName)}`;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
 
 /**
  * Render a compact leaderboard message from the blob payload.
@@ -18,12 +42,13 @@ const {
 function formatLeaderboard(leagueData, chatId) {
   const teams = Array.isArray(leagueData.teams) ? [...leagueData.teams] : [];
   teams.sort((a, b) => (a.position || 0) - (b.position || 0));
+  const selectedTeamId = getSelectedTeam(chatId);
 
   const header =
-    `🏆 ${leagueData.leagueName || leagueData.leagueCode}\n` +
+    `🏆 ${escapeHtml(leagueData.leagueName || leagueData.leagueCode)}\n` +
     t('👥 {COUNT} teams · updated {TIME}', chatId, {
       COUNT: String(leagueData.memberCount ?? teams.length),
-      TIME: leagueData.fetchedAt || '',
+      TIME: escapeHtml(leagueData.fetchedAt || ''),
     });
 
   if (teams.length === 0) {
@@ -34,10 +59,15 @@ function formatLeaderboard(leagueData, chatId) {
   const posWidth = String(maxPos).length;
   const lines = teams.map((team) => {
     const pos = String(team.position ?? '?').padStart(posWidth, ' ');
-    const name = team.teamName || team.userName || '—';
+    const name = escapeHtml(team.teamName || team.userName || '—');
     const score = team.totalScore ?? 0;
+    const line = ` ${pos}. ${name} — ${escapeHtml(score)}`;
+    const teamId = buildTeamId(
+      leagueData.leagueCode,
+      team.teamName || team.userName || 'team',
+    );
 
-    return ` ${pos}. ${name} — ${score}`;
+    return teamId === selectedTeamId ? `<b>${line}</b>` : line;
   });
 
   return `${header}\n\n${lines.join('\n')}`;
@@ -71,7 +101,9 @@ async function sendLeaderboard(bot, chatId, leagueCode) {
     return;
   }
 
-  await bot.sendMessage(chatId, formatLeaderboard(leagueData, chatId));
+  await bot.sendMessage(chatId, formatLeaderboard(leagueData, chatId), {
+    parse_mode: 'HTML',
+  });
 }
 
 async function handleLeaderboardCommand(bot, msg) {

--- a/src/commandsHandler/leaderboardHandler.test.js
+++ b/src/commandsHandler/leaderboardHandler.test.js
@@ -27,9 +27,14 @@ jest.mock('../azureStorageService', () => ({
   getLeagueData: jest.fn(),
 }));
 
+jest.mock('../cache', () => ({
+  getSelectedTeam: jest.fn(),
+}));
+
 const { isAdminMessage } = require('../utils/utils');
 const { listUserLeagues } = require('../leagueRegistryService');
 const { getLeagueData } = require('../azureStorageService');
+const { getSelectedTeam } = require('../cache');
 
 describe('leaderboardHandler', () => {
   let botMock;
@@ -40,6 +45,10 @@ describe('leaderboardHandler', () => {
   });
 
   describe('formatLeaderboard', () => {
+    beforeEach(() => {
+      getSelectedTeam.mockReturnValue(null);
+    });
+
     it('produces header + position-sorted rows', () => {
       const data = {
         leagueName: 'Amba',
@@ -73,6 +82,25 @@ describe('leaderboardHandler', () => {
       );
 
       expect(output).toContain('No teams in this league yet.');
+    });
+
+    it('bolds the selected team row', () => {
+      getSelectedTeam.mockReturnValue('ABC_A');
+
+      const output = formatLeaderboard(
+        {
+          leagueName: 'Amba',
+          leagueCode: 'ABC',
+          teams: [
+            { teamName: 'A', totalScore: 900, position: 1 },
+            { teamName: 'B', totalScore: 800, position: 2 },
+          ],
+        },
+        1,
+      );
+
+      expect(output).toContain('<b> 1. A — 900</b>');
+      expect(output).toContain(' 2. B — 800');
     });
   });
 
@@ -119,6 +147,7 @@ describe('leaderboardHandler', () => {
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         1,
         expect.stringContaining('🏆 Amba'),
+        { parse_mode: 'HTML' },
       );
     });
 

--- a/src/commandsHandler/leagueGraphHandler.js
+++ b/src/commandsHandler/leagueGraphHandler.js
@@ -180,7 +180,7 @@ function buildChartConfig(leagueData, options = {}) {
     const teamLabel = team.teamName || team.userName || `Team ${idx + 1}`;
 
     return {
-      label: isSelectedTeam ? `👉 ${teamLabel}` : teamLabel,
+      label: teamLabel,
       data,
       borderColor: color,
       backgroundColor: color,

--- a/src/commandsHandler/leagueGraphHandler.js
+++ b/src/commandsHandler/leagueGraphHandler.js
@@ -7,6 +7,7 @@ const { getLeagueData } = require('../azureStorageService');
 const { fetchCurrentSeasonRaces } = require('../raceScheduleService');
 const { getChipEmoji } = require('../utils/chipEmojis');
 const { getSelectedTeam } = require('../cache');
+const { buildTeamId } = require('../utils/teamId');
 const {
   LEAGUE_GRAPH_CALLBACK_TYPE,
   COMMAND_FOLLOW_LEAGUE,
@@ -27,22 +28,6 @@ const TEAM_COLOR_PALETTE = [
   '#000075', // navy
   '#a9a9a9', // grey
 ];
-
-function sanitizeTeamName(name) {
-  const base = String(name || 'team')
-    .normalize('NFKD')
-    .replace(/[^\w-]+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
-
-  const trimmed = base.length > 0 ? base : 'team';
-
-  return trimmed.slice(0, 40);
-}
-
-function buildTeamId(leagueCode, teamName) {
-  return `${leagueCode}_${sanitizeTeamName(teamName)}`;
-}
 
 /**
  * Extract matchday keys from a teams array and sort them by trailing numeric id.

--- a/src/commandsHandler/leagueGraphHandler.js
+++ b/src/commandsHandler/leagueGraphHandler.js
@@ -6,6 +6,7 @@ const { listUserLeagues } = require('../leagueRegistryService');
 const { getLeagueData } = require('../azureStorageService');
 const { fetchCurrentSeasonRaces } = require('../raceScheduleService');
 const { getChipEmoji } = require('../utils/chipEmojis');
+const { getSelectedTeam } = require('../cache');
 const {
   LEAGUE_GRAPH_CALLBACK_TYPE,
   COMMAND_FOLLOW_LEAGUE,
@@ -26,6 +27,22 @@ const TEAM_COLOR_PALETTE = [
   '#000075', // navy
   '#a9a9a9', // grey
 ];
+
+function sanitizeTeamName(name) {
+  const base = String(name || 'team')
+    .normalize('NFKD')
+    .replace(/[^\w-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+
+  const trimmed = base.length > 0 ? base : 'team';
+
+  return trimmed.slice(0, 40);
+}
+
+function buildTeamId(leagueCode, teamName) {
+  return `${leagueCode}_${sanitizeTeamName(teamName)}`;
+}
 
 /**
  * Extract matchday keys from a teams array and sort them by trailing numeric id.
@@ -98,6 +115,7 @@ function buildRoundToRaceNameMap(seasonData) {
  */
 function buildChartConfig(leagueData, options = {}) {
   const roundToRaceName = options.roundToRaceName || {};
+  const selectedTeamId = options.selectedTeamId || null;
 
   const teams = Array.isArray(leagueData?.teams) ? [...leagueData.teams] : [];
   teams.sort((a, b) => (a.position || 0) - (b.position || 0));
@@ -141,6 +159,11 @@ function buildChartConfig(leagueData, options = {}) {
 
   const datasets = teams.map((team, idx) => {
     const color = TEAM_COLOR_PALETTE[idx % TEAM_COLOR_PALETTE.length];
+    const teamId = buildTeamId(
+      leagueData?.leagueCode,
+      team.teamName || team.userName || 'team',
+    );
+    const isSelectedTeam = teamId === selectedTeamId;
     const cumulative = cumulativeByTeam[idx];
     // Gap to leader at each step: leader is 0, everyone else is <= 0.
     const data = cumulative.map((value, i) => value - leaderPerStep[i]);
@@ -174,10 +197,13 @@ function buildChartConfig(leagueData, options = {}) {
       data,
       borderColor: color,
       backgroundColor: color,
+      borderWidth: isSelectedTeam ? 5 : 2,
       fill: false,
       tension: 0.25,
-      pointRadius,
-      pointHoverRadius: pointRadius,
+      pointRadius: pointRadius.map((radius) => (isSelectedTeam ? radius + 2 : radius)),
+      pointHoverRadius: pointRadius.map((radius) =>
+        isSelectedTeam ? radius + 2 : radius,
+      ),
       pointBorderWidth,
       chipLabels,
       datalabels: {
@@ -289,7 +315,11 @@ async function sendLeagueGraph(bot, chatId, leagueCode) {
     console.error('Error fetching season schedule for graph labels:', err);
   }
 
-  const config = buildChartConfig(leagueData, { roundToRaceName });
+  const selectedTeamId = getSelectedTeam(chatId);
+  const config = buildChartConfig(leagueData, {
+    roundToRaceName,
+    selectedTeamId,
+  });
 
   const chart = new QuickChart();
   chart

--- a/src/commandsHandler/leagueGraphHandler.js
+++ b/src/commandsHandler/leagueGraphHandler.js
@@ -29,6 +29,24 @@ const TEAM_COLOR_PALETTE = [
   '#a9a9a9', // grey
 ];
 
+function toBoldUnicode(text) {
+  return String(text).replace(/[A-Za-z0-9]/g, (char) => {
+    const code = char.codePointAt(0);
+
+    if (code >= 65 && code <= 90) {
+      return String.fromCodePoint(0x1d5d4 + (code - 65));
+    }
+    if (code >= 97 && code <= 122) {
+      return String.fromCodePoint(0x1d5ee + (code - 97));
+    }
+    if (code >= 48 && code <= 57) {
+      return String.fromCodePoint(0x1d7ec + (code - 48));
+    }
+
+    return char;
+  });
+}
+
 /**
  * Extract matchday keys from a teams array and sort them by trailing numeric id.
  * Accepts keys like `matchday_1`, `matchday_10` — sorts numerically, not lexically.
@@ -177,8 +195,10 @@ function buildChartConfig(leagueData, options = {}) {
       pointBorderWidth[idxInSeries] = 2;
     }
 
+    const teamLabel = team.teamName || team.userName || `Team ${idx + 1}`;
+
     return {
-      label: team.teamName || team.userName || `Team ${idx + 1}`,
+      label: isSelectedTeam ? toBoldUnicode(teamLabel) : teamLabel,
       data,
       borderColor: color,
       backgroundColor: color,

--- a/src/commandsHandler/leagueGraphHandler.js
+++ b/src/commandsHandler/leagueGraphHandler.js
@@ -29,24 +29,6 @@ const TEAM_COLOR_PALETTE = [
   '#a9a9a9', // grey
 ];
 
-function toBoldUnicode(text) {
-  return String(text).replace(/[A-Za-z0-9]/g, (char) => {
-    const code = char.codePointAt(0);
-
-    if (code >= 65 && code <= 90) {
-      return String.fromCodePoint(0x1d5d4 + (code - 65));
-    }
-    if (code >= 97 && code <= 122) {
-      return String.fromCodePoint(0x1d5ee + (code - 97));
-    }
-    if (code >= 48 && code <= 57) {
-      return String.fromCodePoint(0x1d7ec + (code - 48));
-    }
-
-    return char;
-  });
-}
-
 /**
  * Extract matchday keys from a teams array and sort them by trailing numeric id.
  * Accepts keys like `matchday_1`, `matchday_10` — sorts numerically, not lexically.
@@ -198,7 +180,7 @@ function buildChartConfig(leagueData, options = {}) {
     const teamLabel = team.teamName || team.userName || `Team ${idx + 1}`;
 
     return {
-      label: isSelectedTeam ? toBoldUnicode(teamLabel) : teamLabel,
+      label: isSelectedTeam ? `👉 ${teamLabel}` : teamLabel,
       data,
       borderColor: color,
       backgroundColor: color,

--- a/src/commandsHandler/leagueGraphHandler.test.js
+++ b/src/commandsHandler/leagueGraphHandler.test.js
@@ -334,7 +334,7 @@ describe('leagueGraphHandler', () => {
       const selectedTeamId = 'C8EFGOXCB04_Cooperon';
       const config = buildChartConfig(FIXTURE, { selectedTeamId });
 
-      expect(config.data.datasets[0].label).toBe('𝗖𝗼𝗼𝗽𝗲𝗿𝗼𝗻');
+      expect(config.data.datasets[0].label).toBe('👉 Cooperon');
       expect(config.data.datasets[0].borderWidth).toBe(5);
       expect(config.data.datasets[1].borderWidth).toBe(2);
       expect(config.data.datasets[0].pointRadius).toEqual([5, 9, 9]);
@@ -473,7 +473,7 @@ describe('leagueGraphHandler', () => {
       await sendLeagueGraph(botMock, 1, 'ABC');
 
       const configArg = mockSetConfig.mock.calls[0][0];
-      expect(configArg.data.datasets[0].label).toBe('𝗖𝗼𝗼𝗽𝗲𝗿𝗼𝗻');
+      expect(configArg.data.datasets[0].label).toBe('👉 Cooperon');
       expect(configArg.data.datasets[0].borderWidth).toBe(5);
     });
 

--- a/src/commandsHandler/leagueGraphHandler.test.js
+++ b/src/commandsHandler/leagueGraphHandler.test.js
@@ -29,6 +29,10 @@ jest.mock('../raceScheduleService', () => ({
   fetchCurrentSeasonRaces: jest.fn(),
 }));
 
+jest.mock('../cache', () => ({
+  getSelectedTeam: jest.fn(),
+}));
+
 // Mock quickchart-js so tests never touch the network.
 // Names must be prefixed with `mock` to be accessible inside jest.mock factories.
 const mockGetShortUrl = jest.fn();
@@ -61,6 +65,7 @@ const { isAdminMessage } = require('../utils/utils');
 const { listUserLeagues } = require('../leagueRegistryService');
 const { getLeagueData } = require('../azureStorageService');
 const { fetchCurrentSeasonRaces } = require('../raceScheduleService');
+const { getSelectedTeam } = require('../cache');
 
 const {
   handleLeagueGraphCommand,
@@ -125,6 +130,7 @@ describe('leagueGraphHandler', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    getSelectedTeam.mockReturnValue(null);
     botMock = {
       sendMessage: jest.fn().mockResolvedValue(),
       sendPhoto: jest.fn().mockResolvedValue(),
@@ -323,6 +329,17 @@ describe('leagueGraphHandler', () => {
       const config = buildChartConfig(data);
       expect(config.data.datasets[0].chipLabels[0]).toBe('🎖️ Mystery Chip');
     });
+
+    it('highlights the selected team with a thicker line and larger points', () => {
+      const selectedTeamId = 'C8EFGOXCB04_Cooperon';
+      const config = buildChartConfig(FIXTURE, { selectedTeamId });
+
+      expect(config.data.datasets[0].label).toBe('Cooperon');
+      expect(config.data.datasets[0].borderWidth).toBe(5);
+      expect(config.data.datasets[1].borderWidth).toBe(2);
+      expect(config.data.datasets[0].pointRadius).toEqual([5, 9, 9]);
+      expect(config.data.datasets[1].pointRadius).toEqual([3, 3, 7]);
+    });
   });
 
   describe('handleLeagueGraphCommand', () => {
@@ -444,6 +461,20 @@ describe('leagueGraphHandler', () => {
       // No race names — labels are just "R1", "R2", "R3"
       expect(configArg.data.labels).toEqual(['R1', 'R2', 'R3']);
       consoleSpy.mockRestore();
+    });
+
+    it('passes selectedTeamId into chart config so selected series is highlighted', async () => {
+      getSelectedTeam.mockReturnValue('C8EFGOXCB04_Cooperon');
+      getLeagueData.mockResolvedValueOnce(FIXTURE);
+      fetchCurrentSeasonRaces.mockResolvedValueOnce({
+        MRData: { RaceTable: { Races: [] } },
+      });
+
+      await sendLeagueGraph(botMock, 1, 'ABC');
+
+      const configArg = mockSetConfig.mock.calls[0][0];
+      expect(configArg.data.datasets[0].label).toBe('Cooperon');
+      expect(configArg.data.datasets[0].borderWidth).toBe(5);
     });
 
     it('surfaces fetch errors to the user and error channel', async () => {

--- a/src/commandsHandler/leagueGraphHandler.test.js
+++ b/src/commandsHandler/leagueGraphHandler.test.js
@@ -334,7 +334,7 @@ describe('leagueGraphHandler', () => {
       const selectedTeamId = 'C8EFGOXCB04_Cooperon';
       const config = buildChartConfig(FIXTURE, { selectedTeamId });
 
-      expect(config.data.datasets[0].label).toBe('Cooperon');
+      expect(config.data.datasets[0].label).toBe('𝗖𝗼𝗼𝗽𝗲𝗿𝗼𝗻');
       expect(config.data.datasets[0].borderWidth).toBe(5);
       expect(config.data.datasets[1].borderWidth).toBe(2);
       expect(config.data.datasets[0].pointRadius).toEqual([5, 9, 9]);
@@ -473,7 +473,7 @@ describe('leagueGraphHandler', () => {
       await sendLeagueGraph(botMock, 1, 'ABC');
 
       const configArg = mockSetConfig.mock.calls[0][0];
-      expect(configArg.data.datasets[0].label).toBe('Cooperon');
+      expect(configArg.data.datasets[0].label).toBe('𝗖𝗼𝗼𝗽𝗲𝗿𝗼𝗻');
       expect(configArg.data.datasets[0].borderWidth).toBe(5);
     });
 

--- a/src/commandsHandler/leagueGraphHandler.test.js
+++ b/src/commandsHandler/leagueGraphHandler.test.js
@@ -334,7 +334,7 @@ describe('leagueGraphHandler', () => {
       const selectedTeamId = 'C8EFGOXCB04_Cooperon';
       const config = buildChartConfig(FIXTURE, { selectedTeamId });
 
-      expect(config.data.datasets[0].label).toBe('👉 Cooperon');
+      expect(config.data.datasets[0].label).toBe('Cooperon');
       expect(config.data.datasets[0].borderWidth).toBe(5);
       expect(config.data.datasets[1].borderWidth).toBe(2);
       expect(config.data.datasets[0].pointRadius).toEqual([5, 9, 9]);
@@ -473,7 +473,7 @@ describe('leagueGraphHandler', () => {
       await sendLeagueGraph(botMock, 1, 'ABC');
 
       const configArg = mockSetConfig.mock.calls[0][0];
-      expect(configArg.data.datasets[0].label).toBe('👉 Cooperon');
+      expect(configArg.data.datasets[0].label).toBe('Cooperon');
       expect(configArg.data.datasets[0].borderWidth).toBe(5);
     });
 

--- a/src/commandsHandler/selectTeamFromLeagueHandler.js
+++ b/src/commandsHandler/selectTeamFromLeagueHandler.js
@@ -3,6 +3,7 @@ const { isAdminMessage, sendMessageToUser } = require('../utils/utils');
 const { listUserLeagues } = require('../leagueRegistryService');
 const azureStorageService = require('../azureStorageService');
 const { updateUserAttributes } = require('../userRegistryService');
+const { sanitizeTeamName, buildTeamId } = require('../utils/teamId');
 const {
   currentTeamCache,
   bestTeamsCache,
@@ -33,26 +34,6 @@ function mapNameToCode(name) {
   const key = String(name).toLowerCase().trim();
 
   return NAME_TO_CODE_MAPPING[key] || name;
-}
-
-/**
- * Sanitize a team name so it can be safely embedded into blob paths.
- * Keeps the result short and readable.
- */
-function sanitizeTeamName(name) {
-  const base = String(name || 'team')
-    .normalize('NFKD')
-    .replace(/[^\w-]+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
-
-  const trimmed = base.length > 0 ? base : 'team';
-
-  return trimmed.slice(0, 40);
-}
-
-function buildTeamId(leagueCode, teamName) {
-  return `${leagueCode}_${sanitizeTeamName(teamName)}`;
 }
 
 /**

--- a/src/utils/teamId.js
+++ b/src/utils/teamId.js
@@ -1,0 +1,24 @@
+/**
+ * Sanitize a team name so it can be safely embedded into IDs/blob paths.
+ * Keeps the result short and readable.
+ */
+function sanitizeTeamName(name) {
+  const base = String(name || 'team')
+    .normalize('NFKD')
+    .replace(/[^\w-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+
+  const trimmed = base.length > 0 ? base : 'team';
+
+  return trimmed.slice(0, 40);
+}
+
+function buildTeamId(leagueCode, teamName) {
+  return `${leagueCode}_${sanitizeTeamName(teamName)}`;
+}
+
+module.exports = {
+  sanitizeTeamName,
+  buildTeamId,
+};


### PR DESCRIPTION
### Motivation
- Make the selected league team visually stand out in `/leaderboard` output so admins can quickly spot which of the followed teams is currently selected.

### Description
- Lookup the user's `selectedTeam` via `getSelectedTeam(chatId)` and reconstruct team IDs using a `sanitizeTeamName` + `buildTeamId` helper to match leaderboard rows to the selected team.
- Render the selected team's row wrapped in `<b>...</b>` and switch the leaderboard send to HTML mode while escaping dynamic values with `escapeHtml` to avoid formatting issues.
- Update tests to mock `getSelectedTeam`, verify that the selected row is bolded, and assert the handler sends the leaderboard with `{ parse_mode: 'HTML' }`.

### Testing
- Ran the targeted unit tests: `npm test -- src/commandsHandler/leaderboardHandler.test.js` and the leaderboard tests passed.
- Ran the full test/coverage suite (`jest --coverage`) and pre-commit checks (lint + tests), with all test suites passing (60 suites, 572 tests passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7e2242b8832faefe4bf5d30d6411)