### PR TITLE
Show /cancel hint in reply-based command prompts

### DIFF
--- a/src/commandsHandler/broadcastHandler.js
+++ b/src/commandsHandler/broadcastHandler.js
@@ -22,10 +22,10 @@ async function handleBroadcastCommand(bot, msg) {
     return;
   }
 
-  const prompt = t(
-    'Please enter the message or image you want to broadcast to all users:\n\n(Send /cancel to abort.)',
+  const prompt = `${t(
+    'Please enter the message or image you want to broadcast to all users:',
     chatId,
-  );
+  )}\n\n${t('💡 Send /cancel at any time to abort.', chatId)}`;
 
   await registerPendingReply(chatId, 'broadcast');
 

--- a/src/commandsHandler/broadcastHandler.test.js
+++ b/src/commandsHandler/broadcastHandler.test.js
@@ -56,12 +56,16 @@ describe('broadcastHandler', () => {
       await handleBroadcastCommand(botMock, msg);
 
       expect(t).toHaveBeenCalledWith(
-        'Please enter the message or image you want to broadcast to all users:\n\n(Send /cancel to abort.)',
+        'Please enter the message or image you want to broadcast to all users:',
+        123,
+      );
+      expect(t).toHaveBeenCalledWith(
+        '💡 Send /cancel at any time to abort.',
         123,
       );
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         123,
-        'Please enter the message or image you want to broadcast to all users:\n\n(Send /cancel to abort.)',
+        'Please enter the message or image you want to broadcast to all users:\n\n💡 Send /cancel at any time to abort.',
         { reply_markup: { force_reply: true } },
       );
     });

--- a/src/commandsHandler/reportBugHandler.js
+++ b/src/commandsHandler/reportBugHandler.js
@@ -4,10 +4,10 @@ const { registerPendingReply } = require('../pendingReplyManager');
 async function handleReportBugCommand(bot, msg) {
   const chatId = msg.chat.id;
 
-  const prompt = t(
+  const prompt = `${t(
     'What message would you like to send to the admins?',
     chatId,
-  );
+  )}\n\n${t('💡 Send /cancel at any time to abort.', chatId)}`;
 
   await registerPendingReply(chatId, 'report_bug');
 

--- a/src/commandsHandler/reportBugHandler.test.js
+++ b/src/commandsHandler/reportBugHandler.test.js
@@ -40,9 +40,13 @@ describe('reportBugHandler', () => {
         'What message would you like to send to the admins?',
         123,
       );
+      expect(t).toHaveBeenCalledWith(
+        '💡 Send /cancel at any time to abort.',
+        123,
+      );
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         123,
-        'What message would you like to send to the admins?',
+        'What message would you like to send to the admins?\n\n💡 Send /cancel at any time to abort.',
         { reply_markup: { force_reply: true } },
       );
     });

--- a/src/commandsHandler/sendMessageToUserHandler.js
+++ b/src/commandsHandler/sendMessageToUserHandler.js
@@ -22,10 +22,10 @@ async function handleSendMessageToUserCommand(bot, msg) {
     return;
   }
 
-  const prompt = t(
+  const prompt = `${t(
     'Please enter the chat ID of the user you want to send a message or image to:',
     chatId,
-  );
+  )}\n\n${t('💡 Send /cancel at any time to abort.', chatId)}`;
 
   await registerPendingReply(chatId, 'send_message_to_user', {
     step: 'collect_user_id',

--- a/src/commandsHandler/sendMessageToUserHandler.test.js
+++ b/src/commandsHandler/sendMessageToUserHandler.test.js
@@ -63,9 +63,13 @@ describe('sendMessageToUserHandler', () => {
         'Please enter the chat ID of the user you want to send a message or image to:',
         123,
       );
+      expect(t).toHaveBeenCalledWith(
+        '💡 Send /cancel at any time to abort.',
+        123,
+      );
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         123,
-        'Please enter the chat ID of the user you want to send a message or image to:',
+        'Please enter the chat ID of the user you want to send a message or image to:\n\n💡 Send /cancel at any time to abort.',
         { reply_markup: { force_reply: true } },
       );
     });

--- a/src/commandsHandler/setNicknameHandler.js
+++ b/src/commandsHandler/setNicknameHandler.js
@@ -22,10 +22,10 @@ async function handleSetNicknameCommand(bot, msg) {
     return;
   }
 
-  const prompt = t(
+  const prompt = `${t(
     'Please enter the chat ID of the user you want to set a nickname for:',
     chatId,
-  );
+  )}\n\n${t('💡 Send /cancel at any time to abort.', chatId)}`;
 
   await registerPendingReply(chatId, 'set_nickname', {
     step: 'collect_user_id',

--- a/src/commandsHandler/setNicknameHandler.test.js
+++ b/src/commandsHandler/setNicknameHandler.test.js
@@ -63,9 +63,13 @@ describe('setNicknameHandler', () => {
         'Please enter the chat ID of the user you want to set a nickname for:',
         123,
       );
+      expect(t).toHaveBeenCalledWith(
+        '💡 Send /cancel at any time to abort.',
+        123,
+      );
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         123,
-        'Please enter the chat ID of the user you want to set a nickname for:',
+        'Please enter the chat ID of the user you want to set a nickname for:\n\n💡 Send /cancel at any time to abort.',
         { reply_markup: { force_reply: true } },
       );
     });

--- a/src/pendingReplyRegistry.js
+++ b/src/pendingReplyRegistry.js
@@ -111,14 +111,16 @@ const PENDING_REPLY_REGISTRY = {
             targetChatId,
           });
 
+          const collectMessagePrompt = `${t(
+            'What message or image do you want to send to {NAME}?',
+            chatId,
+            { NAME: user.chatName },
+          )}\n\n${t('💡 Send /cancel at any time to abort.', chatId)}`;
+
           await replyBot
-            .sendMessage(
-              chatId,
-              t('What message or image do you want to send to {NAME}?', chatId, {
-                NAME: user.chatName,
-              }),
-              { reply_markup: { force_reply: true } },
-            )
+            .sendMessage(chatId, collectMessagePrompt, {
+              reply_markup: { force_reply: true },
+            })
             .catch((err) =>
               console.error('Error sending collect message prompt:', err),
             );
@@ -346,14 +348,16 @@ const PENDING_REPLY_REGISTRY = {
             targetChatName: user.chatName,
           });
 
