### PR TITLE
refactor: remove lazy migration from legacy league teamIds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,18 +427,6 @@ constructorsCache[chatId]; // constructor data shared across teams
 
 Best-team ranking preferences are stored per team in `userCache[chatId].bestTeamBudgetChangePointsPerMillion`.
 
-### Lazy migration from legacy league teamIds
-
-Production has historical data keyed by the legacy `{leagueCode}_{sanitizeIdSegment(teamName)}` format (e.g. `C8EFGOXCB04_Kilzid`). On every cold start, `refreshLeagueSourcedTeams` in `cacheInitializer.js` detects entries in legacy format (heuristic: the prefix before the first `_` matches one of the user's followed `leagueCode`s, looked up via `listUserLeagues(chatId)`) and rewrites them in place:
-
-1. Save a new blob `user-teams/{chatId}_{newTeamId}.json` with refreshed roster.
-2. Move `currentTeamCache`, `bestTeamsCache`, `selectedChipCache` entries to the new key (dedup on collision when the same fantasy team was followed via multiple leagues).
-3. Rewrite `userCache[chatId].selectedTeam` and rename keys inside `selectedBestTeamByTeam`.
-4. Delete the legacy blob.
-5. Persist updated user attributes via a single `updateUserAttributes` call.
-
-Failures keep the legacy entry in place and retry on the next startup. Once production is fully migrated, the migration block in `refreshLeagueSourcedTeams` and the `buildLegacyLeagueTeamId` / `extractLeagueCode` helpers are removed in a follow-up PR (`feature/doronkilzi/remove-fantasy-id-migration`).
-
 ### Best-Team Ranking
 
 `/set_best_team_ranking` lets the user choose how much expected budget change should influence `/best_teams` ordering. The calculator ranks teams using projected points plus a hidden budget-change bonus:

--- a/src/cacheInitializer.js
+++ b/src/cacheInitializer.js
@@ -7,11 +7,8 @@ const {
   nextRaceInfoCache,
   userCache,
   remainingRaceCountCache,
-  bestTeamsCache,
-  selectedChipCache,
   normalizeBestTeamBudgetChangePointsPerMillion,
   normalizeSelectedBestTeamByTeam,
-  serializeSelectedBestTeamByTeam,
 } = require('./cache');
 const {
   sendLogMessage,
@@ -30,15 +27,11 @@ const {
   getNextRaceInfoData,
   getLeagueTeamsData,
   saveUserTeam,
-  deleteUserTeam,
 } = require('./azureStorageService');
-const { listAllUsers, updateUserAttributes } = require('./userRegistryService');
+const { listAllUsers } = require('./userRegistryService');
 const { fetchRemainingRaceCount } = require('./raceScheduleService');
-const {
-  sanitizeIdSegment,
-  buildLeagueTeamId,
-} = require('./utils/teamId');
 const { listUserLeagues } = require('./leagueRegistryService');
+const { buildLeagueTeamId } = require('./utils/teamId');
 const { mapLeagueTeamToBotTeam } = require('./utils/leagueTeamHelpers');
 
 /**
@@ -213,22 +206,13 @@ Constructors not found in mapping: ${notFounds.constructors.join(', ')}
 }
 
 /**
- * For any cached team in league format, re-fetch the league's teams-data.json
- * and replace the cached data (and the persisted blob) with the latest
- * roster/budget/transfers for that team.
+ * For any cached team in league format (`{sanitize(userName)}_{teamNo}`),
+ * re-fetch the team's latest entry from one of the user's followed
+ * `teams-data.json` blobs and replace the cached data + persisted blob
+ * with the latest roster/budget/transfers.
  *
- * This pass ALSO performs the one-time migration from the legacy league-scoped
- * teamId (`{leagueCode}_{sanitizedTeamName}`) to the new league-agnostic
- * fantasy teamId (`{sanitize(userName)}_{teamNo}`). Detection rule: a teamId
- * is in legacy format iff its prefix (split at the first `_`) matches one of
- * the user's followed leagueCodes; otherwise it's already in the new format.
- *
- * Best-effort: errors for individual leagues or teams are logged but do not
- * abort cache initialization. Failed migrations leave the old entry in place;
- * retried on next startup.
- *
- * @todo PR B (`feature/doronkilzi/remove-fantasy-id-migration`) deletes the
- * legacy-detection + migration branch of this function.
+ * Best-effort: errors for individual leagues or teams are logged but do
+ * not abort cache initialization.
  */
 async function refreshLeagueSourcedTeams(bot) {
   const leagueTeamsByCode = {};
@@ -236,8 +220,6 @@ async function refreshLeagueSourcedTeams(bot) {
   let refreshed = 0;
   let missing = 0;
   let failed = 0;
-  let migrated = 0;
-  let migrationConflicts = 0;
 
   async function loadLeagueTeams(leagueCode) {
     if (!(leagueCode in leagueTeamsByCode)) {
@@ -256,12 +238,12 @@ async function refreshLeagueSourcedTeams(bot) {
     if (!(chatId in userLeagueCodesByChatId)) {
       try {
         const leagues = await listUserLeagues(chatId);
-        userLeagueCodesByChatId[chatId] = new Set(
-          (leagues || []).map((l) => l.leagueCode),
+        userLeagueCodesByChatId[chatId] = (leagues || []).map(
+          (l) => l.leagueCode,
         );
       } catch (err) {
         console.error(`Failed to list user leagues for ${chatId}:`, err);
-        userLeagueCodesByChatId[chatId] = new Set();
+        userLeagueCodesByChatId[chatId] = [];
       }
     }
 
@@ -271,148 +253,14 @@ async function refreshLeagueSourcedTeams(bot) {
   for (const [chatId, teamsById] of Object.entries(currentTeamCache)) {
     if (!teamsById || typeof teamsById !== 'object') {continue;}
 
-    const userKey = String(chatId);
     const followedLeagueCodes = await loadFollowedLeagueCodes(chatId);
-
-    // Snapshot keys up-front — we mutate `teamsById` during the loop.
     const teamIds = Object.keys(teamsById);
 
-    for (const oldTeamId of teamIds) {
-      const underscoreIdx = oldTeamId.indexOf('_');
-      if (underscoreIdx <= 0) {continue;} // screenshot team (T1/T2/T3)
-
-      const prefix = oldTeamId.slice(0, underscoreIdx);
-      const isLegacyFormat = followedLeagueCodes.has(prefix);
+    for (const teamId of teamIds) {
+      // Screenshot teams (`T1`/`T2`/`T3`) have no `_` — skip.
+      if (!teamId.includes('_')) {continue;}
 
       try {
-        if (isLegacyFormat) {
-          // ---- Legacy → new-format migration path ----
-          const leagueCode = prefix;
-          const sanitizedSlug = oldTeamId.slice(underscoreIdx + 1);
-          const data = await loadLeagueTeams(leagueCode);
-
-          if (!data || !Array.isArray(data.teams)) {
-            missing += 1;
-            continue; // retry next startup
-          }
-
-          const match = data.teams.find(
-            (team) => sanitizeIdSegment(team.teamName) === sanitizedSlug,
-          );
-
-          if (!match) {
-            missing += 1;
-            continue;
-          }
-
-          const newTeamId = buildLeagueTeamId(match.userName, match.teamNo);
-          if (!newTeamId) {
-            // Upstream blob still missing teamNo (legacy api-data).
-            // Refresh in place under the old id; retry on next startup.
-            const refreshedTeam = mapLeagueTeamToBotTeam(match);
-            currentTeamCache[chatId][oldTeamId] = refreshedTeam;
-            try {
-              await saveUserTeam(bot, chatId, oldTeamId, refreshedTeam, {
-                silent: true,
-              });
-            } catch (saveErr) {
-              console.error(
-                `Failed to persist refreshed legacy team ${oldTeamId} for ${chatId}:`,
-                saveErr,
-              );
-            }
-            refreshed += 1;
-            continue;
-          }
-
-          const refreshedTeam = mapLeagueTeamToBotTeam(match);
-
-          // Save new blob first; if that fails, abort migration for this
-          // entry (leave old blob/cache intact for retry).
-          try {
-            await saveUserTeam(bot, chatId, newTeamId, refreshedTeam, {
-              silent: true,
-            });
-          } catch (saveErr) {
-            console.error(
-              `Failed to save migrated team blob ${newTeamId} for ${chatId}:`,
-              saveErr,
-            );
-            failed += 1;
-            continue;
-          }
-
-          // Move in-memory caches (dedup on collision — same fantasy id
-          // already followed via another league).
-          const collision =
-            currentTeamCache[chatId][newTeamId] !== undefined &&
-            newTeamId !== oldTeamId;
-          if (collision) {
-            migrationConflicts += 1;
-          } else {
-            currentTeamCache[chatId][newTeamId] = refreshedTeam;
-          }
-          delete currentTeamCache[chatId][oldTeamId];
-
-          if (bestTeamsCache[chatId] && oldTeamId in bestTeamsCache[chatId]) {
-            if (!(newTeamId in bestTeamsCache[chatId])) {
-              bestTeamsCache[chatId][newTeamId] = bestTeamsCache[chatId][oldTeamId];
-            }
-            delete bestTeamsCache[chatId][oldTeamId];
-          }
-
-          if (
-            selectedChipCache[chatId] &&
-            oldTeamId in selectedChipCache[chatId]
-          ) {
-            if (!(newTeamId in selectedChipCache[chatId])) {
-              selectedChipCache[chatId][newTeamId] =
-                selectedChipCache[chatId][oldTeamId];
-            }
-            delete selectedChipCache[chatId][oldTeamId];
-          }
-
-          // userCache: rename selectedTeam if it points at the old id, and
-          // rename keys inside selectedBestTeamByTeam.
-          if (userCache[userKey]) {
-            if (userCache[userKey].selectedTeam === oldTeamId) {
-              userCache[userKey].selectedTeam = newTeamId;
-            }
-            const sbtbt = normalizeSelectedBestTeamByTeam(
-              userCache[userKey].selectedBestTeamByTeam,
-            );
-            if (oldTeamId in sbtbt) {
-              if (!(newTeamId in sbtbt)) {
-                sbtbt[newTeamId] = sbtbt[oldTeamId];
-              }
-              delete sbtbt[oldTeamId];
-              userCache[userKey].selectedBestTeamByTeam = sbtbt;
-            }
-          }
-
-          // Delete the old blob. Failure here leaves a stray blob but the
-          // cache is already consistent; tolerate.
-          try {
-            await deleteUserTeam(bot, chatId, oldTeamId, { silent: true });
-          } catch (delErr) {
-            console.error(
-              `Failed to delete legacy blob ${oldTeamId} for ${chatId} (cache already migrated):`,
-              delErr,
-            );
-          }
-
-          migrated += 1;
-          continue;
-        }
-
-        // ---- New-format in-place refresh path ----
-        // Parse the new id: `{sanitizedUserName}_{teamNo}`. We can't
-        // recover the raw userName from the sanitized form, so we match
-        // by rebuilding the id from each candidate team and comparing.
-        const lastUnderscoreIdx = oldTeamId.lastIndexOf('_');
-        if (lastUnderscoreIdx <= 0) {continue;}
-
-        // Try refreshing from each followed league until we find a match.
         let foundMatch = null;
         for (const leagueCode of followedLeagueCodes) {
           const data = await loadLeagueTeams(leagueCode);
@@ -420,7 +268,7 @@ async function refreshLeagueSourcedTeams(bot) {
 
           const match = data.teams.find(
             (team) =>
-              buildLeagueTeamId(team.userName, team.teamNo) === oldTeamId,
+              buildLeagueTeamId(team.userName, team.teamNo) === teamId,
           );
           if (match) {
             foundMatch = match;
@@ -434,15 +282,15 @@ async function refreshLeagueSourcedTeams(bot) {
         }
 
         const refreshedTeam = mapLeagueTeamToBotTeam(foundMatch);
-        currentTeamCache[chatId][oldTeamId] = refreshedTeam;
+        currentTeamCache[chatId][teamId] = refreshedTeam;
 
         try {
-          await saveUserTeam(bot, chatId, oldTeamId, refreshedTeam, {
+          await saveUserTeam(bot, chatId, teamId, refreshedTeam, {
             silent: true,
           });
         } catch (saveErr) {
           console.error(
-            `Failed to persist refreshed league team ${oldTeamId} for ${chatId}:`,
+            `Failed to persist refreshed league team ${teamId} for ${chatId}:`,
             saveErr,
           );
         }
@@ -451,44 +299,17 @@ async function refreshLeagueSourcedTeams(bot) {
       } catch (err) {
         failed += 1;
         console.error(
-          `Failed to refresh league-sourced team ${oldTeamId} for ${chatId}:`,
-          err,
-        );
-      }
-    }
-
-    // Persist userCache changes for this chatId if migration touched them.
-    if (userCache[userKey]) {
-      try {
-        await updateUserAttributes(chatId, {
-          selectedTeam: userCache[userKey].selectedTeam || null,
-          selectedBestTeamByTeam: serializeSelectedBestTeamByTeam(
-            userCache[userKey].selectedBestTeamByTeam,
-          ),
-        });
-      } catch (err) {
-        console.error(
-          `Failed to persist migrated user attributes for ${chatId}:`,
+          `Failed to refresh league-sourced team ${teamId} for ${chatId}:`,
           err,
         );
       }
     }
   }
 
-  if (
-    refreshed > 0 ||
-    missing > 0 ||
-    failed > 0 ||
-    migrated > 0 ||
-    migrationConflicts > 0
-  ) {
-    const migrationNote =
-      migrated > 0 || migrationConflicts > 0
-        ? `, ${migrated} migrated to new id format (${migrationConflicts} dedup'd)`
-        : '';
+  if (refreshed > 0 || missing > 0 || failed > 0) {
     await sendLogMessage(
       bot,
-      `League-sourced teams refresh: ${refreshed} refreshed, ${missing} missing in league, ${failed} failed${migrationNote}`,
+      `League-sourced teams refresh: ${refreshed} refreshed, ${missing} missing in league, ${failed} failed`,
     );
   }
 }

--- a/src/cacheInitializer.test.js
+++ b/src/cacheInitializer.test.js
@@ -15,9 +15,8 @@ const {
   getNextRaceInfoData,
   getLeagueTeamsData,
   saveUserTeam,
-  deleteUserTeam,
 } = require('./azureStorageService');
-const { listAllUsers, updateUserAttributes } = require('./userRegistryService');
+const { listAllUsers } = require('./userRegistryService');
 const { listUserLeagues } = require('./leagueRegistryService');
 const {
   initializeCaches,
@@ -42,12 +41,10 @@ jest.mock('./azureStorageService', () => ({
   getNextRaceInfoData: jest.fn(),
   getLeagueTeamsData: jest.fn(),
   saveUserTeam: jest.fn(),
-  deleteUserTeam: jest.fn(),
 }));
 
 jest.mock('./userRegistryService', () => ({
   listAllUsers: jest.fn(),
-  updateUserAttributes: jest.fn(),
 }));
 
 jest.mock('./leagueRegistryService', () => ({
@@ -313,15 +310,11 @@ describe('cacheInitializer', () => {
     beforeEach(() => {
       getLeagueTeamsData.mockReset();
       saveUserTeam.mockReset().mockResolvedValue(undefined);
-      deleteUserTeam.mockReset().mockResolvedValue(undefined);
-      updateUserAttributes.mockReset().mockResolvedValue(undefined);
       listUserLeagues.mockReset().mockResolvedValue([]);
       Object.keys(userCache).forEach((k) => delete userCache[k]);
     });
 
     it('refreshes new-format teams (sanitizedUserName_teamNo) from the latest league blob', async () => {
-      // Already in new format — leagueCode prefix doesn't appear in
-      // listUserLeagues, so migration is skipped.
       currentTeamCache[111] = {
         T1: { drivers: ['OLD'], constructors: ['OLD'] },
         'My-Team-Owner_1': { drivers: ['STALE'], constructors: ['STALE'] },
@@ -396,145 +389,6 @@ describe('cacheInitializer', () => {
         expect.any(Object),
         { silent: true },
       );
-    });
-
-    it('migrates legacy-format teamIds to {sanitizedUserName}_{teamNo}', async () => {
-      // Legacy id `ABC_My-Team` with user following league ABC → migration
-      // path is taken. teamNo is present in the league blob, so the
-      // migration completes.
-      currentTeamCache[111] = {
-        'ABC_My-Team': { drivers: ['STALE'], constructors: ['STALE'] },
-      };
-      userCache['111'] = {
-        selectedTeam: 'ABC_My-Team',
-        selectedBestTeamByTeam: {
-          'ABC_My-Team': {
-            drivers: ['x'],
-            constructors: ['y'],
-            boostDriver: 'x',
-          },
-        },
-      };
-
-      listUserLeagues.mockResolvedValue([
-        { leagueCode: 'ABC', leagueName: 'League ABC' },
-      ]);
-
-      getLeagueTeamsData.mockResolvedValue({
-        leagueName: 'League ABC',
-        teams: [
-          {
-            teamName: 'My Team',
-            userName: 'My Team Owner',
-            teamNo: 1,
-            position: 1,
-            budget: 100,
-            transfersRemaining: 2,
-            drivers: [{ name: 'M. Verstappen', price: 30, isCaptain: true }],
-            constructors: [{ name: 'Red Bull Racing', price: 20 }],
-          },
-        ],
-      });
-
-      await refreshLeagueSourcedTeams(mockBot);
-
-      // Old id removed, new id present
-      expect(currentTeamCache[111]['ABC_My-Team']).toBeUndefined();
-      expect(currentTeamCache[111]['My-Team-Owner_1']).toEqual(
-        expect.objectContaining({
-          drivers: ['VER'],
-          constructors: ['RED'],
-          boost: 'VER',
-        }),
-      );
-      // userCache.selectedTeam was renamed
-      expect(userCache['111'].selectedTeam).toBe('My-Team-Owner_1');
-      // selectedBestTeamByTeam key was renamed
-      expect(
-        userCache['111'].selectedBestTeamByTeam['My-Team-Owner_1'],
-      ).toBeDefined();
-      expect(
-        userCache['111'].selectedBestTeamByTeam['ABC_My-Team'],
-      ).toBeUndefined();
-      // Old blob deleted
-      expect(deleteUserTeam).toHaveBeenCalledWith(
-        mockBot,
-        '111',
-        'ABC_My-Team',
-        { silent: true },
-      );
-      // Migrated attributes persisted via Azure Table merge
-      expect(updateUserAttributes).toHaveBeenCalledWith(
-        '111',
-        expect.objectContaining({ selectedTeam: 'My-Team-Owner_1' }),
-      );
-    });
-
-    it('dedups when the same fantasy team is followed via multiple leagues', async () => {
-      // User had `ABC_Kilzid` AND `XYZ_Kilzid` — both refer to the same
-      // F1 Fantasy team. After migration only one entry remains.
-      currentTeamCache[111] = {
-        'ABC_Kilzid': { drivers: ['STALE1'] },
-        'XYZ_Kilzid': { drivers: ['STALE2'] },
-      };
-      listUserLeagues.mockResolvedValue([
-        { leagueCode: 'ABC', leagueName: 'League ABC' },
-        { leagueCode: 'XYZ', leagueName: 'League XYZ' },
-      ]);
-      getLeagueTeamsData.mockImplementation((code) => {
-        const team = {
-          teamName: 'Kilzid',
-          userName: 'Doron Kilzi',
-          teamNo: 1,
-          position: 1,
-          budget: 100,
-          transfersRemaining: 1,
-          drivers: [{ name: 'O. Bearman', price: 10, isCaptain: true }],
-          constructors: [{ name: 'Racing Bulls', price: 5 }],
-        };
-
-        return Promise.resolve({ leagueCode: code, teams: [team] });
-      });
-
-      await refreshLeagueSourcedTeams(mockBot);
-
-      const cacheForUser = currentTeamCache[111];
-      expect(Object.keys(cacheForUser)).toEqual(['Doron-Kilzi_1']);
-      expect(cacheForUser['Doron-Kilzi_1']).toBeDefined();
-    });
-
-    it('leaves legacy ids alone when the upstream blob has no teamNo yet', async () => {
-      // Pre-PR-#18 data — userName present but teamNo missing. We refresh
-      // in place under the legacy id and retry migration on next startup.
-      currentTeamCache[111] = {
-        'ABC_My-Team': { drivers: ['STALE'] },
-      };
-      listUserLeagues.mockResolvedValue([
-        { leagueCode: 'ABC', leagueName: 'League ABC' },
-      ]);
-      getLeagueTeamsData.mockResolvedValue({
-        teams: [
-          {
-            teamName: 'My Team',
-            userName: 'My Team Owner',
-            // no teamNo
-            position: 1,
-            budget: 100,
-            transfersRemaining: 2,
-            drivers: [{ name: 'M. Verstappen', price: 30, isCaptain: true }],
-            constructors: [{ name: 'Red Bull Racing', price: 20 }],
-          },
-        ],
-      });
-
-      await refreshLeagueSourcedTeams(mockBot);
-
-      // Old id still present (refreshed in place)
-      expect(currentTeamCache[111]['ABC_My-Team']).toEqual(
-        expect.objectContaining({ drivers: ['VER'], boost: 'VER' }),
-      );
-      expect(currentTeamCache[111]['My-Team-Owner_undefined']).toBeUndefined();
-      expect(deleteUserTeam).not.toHaveBeenCalled();
     });
 
     it('is a no-op for users with only T1/T2/T3 style ids', async () => {

--- a/src/utils/leagueTeamHelpers.js
+++ b/src/utils/leagueTeamHelpers.js
@@ -5,7 +5,6 @@ const {
   sanitizeIdSegment,
   sanitizeTeamName,
   buildLeagueTeamId,
-  buildLegacyLeagueTeamId,
 } = require('./teamId');
 const {
   currentTeamCache,
@@ -222,17 +221,6 @@ async function removeFollowedTeam(
   return { removed: true, fallbackSelectedTeam };
 }
 
-/**
- * @deprecated Used only by the lazy migration in `cacheInitializer.js` to
- * detect old-format teamIds (`{leagueCode}_{sanitizedTeamName}`). Once
- * migration is removed in PR B this function goes away.
- */
-function extractLeagueCode(teamId) {
-  const separatorIdx = teamId.indexOf('_');
-
-  return separatorIdx === -1 ? null : teamId.substring(0, separatorIdx);
-}
-
 function buildLeagueNameMap(leagues) {
   const map = {};
   for (const league of leagues || []) {
@@ -262,11 +250,9 @@ module.exports = {
   refreshLeagueTeamsData,
   followLeagueTeam,
   removeFollowedTeam,
-  extractLeagueCode,
   buildLeagueNameMap,
   buildTeamLabel,
   sanitizeIdSegment,
   sanitizeTeamName,
   buildLeagueTeamId,
-  buildLegacyLeagueTeamId,
 };

--- a/src/utils/teamId.js
+++ b/src/utils/teamId.js
@@ -1,7 +1,6 @@
 /**
  * Sanitize a value so it can be safely embedded into an id segment / blob path.
- * Keeps the result short and readable. Generalized from the previous
- * `sanitizeTeamName` — works for any string (team names, user names, etc.).
+ * Keeps the result short and readable.
  */
 function sanitizeIdSegment(value) {
   const base = String(value || 'team')
@@ -37,20 +36,6 @@ function buildLeagueTeamId(userName, teamNo) {
   return `${sanitizeIdSegment(userName)}_${teamNo}`;
 }
 
-/**
- * Legacy league-team id builder, kept ONLY so the cacheInitializer
- * migration path can detect and rewrite old blobs/cache entries.
- * Removed in the follow-up PR after production has fully migrated.
- *
- * Old format: `{leagueCode}_{sanitizeIdSegment(teamName)}` — encodes the
- * league, so the same F1 Fantasy team in two leagues had two distinct ids.
- *
- * @deprecated Use `buildLeagueTeamId(userName, teamNo)` for new code.
- */
-function buildLegacyLeagueTeamId(leagueCode, teamName) {
-  return `${leagueCode}_${sanitizeIdSegment(teamName)}`;
-}
-
 // Back-compat alias — some call sites still use the old function name to
 // sanitize team names for display/callback-payload purposes (not id
 // construction). Safe to keep.
@@ -60,6 +45,5 @@ module.exports = {
   sanitizeIdSegment,
   sanitizeTeamName,
   buildLeagueTeamId,
-  buildLegacyLeagueTeamId,
 };
 


### PR DESCRIPTION
## ⚠️ DRAFT — do not merge yet

Stacked on top of [#178](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/178). **Merge target is `feature/doronkilzi/migrate-fantasy-team-id`** (which itself targets `main`), so this PR's diff cleanly shows just the migration removal.

Once #178 merges to `main`, GitHub will auto-retarget this PR's base to `main`.

## When to merge

After you've confirmed that all active users have visited production **at least once** since #178 was deployed (so their data has been migrated by the lazy startup pass). Recommended window: **≤30 days** after #178 lands, so the migration code doesn't accumulate entropy.

## What this PR removes

- **Migration branch** inside `cacheInitializer.refreshLeagueSourcedTeams` — the function returns to a clean refresh-in-place loop.
- **`buildLegacyLeagueTeamId`** helper in `src/utils/teamId.js`.
- **`extractLeagueCode`** helper in `src/utils/leagueTeamHelpers.js` (no remaining consumers).
- Migration-specific tests in `cacheInitializer.test.js` (3 cases).
- The "Lazy migration from legacy league teamIds" section in `AGENTS.md`.

## What this PR keeps

- `deleteUserTeam`'s `silent` option (added by #178 for migration but useful as a general parameter).

## Verified

- `npm run lint` clean.
- `npm test` — 706/706 passing (down from 709, just the 3 removed migration tests).

## Diff scope

390 lines deleted, 23 added — exclusively cleanup. No behavior changes for migrated users.