### PR TITLE
Exclude 'The Best Bot' team from league graphs

### DIFF
--- a/src/commandsHandler/leagueBudgetGraphHandler.js
+++ b/src/commandsHandler/leagueBudgetGraphHandler.js
@@ -5,6 +5,7 @@ const { getLeagueData } = require('../azureStorageService');
 const { fetchCurrentSeasonRaces } = require('../raceScheduleService');
 const { getSelectedTeam } = require('../cache');
 const { buildTeamId } = require('../utils/teamId');
+const { filterExcludedGraphTeams } = require('../utils/leagueGraphFilter');
 const {
   buildRoundToRaceNameMap,
   matchdayNumber,
@@ -50,7 +51,7 @@ function buildBudgetChartConfig(leagueData, options = {}) {
   const roundToRaceName = options.roundToRaceName || {};
   const selectedTeamId = options.selectedTeamId || null;
 
-  const teams = Array.isArray(leagueData?.teams) ? [...leagueData.teams] : [];
+  const teams = filterExcludedGraphTeams(leagueData?.teams);
   const matchdayKeys = getSortedBudgetMatchdayKeys(teams);
 
   // Sort legend/series order by each team's most recent recorded budget

--- a/src/commandsHandler/leagueBudgetGraphHandler.test.js
+++ b/src/commandsHandler/leagueBudgetGraphHandler.test.js
@@ -298,6 +298,32 @@ describe('leagueBudgetGraphHandler', () => {
       const config = buildBudgetChartConfig(FIXTURE);
       expect(config.options.scales.y.title.text).toBe('Budget ($M)');
     });
+
+    it('excludes teams flagged by the graph filter (e.g. "The Best Bot")', () => {
+      const data = {
+        ...FIXTURE,
+        teams: [
+          ...FIXTURE.teams,
+          {
+            teamName: 'The Best Bot',
+            userName: 'doronkilzi',
+            position: 4,
+            raceBudgets: {
+              matchday_1: 100,
+              matchday_2: 200,
+              matchday_3: 300,
+              matchday_4: 400,
+            },
+          },
+        ],
+      };
+      const config = buildBudgetChartConfig(data);
+      const labels = config.data.datasets.map((d) => d.label);
+      expect(labels).not.toContain('The Best Bot');
+      expect(labels).toContain('Cooperon');
+      expect(labels).toContain('dorsegal1');
+      expect(labels).toContain('Kilzid');
+    });
   });
 
   describe('sendLeagueBudgetGraph', () => {

--- a/src/commandsHandler/leagueGraphHandler.js
+++ b/src/commandsHandler/leagueGraphHandler.js
@@ -7,6 +7,7 @@ const { fetchCurrentSeasonRaces } = require('../raceScheduleService');
 const { getChipEmoji } = require('../utils/chipEmojis');
 const { getSelectedTeam } = require('../cache');
 const { buildTeamId } = require('../utils/teamId');
+const { filterExcludedGraphTeams } = require('../utils/leagueGraphFilter');
 const {
   LEAGUE_GRAPH_CALLBACK_TYPE,
   LEAGUE_GRAPH_TYPE_CALLBACK_TYPE,
@@ -103,7 +104,7 @@ function buildChartConfig(leagueData, options = {}) {
   const roundToRaceName = options.roundToRaceName || {};
   const selectedTeamId = options.selectedTeamId || null;
 
-  const teams = Array.isArray(leagueData?.teams) ? [...leagueData.teams] : [];
+  const teams = filterExcludedGraphTeams(leagueData?.teams);
   teams.sort((a, b) => (a.position || 0) - (b.position || 0));
 
   const matchdayKeys = getSortedMatchdayKeys(teams);

--- a/src/commandsHandler/leagueGraphHandler.test.js
+++ b/src/commandsHandler/leagueGraphHandler.test.js
@@ -352,6 +352,29 @@ describe('leagueGraphHandler', () => {
       expect(config.options.scales.y.ticks.font.size).toBe(13);
       expect(config.data.datasets[0].datalabels.font.size).toBe(12);
     });
+
+    it('excludes teams flagged by the graph filter (e.g. "The Best Bot")', () => {
+      const data = {
+        ...FIXTURE,
+        teams: [
+          ...FIXTURE.teams,
+          {
+            teamName: 'The Best Bot',
+            userName: 'doronkilzi',
+            position: 4,
+            totalScore: 9999,
+            raceScores: { matchday_1: 999, matchday_2: 999, matchday_3: 999 },
+            chipsUsed: [],
+          },
+        ],
+      };
+      const config = buildChartConfig(data);
+      const labels = config.data.datasets.map((d) => d.label);
+      expect(labels).not.toContain('The Best Bot');
+      expect(labels).toContain('Cooperon');
+      expect(labels).toContain('dorsegal1');
+      expect(labels).toContain('Kilzid');
+    });
   });
 
   describe('handleLeagueGraphsCommand', () => {

--- a/src/commandsHandler/leagueStandingsGraphHandler.js
+++ b/src/commandsHandler/leagueStandingsGraphHandler.js
@@ -6,6 +6,7 @@ const { fetchCurrentSeasonRaces } = require('../raceScheduleService');
 const { getChipEmoji } = require('../utils/chipEmojis');
 const { getSelectedTeam } = require('../cache');
 const { buildTeamId } = require('../utils/teamId');
+const { filterExcludedGraphTeams } = require('../utils/leagueGraphFilter');
 const {
   buildRoundToRaceNameMap,
   matchdayNumber,
@@ -73,7 +74,7 @@ function buildStandingsChartConfig(leagueData, options = {}) {
   const roundToRaceName = options.roundToRaceName || {};
   const selectedTeamId = options.selectedTeamId || null;
 
-  const teams = Array.isArray(leagueData?.teams) ? [...leagueData.teams] : [];
+  const teams = filterExcludedGraphTeams(leagueData?.teams);
   const matchdayKeys = getSortedMatchdayKeys(teams);
 
   const ranksPerTeam = computeRankPerMatchday(teams, matchdayKeys);

--- a/src/commandsHandler/leagueStandingsGraphHandler.test.js
+++ b/src/commandsHandler/leagueStandingsGraphHandler.test.js
@@ -264,6 +264,33 @@ describe('leagueStandingsGraphHandler', () => {
       const config = buildStandingsChartConfig(FIXTURE);
       expect(config.options.scales.y.title.text).toBe('Standing');
     });
+
+    it('excludes teams flagged by the graph filter (e.g. "The Best Bot")', () => {
+      const data = {
+        ...FIXTURE,
+        teams: [
+          ...FIXTURE.teams,
+          {
+            teamName: 'The Best Bot',
+            userName: 'doronkilzi',
+            position: 4,
+            raceScores: {
+              matchday_1: 200,
+              matchday_2: 200,
+              matchday_3: 200,
+              matchday_4: 200,
+            },
+            chipsUsed: [],
+          },
+        ],
+      };
+      const config = buildStandingsChartConfig(data);
+      const labels = config.data.datasets.map((d) => d.label);
+      expect(labels).not.toContain('The Best Bot');
+      expect(labels).toContain('Cooperon');
+      expect(labels).toContain('dorsegal1');
+      expect(labels).toContain('Kilzid');
+    });
   });
 
   describe('sendLeagueStandingsGraph', () => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -49,6 +49,13 @@ exports.LEAGUE_GRAPH_TYPES = {
   BUDGET: 'budget',
   STANDINGS: 'standings',
 };
+// Teams whose `teamName` (case-insensitive, trimmed) should be excluded from
+// league graph rendering. Matched values themselves are also normalized
+// (lowercased + trimmed) when checked. Only `teamName` is checked — `userName`
+// is intentionally ignored. Used by graph handlers only — leaderboard,
+// /league_changes, /live_score and /teams_tracker still include every real
+// participant.
+exports.EXCLUDED_GRAPH_TEAM_NAMES = ['the best bot'];
 // Kept short (2 chars) so the callback data `TT:<action>:<leagueCode>:<position>`
 // stays under the 64-byte Telegram limit.
 exports.TEAMS_TRACKER_CALLBACK_TYPE = 'TT';

--- a/src/utils/leagueGraphFilter.js
+++ b/src/utils/leagueGraphFilter.js
@@ -1,0 +1,62 @@
+const { EXCLUDED_GRAPH_TEAM_NAMES } = require('../constants');
+
+/**
+ * Normalize a team name for case-insensitive, whitespace-tolerant comparison.
+ * Returns an empty string for non-string input so the caller can safely use
+ * `Set.has(...)` / equality checks without an extra null guard.
+ *
+ * @param {*} value
+ * @returns {string}
+ */
+function normalizeTeamName(value) {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+const EXCLUDED_NAME_SET = new Set(
+  (Array.isArray(EXCLUDED_GRAPH_TEAM_NAMES) ? EXCLUDED_GRAPH_TEAM_NAMES : [])
+    .map(normalizeTeamName)
+    .filter((name) => name.length > 0),
+);
+
+/**
+ * True when the team's `teamName` matches one of the configured
+ * `EXCLUDED_GRAPH_TEAM_NAMES` entries (comparison is case-insensitive and
+ * trims surrounding whitespace). `userName` is intentionally NOT considered
+ * — only the team name is used.
+ *
+ * @param {Object|null|undefined} team
+ * @returns {boolean}
+ */
+function isExcludedFromGraphs(team) {
+  if (!team || typeof team !== 'object') {
+    return false;
+  }
+  if (EXCLUDED_NAME_SET.size === 0) {
+    return false;
+  }
+
+  const teamName = normalizeTeamName(team.teamName);
+
+  return teamName.length > 0 && EXCLUDED_NAME_SET.has(teamName);
+}
+
+/**
+ * Filter out teams flagged by `isExcludedFromGraphs`. Returns a new array.
+ * Non-array input is treated as empty (mirrors the defensive `Array.isArray`
+ * guards already used in the graph builders).
+ *
+ * @param {Array<Object>|null|undefined} teams
+ * @returns {Array<Object>}
+ */
+function filterExcludedGraphTeams(teams) {
+  if (!Array.isArray(teams)) {
+    return [];
+  }
+
+  return teams.filter((team) => !isExcludedFromGraphs(team));
+}
+
+module.exports = {
+  isExcludedFromGraphs,
+  filterExcludedGraphTeams,
+};

--- a/src/utils/leagueGraphFilter.test.js
+++ b/src/utils/leagueGraphFilter.test.js
@@ -1,0 +1,83 @@
+const {
+  isExcludedFromGraphs,
+  filterExcludedGraphTeams,
+} = require('./leagueGraphFilter');
+
+describe('leagueGraphFilter', () => {
+  describe('isExcludedFromGraphs', () => {
+    it('matches the configured name on teamName (exact)', () => {
+      expect(isExcludedFromGraphs({ teamName: 'the best bot' })).toBe(true);
+    });
+
+    it('does NOT match on userName even when userName is the configured name', () => {
+      expect(
+        isExcludedFromGraphs({ teamName: 'Cooperon', userName: 'the best bot' }),
+      ).toBe(false);
+      expect(isExcludedFromGraphs({ userName: 'The Best Bot' })).toBe(false);
+    });
+
+    it('matches case-insensitively (teamName)', () => {
+      expect(isExcludedFromGraphs({ teamName: 'The Best Bot' })).toBe(true);
+      expect(isExcludedFromGraphs({ teamName: 'THE BEST BOT' })).toBe(true);
+      expect(isExcludedFromGraphs({ teamName: 'tHe BeSt BoT' })).toBe(true);
+    });
+
+    it('trims surrounding whitespace before matching (teamName)', () => {
+      expect(isExcludedFromGraphs({ teamName: '  The Best Bot  ' })).toBe(true);
+      expect(isExcludedFromGraphs({ teamName: '\tthe best bot\n' })).toBe(true);
+    });
+
+    it('does not match unrelated names', () => {
+      expect(isExcludedFromGraphs({ teamName: 'Best Bot' })).toBe(false);
+      expect(isExcludedFromGraphs({ teamName: 'The Best' })).toBe(false);
+      expect(
+        isExcludedFromGraphs({ teamName: 'the best bot squad' }),
+      ).toBe(false);
+    });
+
+    it('returns false for missing fields, missing team, or non-string teamName', () => {
+      expect(isExcludedFromGraphs(null)).toBe(false);
+      expect(isExcludedFromGraphs(undefined)).toBe(false);
+      expect(isExcludedFromGraphs({})).toBe(false);
+      expect(isExcludedFromGraphs({ teamName: 42 })).toBe(false);
+      expect(isExcludedFromGraphs({ teamName: null })).toBe(false);
+    });
+  });
+
+  describe('filterExcludedGraphTeams', () => {
+    it('removes teams whose teamName matches', () => {
+      const teams = [
+        { teamName: 'Cooperon', userName: 'Ron Cooper' },
+        { teamName: 'The Best Bot', userName: 'Doron Kilzi' },
+        { teamName: 'Kilzid', userName: 'Doron Kilzi' },
+      ];
+      expect(filterExcludedGraphTeams(teams)).toEqual([
+        { teamName: 'Cooperon', userName: 'Ron Cooper' },
+        { teamName: 'Kilzid', userName: 'Doron Kilzi' },
+      ]);
+    });
+
+    it('keeps teams whose userName matches the bot name but whose teamName does not', () => {
+      const teams = [
+        { teamName: 'PerfectlyNormalTeam', userName: 'the best bot' },
+        { teamName: 'Cooperon', userName: 'Ron Cooper' },
+      ];
+      expect(filterExcludedGraphTeams(teams)).toEqual(teams);
+    });
+
+    it('returns an empty array for non-array input', () => {
+      expect(filterExcludedGraphTeams(null)).toEqual([]);
+      expect(filterExcludedGraphTeams(undefined)).toEqual([]);
+      expect(filterExcludedGraphTeams('teams')).toEqual([]);
+      expect(filterExcludedGraphTeams({ teams: [] })).toEqual([]);
+    });
+
+    it('returns the original array contents when nothing matches', () => {
+      const teams = [
+        { teamName: 'Cooperon', userName: 'Ron Cooper' },
+        { teamName: 'Kilzid', userName: 'Doron Kilzi' },
+      ];
+      expect(filterExcludedGraphTeams(teams)).toEqual(teams);
+    });
+  });
+});


### PR DESCRIPTION
## Why

The bot owner participates in tracked leagues under the team name **"The Best Bot"**. Rendering him alongside real players in `/league_graphs` (Gap to Leader, Standings, Budget) skewed the visual story for everyone else.

## What

Filter `leagueData.teams` inside the three `build*ChartConfig` pure functions, removing any team whose **`teamName`** matches a configured exclusion list (case-insensitive, trimmed). `userName` is intentionally **not** considered.

- `src/constants.js` — exports `EXCLUDED_GRAPH_TEAM_NAMES = ['the best bot']`. Adding more names later is a one-line edit.
- `src/utils/leagueGraphFilter.js` (new) — `isExcludedFromGraphs(team)` and `filterExcludedGraphTeams(teams)`.
- `leagueGraphHandler.js`, `leagueStandingsGraphHandler.js`, `leagueBudgetGraphHandler.js` — each `build*ChartConfig` now starts with `filterExcludedGraphTeams(leagueData?.teams)` in place of the raw `Array.isArray(...)` spread.

## Out of scope (intentionally unchanged)

`/leaderboard`, `/league_changes`, `/live_score`, `/teams_tracker` — the bot still legitimately competes there. Only graph rendering is filtered.

## Tests

- New `src/utils/leagueGraphFilter.test.js` — covers exact match, case-insensitivity, whitespace trimming, no match, missing fields, non-array input, and explicitly asserts that a team with `userName === 'the best bot'` but a normal `teamName` is **kept**.
- Each existing graph builder test gained one assertion that injecting a team named `"The Best Bot"` into the fixture results in it being absent from `datasets`.
- `npm test` → **691/691 passing**. `npm run lint` → clean (only the pre-existing unrelated `max-params` warning in `photoProcessingService.js`).