### PR TITLE
Improve help text, /list_users ordering, and /leaderboard gap display

### DIFF
--- a/src/commandsHandler/leaderboardHandler.js
+++ b/src/commandsHandler/leaderboardHandler.js
@@ -42,11 +42,14 @@ function formatLeaderboard(leagueData, chatId) {
 
   const maxPos = teams[teams.length - 1].position ?? teams.length;
   const posWidth = String(maxPos).length;
-  const lines = teams.map((team) => {
+  const leaderScore = teams[0]?.totalScore ?? 0;
+  const lines = teams.map((team, idx) => {
     const pos = String(team.position ?? '?').padStart(posWidth, ' ');
     const name = escapeHtml(team.teamName || team.userName || '—');
     const score = team.totalScore ?? 0;
-    const line = ` ${pos}. ${name} — ${escapeHtml(score)}`;
+    const gapSuffix =
+      idx === 0 ? '' : ` (${escapeHtml(score - leaderScore)})`;
+    const line = ` ${pos}. ${name} — ${escapeHtml(score)}${gapSuffix}`;
     const teamId = buildTeamId(
       leagueData.leagueCode,
       team.teamName || team.userName || 'team',

--- a/src/commandsHandler/listUsersHandler.js
+++ b/src/commandsHandler/listUsersHandler.js
@@ -82,8 +82,8 @@ function formatUsersMessage(users, chatId) {
       message += `📛 ${t('Nickname', chatId)}: ${user.nickname}\n`;
     }
     message += `🌐 ${t('Language', chatId)}: ${langDisplay}\n`;
-    message += `📅 ${t('First Seen', chatId)}: ${firstSeenFormatted.dateStr}, ${firstSeenFormatted.timeStr}\n`;
-    message += `🕐 ${t('Last Seen', chatId)}: ${lastSeenFormatted.dateStr}, ${lastSeenFormatted.timeStr}\n\n`;
+    message += `🕐 ${t('Last Seen', chatId)}: ${lastSeenFormatted.dateStr}, ${lastSeenFormatted.timeStr}\n`;
+    message += `📅 ${t('First Seen', chatId)}: ${firstSeenFormatted.dateStr}, ${firstSeenFormatted.timeStr}\n\n`;
   });
 
   return message;

--- a/src/constants.js
+++ b/src/constants.js
@@ -326,7 +326,7 @@ exports.MENU_CATEGORIES = {
         constant: exports.COMMAND_LEAGUE_GRAPHS,
         title: '📊 Graphs',
         description:
-          'Show league graphs: gap to leader per race, or budget per race',
+          'Show league graphs: gap to leader, standings, or budget per race',
       },
     ],
   },

--- a/src/translations.js
+++ b/src/translations.js
@@ -469,8 +469,8 @@ const translations = {
     '📋 Teams Tracker': '📋 קבוצות במעקב',
     'Pick which league teams to follow (toggle up to 6 teams, then save)':
       'בחר אילו קבוצות מהליגה לעקוב אחריהן (עד 6 קבוצות, ושמור בסיום)',
-    'Show league graphs: gap to leader per race, or budget per race':
-      'הצג גרפים של הליגה: פער מהמוביל לכל מרוץ, או תקציב לכל מרוץ',
+    'Show league graphs: gap to leader, standings, or budget per race':
+      'הצג גרפים של הליגה: פער מהמוביל, דירוג, או תקציב לכל מרוץ',
     'Pick a league to manage followed teams:':
       'בחר ליגה כדי לנהל את הקבוצות במעקב:',
     'Toggle teams to follow. Save when done.':


### PR DESCRIPTION
## Changes

- **/league_graphs help text**: Mention the standings graph alongside gap-to-leader and budget (was missing).
- **/list_users**: Show 🕐 Last Seen above 📅 First Seen for each user.
- **/leaderboard**: Append `(gap-to-leader)` after each non-leader team's total score, e.g. ` 2. B — 800 (-100)`.

## Files
- `src/constants.js`, `src/translations.js` — updated /league_graphs description (EN + HE)
- `src/commandsHandler/listUsersHandler.js` — swap First Seen / Last Seen order
- `src/commandsHandler/leaderboardHandler.js` — gap suffix in leaderboard rows