+          const collectNicknamePrompt = `${t(
+            'Please enter the nickname for {NAME}:',
+            chatId,
+            { NAME: user.chatName },
+          )}\n\n${t('💡 Send /cancel at any time to abort.', chatId)}`;
+
           await replyBot
-            .sendMessage(
-              chatId,
-              t('Please enter the nickname for {NAME}:', chatId, {
-                NAME: user.chatName,
-              }),
-              { reply_markup: { force_reply: true } },
-            )
+            .sendMessage(chatId, collectNicknamePrompt, {
+              reply_markup: { force_reply: true },
+            })
             .catch((err) =>
               console.error('Error sending collect nickname prompt:', err),
             );

--- a/src/pendingReplyRegistry.test.js
+++ b/src/pendingReplyRegistry.test.js
@@ -342,9 +342,13 @@ describe('pendingReplyRegistry', () => {
           100,
           { NAME: 'Target User' },
         );
+        expect(t).toHaveBeenCalledWith(
+          '💡 Send /cancel at any time to abort.',
+          100,
+        );
         expect(botMock.sendMessage).toHaveBeenCalledWith(
           100,
-          'What message or image do you want to send to {NAME}?',
+          'What message or image do you want to send to {NAME}?\n\n💡 Send /cancel at any time to abort.',
           { reply_markup: { force_reply: true } },
         );
       });

--- a/src/translations.js
+++ b/src/translations.js
@@ -383,8 +383,8 @@ const translations = {
       'אנא הזן טקסט או תמונה לשליחה.',
     '📩 Message from bot admin:\n\n{MESSAGE}':
       '📩 הודעה ממנהל הבוט:\n\n{MESSAGE}',
-    'Please enter the message or image you want to broadcast to all users:\n\n(Send /cancel to abort.)':
-      'אנא הזן את ההודעה או התמונה שברצונך לשלוח לכל המשתמשים:\n\n(שלח /cancel כדי לבטל.)',
+    'Please enter the message or image you want to broadcast to all users:':
+      'אנא הזן את ההודעה או התמונה שברצונך לשלוח לכל המשתמשים:',
     '📢 Broadcast from bot admin:\n\n{MESSAGE}':
       '📢 הודעה ממנהל הבוט:\n\n{MESSAGE}',
     'Broadcast complete.\n\n✅ Sent successfully: {SUCCESS}\n❌ Failed: {FAILED}':


### PR DESCRIPTION
## Summary

Surface the existing global `/cancel` mechanism to users by appending a localized hint (`💡 Send /cancel at any time to abort.`) to every reply-based command prompt. Previously users had no way to discover they could abort a flow.

## Changes
- **Prompts updated** (all reuse the existing translation key already used by `/follow_league`, EN+HE present):
  - `/report_bug`
  - `/broadcast` — also normalized `translations.js` to drop the ad-hoc `(Send /cancel to abort.)` suffix from the prompt key
  - `/send_message_to_user` — initial prompt + step-2 prompt in `pendingReplyRegistry.js`
  - `/set_nickname` — initial prompt + step-2 prompt in `pendingReplyRegistry.js`
- `/follow_league` already showed the hint and is unchanged.

## Verification
- The global cancel mechanism (`messageHandler.js` → `isCancelKeyword`) was confirmed working via the existing 7 cancel tests — no logic change needed there.
- Updated 5 test files to assert the new composed prompt strings.
- Full test suite: **608/608 passing**. Lint clean.