### PR TITLE
[codex] Add update date to whats new

### DIFF
--- a/src/commandsHandler/whatsNewHandler.js
+++ b/src/commandsHandler/whatsNewHandler.js
@@ -1,5 +1,5 @@
 const { sendErrorMessage } = require('../utils');
-const { t } = require('../i18n');
+const { getLocale, t } = require('../i18n');
 const { getLatestAnnouncement } = require('../announcementsService');
 const { MAX_TELEGRAM_MESSAGE_LENGTH } = require('../constants');
 
@@ -11,6 +11,29 @@ function escapeCommandUnderscores(text) {
   return text.replace(/\/[A-Za-z][A-Za-z0-9_]*/g, (match) =>
     match.replace(/_/g, '\\_'),
   );
+}
+
+function formatUpdateDate(createdAt, chatId) {
+  const date = new Date(createdAt);
+  if (!Number.isFinite(date.getTime())) {
+    return null;
+  }
+
+  return date.toLocaleDateString(getLocale(chatId), {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'Asia/Jerusalem',
+  });
+}
+
+function buildAnnouncementText(latest, chatId) {
+  const updateDate = formatUpdateDate(latest.createdAt, chatId);
+  if (!updateDate) {
+    return latest.text;
+  }
+
+  return `${t('Updated on: {DATE}', chatId, { DATE: updateDate })}\n\n${latest.text}`;
 }
 
 async function handleWhatsNewCommand(bot, msg) {
@@ -26,7 +49,7 @@ async function handleWhatsNewCommand(bot, msg) {
     return;
   }
 
-  let text = latest.text;
+  let text = buildAnnouncementText(latest, chatId);
   if (text.length > MAX_TELEGRAM_MESSAGE_LENGTH) {
     text = `${text.slice(0, MAX_TELEGRAM_MESSAGE_LENGTH - 1)}…`;
     await sendErrorMessage(

--- a/src/commandsHandler/whatsNewHandler.test.js
+++ b/src/commandsHandler/whatsNewHandler.test.js
@@ -49,15 +49,34 @@ describe('handleWhatsNewCommand', () => {
     expect(botMock.sendMessage).toHaveBeenCalledTimes(1);
     expect(botMock.sendMessage).toHaveBeenCalledWith(
       KILZI_CHAT_ID,
-      '*בולד* — נסו /best\\_teams ו־/follow\\_league',
+      'Updated on: 15 April 2026\n\n*בולד* — נסו /best\\_teams ו־/follow\\_league',
       { parse_mode: 'Markdown' },
     );
   });
 
-  it('sends the latest announcement text with Markdown parse_mode', async () => {
+  it('sends the latest announcement text with update date and Markdown parse_mode', async () => {
     mockGetLatestAnnouncement.mockReturnValue({
       id: 'x',
       createdAt: '2026-04-15T10:00:00.000Z',
+      version: 'standard',
+      text: '*בולד* שלום עולם',
+    });
+    const msg = { chat: { id: KILZI_CHAT_ID }, text: '/whats_new' };
+
+    await handleWhatsNewCommand(botMock, msg);
+
+    expect(botMock.sendMessage).toHaveBeenCalledTimes(1);
+    expect(botMock.sendMessage).toHaveBeenCalledWith(
+      KILZI_CHAT_ID,
+      'Updated on: 15 April 2026\n\n*בולד* שלום עולם',
+      { parse_mode: 'Markdown' },
+    );
+  });
+
+  it('sends the announcement without an update date when createdAt is invalid', async () => {
+    mockGetLatestAnnouncement.mockReturnValue({
+      id: 'x',
+      createdAt: 'not-a-date',
       version: 'standard',
       text: '*בולד* שלום עולם',
     });
@@ -95,13 +114,13 @@ describe('handleWhatsNewCommand', () => {
     expect(botMock.sendMessage).toHaveBeenNthCalledWith(
       1,
       KILZI_CHAT_ID,
-      'broken *markdown /best\\_teams',
+      'Updated on: 15 April 2026\n\nbroken *markdown /best\\_teams',
       { parse_mode: 'Markdown' },
     );
     expect(botMock.sendMessage).toHaveBeenNthCalledWith(
       2,
       KILZI_CHAT_ID,
-      'broken *markdown /best_teams',
+      'Updated on: 15 April 2026\n\nbroken *markdown /best_teams',
     );
     consoleErrorSpy.mockRestore();
   });

--- a/src/translations.js
+++ b/src/translations.js
@@ -24,6 +24,7 @@ const translations = {
     'Sorry, only admins can use this command.':
       'מצטער, רק מנהלים יכולים להשתמש בפקודה זו.',
     'No release notes available yet.': 'אין הודעת עדכון זמינה כרגע.',
+    'Updated on: {DATE}': 'עודכן בתאריך: {DATE}',
     "🆕 What's New": '🆕 מה חדש',
     'Show the latest release announcement': 'הצגת הודעת השחרור האחרונה',
     'Please send a drivers screenshot.': 'אנא שלח צילום מסך של נהגים.',


### PR DESCRIPTION
## Summary

Adds an update date line to the `/whats_new` command output, using the latest announcement's `createdAt` timestamp.

## Details

- Formats the update date in the user's locale and Asia/Jerusalem timezone.
- Prepends `Updated on: {DATE}` before the announcement body.
- Adds the Hebrew translation `עודכן בתאריך: {DATE}`.
- Keeps the announcement body unchanged and skips the date line if `createdAt` is invalid.

## Validation

- `npx jest src/commandsHandler/whatsNewHandler.test.js --runInBand --no-watchman`
- Commit hook: `eslint .` and `jest --coverage` passed. Coverage run completed with 63 test suites and 604 tests passing.