### PR TITLE
[codex] Rename help menu category

### DIFF
--- a/src/commandsHandler/helpHandler.test.js
+++ b/src/commandsHandler/helpHandler.test.js
@@ -57,7 +57,7 @@ describe('displayHelpMessage', () => {
     expect(sentMessage).toContain('🏎️ Team Management');
     expect(sentMessage).toContain('📊 Analysis & Stats');
     expect(sentMessage).toContain('🔧 Utilities');
-    expect(sentMessage).toContain('❓ Help & Menu');
+    expect(sentMessage).toContain('❓ Support & Info');
 
     // Should NOT include admin category for regular users
     expect(sentMessage).not.toContain('👤 Admin Commands');
@@ -117,7 +117,7 @@ describe('displayHelpMessage', () => {
     expect(sentMessage).toContain('📊 Analysis & Stats');
     expect(sentMessage).toContain('🔧 Utilities');
     expect(sentMessage).toContain('👤 Admin Commands');
-    expect(sentMessage).toContain('❓ Help & Menu');
+    expect(sentMessage).toContain('❓ Support & Info');
 
     // Should include help and menu commands
     const helpCommand = USER_COMMANDS_CONFIG.find(
@@ -222,7 +222,7 @@ describe('displayHelpMessage', () => {
 
     // Check message structure
     const sections = sentMessage.split('\n\n');
-    expect(sections.length).toBeGreaterThanOrEqual(5); // Header, Team Management, Analysis & Stats, Utilities, Admin Commands, Help & Menu, Other Messages
+    expect(sections.length).toBeGreaterThanOrEqual(5); // Header, Team Management, Analysis & Stats, Utilities, Admin Commands, Support & Info, Other Messages
 
     // Check that the message starts with the correct header
     expect(sentMessage).toMatch(/^\*F1 Fantasy Bot - Available Commands\*/);
@@ -232,7 +232,7 @@ describe('displayHelpMessage', () => {
     expect(sentMessage).toMatch(/📊 Analysis & Stats/);
     expect(sentMessage).toMatch(/🔧 Utilities/);
     expect(sentMessage).toMatch(/👤 Admin Commands/);
-    expect(sentMessage).toMatch(/❓ Help & Menu/);
+    expect(sentMessage).toMatch(/❓ Support & Info/);
 
     // Check that the message ends with Other Messages
     expect(sentMessage).toMatch(/\*Other Messages:\*/);

--- a/src/commandsHandler/menuHandler.test.js
+++ b/src/commandsHandler/menuHandler.test.js
@@ -117,7 +117,7 @@ describe('Menu Handler', () => {
               ]),
               expect.arrayContaining([
                 expect.objectContaining({
-                  text: '❓ Help & Menu',
+                  text: '❓ Support & Info',
                   callback_data: `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.CATEGORY}:help_menu`,
                 }),
               ]),

--- a/src/constants.js
+++ b/src/constants.js
@@ -104,8 +104,8 @@ exports.COMMAND_WHATS_NEW = '/whats_new';
 exports.MENU_CATEGORIES = {
   HELP_MENU: {
     id: 'help_menu',
-    title: '❓ Help & Menu',
-    description: 'Help and navigation commands',
+    title: '❓ Support & Info',
+    description: 'Help, updates, and feedback',
     commands: [
       {
         constant: exports.COMMAND_HELP,

--- a/src/translations.js
+++ b/src/translations.js
@@ -221,8 +221,8 @@ const translations = {
     'Remaining race count is unavailable right now. Switch to Pure Points or try again later.':
       'מספר המרוצים שנותרו אינו זמין כרגע. עבור לנקודות בלבד או נסה שוב מאוחר יותר.',
     'Please provide a question.': 'אנא ספק שאלה.',
-    '❓ Help & Menu': '❓ עזרה ותפריט',
-    'Help and navigation commands': 'פקודות עזרה וניווט',
+    '❓ Support & Info': '❓ תמיכה ומידע',
+    'Help, updates, and feedback': 'עזרה, עדכונים ומשוב',
     '🏎️ Team Management': '🏎️ ניהול קבוצה',
     'Manage and optimize your F1 Fantasy team':
       'ניהול ואופטימיזציה של קבוצת F1 Fantasy',


### PR DESCRIPTION
## Summary
- Rename the support/help menu category from "Help & Menu" to "Support & Info".
- Update the category description to "Help, updates, and feedback".
- Update Hebrew translations and menu/help tests for the new label.

## Why
The category contains help, usage flow, release updates, and bug reporting, so "Support & Info" better reflects the actual content than "Help & Menu".

## Validation
- `npm test -- --watchman=false --runTestsByPath src/commandsHandler/menuHandler.test.js src/commandsHandler/helpHandler.test.js`
- Pre-commit hook: `npm run lint` and `npm run test:coverage` passed. Lint reported one existing warning in `src/photoProcessingService.js`.