### PR TITLE
feat: web-agent best-teams (Phase 2) + cost-cap fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Both surfaces share the same business logic via **pure cores** in `src/cores/`. 
   - `src/azureStorageService.js` and `src/azureBillingService.js` wrap Azure integrations.
 - **Internationalization:** `src/i18n.js` and `src/translations.js` provide language support (English/Hebrew) used throughout handlers.
 - **AI Assist:** `src/prompts.js` defines system prompts. `/ask`-style natural language queries are handled by `src/commandsHandler/askHandler.js`, which leverages Azure OpenAI to map free-text requests into command sequences.
-- **Logic Cores:** `src/cores/` holds **pure** business-logic functions that take inputs and return structured JSON. They do not depend on `bot`, `t()`, or `sendMessage`. Each Telegram handler is being progressively refactored into `(pure core in src/cores/) + (thin Telegram adapter)`. The same core is consumed by the web-chat agent's tools — so a question like "best teams with VER but no ALO" runs through the same calculator as the `/best_teams` command. **Refactor rule:** existing handler tests must keep passing unchanged after the extraction; if they don't, fix the refactor, not the test. Phase 1 has extracted only `nextRacesCore.js`; more will land as future phases ship.
+- **Logic Cores:** `src/cores/` holds **pure** business-logic functions that take inputs and return structured JSON. They do not depend on `bot`, `t()`, or `sendMessage`. Each Telegram handler is being progressively refactored into `(pure core in src/cores/) + (thin Telegram adapter)`. The same core is consumed by the web-chat agent's tools — so a question like "best teams with VER but no ALO" runs through the same calculator as the `/best_teams` command. **Refactor rule:** existing handler tests must keep passing unchanged after the extraction; if they don't, fix the refactor, not the test. Phases 1–2 have extracted `nextRacesCore.js`, `bestTeamsCore.js`, and `userTeamsCore.js`; more will land as future phases ship.
 - **Agent (Web Chat):** `src/agent/`, `agentWebhook/`, and `web/` together implement a second user-facing surface. Identity is resolved from the `AGENT_HARDCODED_CHAT_ID` env var (v1) so all tool calls operate as that user against the same caches/blobs as the Telegram bot. See the [Agent (Web Chat)](#agent-web-chat) section for the full architecture, the cores↔tools pattern, and how to add a new tool with a matching React component.
 
 ---
@@ -310,7 +310,7 @@ The table is **extensible** — new attributes can be added at any time without 
 `src/leagueRegistryService.js` tracks league follows in an Azure Table Storage table (`UserLeagues`). Data is produced by the sibling repo `f1-fantasy-api-data`, which writes two blobs per league to Azure Blob Storage in the same container (`AZURE_STORAGE_CONTAINER_NAME`) used by the bot:
 
 - `leagues/{leagueCode}/league-standings.json` — header + `teams: [{ teamName, userName, position, totalScore, raceScores, raceBudgets, chipsUsed }]`. Used by `/leaderboard` and `/league_graphs`.
-- `leagues/{leagueCode}/teams-data.json` — header + `teams: [{ teamName, userName, position, budget, transfersRemaining, drivers, constructors }]` where each roster entry is `{ id, name, price, isCaptain, isMegaCaptain, isFinal }`. Used by `/teams_tracker` to load/manage followed team rosters from the league directly into the bot's cache.
+- `leagues/{leagueCode}/teams-data.json` — header + `teams: [{ teamName, userName, position, budget, transfersRemaining, drivers, constructors }]` where each roster entry is `{ id, name, price, isCaptain, isMegaCaptain, isFinal }`. Used by `/teams_tracker` to load/manage followed team rosters from the league directly into the bot's cache. `budget` is the user's cost cap going into the upcoming matchday (`team_info.maxTeambal` from upstream — see f1-fantasy-api-data PR #19). The bot's `mapLeagueTeamToBotTeam` derives `costCapRemaining = max(0, budget − Σ_prices)`. Blobs written before that PR shipped carried `budget = team_info.teamVal` (≈ Σ_prices) which trivially yields `costCapRemaining = 0` through the same formula — same as production today, no regression during the deployment transition.
 - `leagues/{leagueCode}/locked/matchday_{N}.json` — one blob per locked matchday written by the upstream `MODE=locked` scrape (fires ~1 minute after each session start: qualifying, race, and on sprint weekends the sprint race). Same per-team shape as `teams-data.json` plus a top-level `mode: 'locked'` discriminator and per-team `chipsUsed: [{ name, gameDayId }]`. Used by `/league_changes` and `/live_score`.
 
 ### How It Works
@@ -540,6 +540,12 @@ Blob naming includes the team ID:
 
 A second user-facing surface that runs the same business logic as the Telegram bot through tool calls. Architecture, code layout, and the patterns for adding new capabilities live in this section.
 
+Phase-2 capabilities (shipped):
+
+- `get_next_races` — upcoming races for the season (Phase 1).
+- `list_user_teams` — the user's tracked teams (teamId + friendly teamName).
+- `get_best_teams` — top scoring fantasy combinations with optional must-include / must-exclude filters on drivers and constructors (the marquee "best teams for X with Verstappen but no Alonso" question runs here).
+
 ### Architecture
 
 ```
@@ -599,6 +605,7 @@ Browser (Vite + React + CopilotKit)
 | **`@ai-sdk/azure`** with `useDeploymentBasedUrls: true` | Stock `@ai-sdk/openai` builds URLs as `/openai/responses` — wrong for Azure. The Azure provider knows the `/openai/deployments/{model}/chat/completions?api-version=…` shape. Pass `baseURL: '${endpoint}/openai'` so it works for both `*.openai.azure.com` (classic) and `*.services.ai.azure.com` (Azure AI Foundry) hosts. Use `azure.chat(deploymentId)` — `azure(deploymentId)` returns the `/responses` API model and 404s on most deployments. |
 | **Zod** for tool parameters | Required by `defineTool` (Standard Schema V1). Already a transitive dep through `@copilotkit/runtime`. |
 | **Single-route mode** on the runtime handler | The default `multi-route` mode would force the frontend to address per-route URLs; single-route keeps the frontend pointed at `{basePath}` with a JSON envelope. Side effect: `GET /threads?agentId=…` returns 405 in single-route — these errors in the browser console are harmless and represent chat-history persistence we haven't enabled. |
+| **`parallelToolCalls: false`** on the agent's `providerOptions.openai` | CopilotKit's `useLazyToolRenderer` (`node_modules/@copilotkit/react-core/src/hooks/use-lazy-tool-renderer.tsx` line 15) only ever renders `message.toolCalls[0]`. When Azure OpenAI emits two tool calls in the SAME assistant message (its default behaviour for independent tool calls), only the first React component renders and the rest are silently dropped. Forcing sequential calls makes each tool land in its own assistant message, so each gets its own rich UI render. |
 | **Separate Azure Function App** for the agent | Independent deploy/scale/failure-isolation from the Telegram bot. An agent rollout cannot break Telegram. The agent re-initialises any state it needs on cold start. |
 
 ### Code layout
@@ -607,14 +614,19 @@ Browser (Vite + React + CopilotKit)
 f1-fantazy-bot/
 ├── src/
 │   ├── cores/
-│   │   └── nextRacesCore.js          # pure: getNextRaces() → {season, races, counts}
+│   │   ├── nextRacesCore.js          # pure: getNextRaces() → {season, races, counts}
+│   │   ├── bestTeamsCore.js          # pure: computeBestTeams({chatId, teamId?, teamName?, rankBy?, mustInclude*, mustExclude*})
+│   │   └── userTeamsCore.js          # pure: listUserTeams({chatId}) → [{teamId, teamName, ...}]
 │   ├── agent/
 │   │   ├── identity.js               # AGENT_HARDCODED_CHAT_ID (LLM never sees it)
 │   │   ├── systemPrompt.js           # English-only v1; built once at startup
 │   │   ├── tools.js                  # defineTool({ name, description, parameters: z.object({…}), execute })
+│   │   ├── cacheBootstrap.js         # ensureCacheReady() — lazy initializeCaches(noopBot) for agent process
 │   │   └── runtime.js                # BuiltInAgent + CopilotRuntime + createCopilotRuntimeHandler
+│   ├── bestTeamsCalculator.js        # exports an optional `options` arg: filters + rankBy + resultCount
 │   └── commandsHandler/
-│       └── nextRacesHandler.js       # refactored: thin Telegram adapter over the core
+│       ├── nextRacesHandler.js       # refactored: thin Telegram adapter over the core
+│       └── bestTeamsHandler.js       # refactored: thin Telegram adapter over the core
 ├── agentWebhook/
 │   ├── function.json                 # httpTrigger, route `agent/{*restOfPath}`
 │   └── index.js                      # Azure Functions v3 ↔ Web Request bridge
@@ -622,12 +634,34 @@ f1-fantazy-bot/
 │   ├── src/
 │   │   ├── App.tsx                   # <CopilotKit runtimeUrl=…> + <CopilotChat />
 │   │   └── components/
-│   │       └── NextRacesTable.tsx    # useCopilotAction({ available: 'frontend', render })
+│   │       ├── NextRacesTable.tsx    # useCopilotAction({ name: 'get_next_races', available: 'frontend', render })
+│   │       ├── BestTeamsTable.tsx    # useCopilotAction({ name: 'get_best_teams', available: 'frontend', render })
+│   │       └── UserTeamsList.tsx     # useCopilotAction({ name: 'list_user_teams', available: 'frontend', render })
 │   ├── package.json
 │   └── …                             # own package.json — frontend deps don't pollute the backend
 └── scripts/
     └── dev-agent-server.js           # local Node HTTP wrapper around agentWebhook (no `func` CLI needed)
 ```
+
+### Cache bootstrap (cross-process)
+
+The Telegram bot's `src/bot.js` runs `initializeCaches(bot)` at startup so every command handler can read from `driversCache`, `currentTeamCache`, etc. The agent runs in a **separate process** (its own Azure Function App) and therefore has its own empty in-memory caches — they MUST be populated before any tool that reads them can run.
+
+`src/agent/cacheBootstrap.js` exports `ensureCacheReady()`: it lazily calls `initializeCaches(noopBot)` once per process, where `noopBot` is `{ sendMessage: async () => undefined }` so the bot-side `sendLogMessage`/`sendErrorMessage`/`sendMessageToAdmins` calls become no-ops (the agent process has no Telegram token). The promise is cached for reuse; on failure it resets so the next tool call retries from scratch (transient Azure errors don't brick the agent for the lifetime of the process).
+
+Tools that need caches MUST `await ensureCacheReady()` before reading from `currentTeamCache`/`driversCache`/etc.:
+
+```js
+execute: async (args) => {
+  await ensureCacheReady();
+  const chatId = getAgentChatId();
+  return await computeBestTeams({ chatId, ...args });
+},
+```
+
+Tools that don't need caches (e.g. `get_next_races` calls Ergast directly) can skip the await.
+
+> **Caveat:** `initializeCaches` also runs `refreshLeagueSourcedTeams`, which can `saveUserTeam` back to Azure Storage. The agent process needs the same Azure Storage credentials the bot does, and league refreshes happen idempotently on both sides — this is intentional but worth knowing during deployment.
 
 ### Tool definitions
 
@@ -670,6 +704,8 @@ useCopilotAction({
 
 > **Pitfall (don't repeat):** without `available: 'frontend'`, CopilotKit's `getActionConfig` throws `Invalid action configuration` and the whole React tree crashes blank. The marker tells CopilotKit "this is render-only for a backend-executed tool".
 
+> **Pitfall (Phase 2):** if you don't disable parallel tool calls (`providerOptions: { openai: { parallelToolCalls: false } }` on the `BuiltInAgent`), Azure OpenAI is free to emit multiple tools in the SAME assistant message — and CopilotKit's `useLazyToolRenderer` only renders `toolCalls[0]`. You'll see ONE of N tool results render and the rest silently disappear from the UI (the LLM's text reply will still describe them correctly, just no rich component). Fix: keep parallel calls disabled in `src/agent/runtime.js`.
+
 ### Identity model (v1)
 
 - `AGENT_HARDCODED_CHAT_ID` env var is the only identity. `src/agent/identity.js` reads it once and exposes `getAgentChatId()`.
@@ -707,9 +743,9 @@ npm run dev:web      # only Vite frontend on :5173/:5174
 
 1. **Extract the core** at `src/cores/<feature>Core.js`. Pure function, structured JSON return.
 2. **Refactor the matching Telegram handler** to call the core. Run `npx jest <handler>.test.js` — must pass unchanged.
-3. **Add the tool** to `src/agent/tools.js` via `defineTool({ name, description, parameters: z.object({…}), execute })`. The `execute` handler calls the core. If `chatId` is needed, use `getAgentChatId()` from `src/agent/identity.js`.
-4. **Update the system prompt** in `src/agent/systemPrompt.js` if the new tool requires guidance (e.g., "if the user names a team, first call `list_user_teams` to resolve the teamId").
-5. **Build the React component** at `web/src/components/<Feature>.tsx`. Define it inside a `useCopilotAction({ name, available: 'frontend', render })` hook (the hook must run inside a component mounted under `<CopilotKit>`).
+3. **Add the tool** to `src/agent/tools.js` via `defineTool({ name, description, parameters: z.object({…}), execute })`. The `execute` handler calls the core. If `chatId` is needed, use `getAgentChatId()` from `src/agent/identity.js`. **If the core reads from `currentTeamCache`/`driversCache`/etc, `await ensureCacheReady()` first** (see [Cache bootstrap](#cache-bootstrap-cross-process)).
+4. **Update the system prompt** in `src/agent/systemPrompt.js` if the new tool requires guidance (e.g. "if the user names a team in a 'best teams' question, call get_best_teams directly with `teamName` — don't pre-call list_user_teams; the multi-step routing costs latency and only one rich UI component can render per assistant turn").
+5. **Build the React component** at `web/src/components/<Feature>.tsx`. Define it inside a `useCopilotAction({ name, available: 'frontend', render })` hook (the hook must run inside a component mounted under `<CopilotKit>`). Match `name` exactly to the backend tool's name; for `available: 'frontend'` actions the `parameters` array is metadata-only — keep it as `[]` to avoid TypeScript / shape-matching issues with CopilotKit's frontend tooling.
 6. **Wire the hook** by importing and calling it from `web/src/App.tsx` (or wherever the `<AgentActions />` component lives).
 7. **Tests:** unit-test the core in `src/cores/<feature>Core.test.js`. Unit-test the tool's JSON shape if non-trivial. Re-run the full Telegram suite — must stay green.
 8. **Verify in-browser with Playwright MCP.** The browser is the source of truth for UI changes — every UI change must be Playwright-verified before declaring "done".
@@ -720,20 +756,27 @@ npm run dev:web      # only Vite frontend on :5173/:5174
 - **SSE streaming on Azure Functions Consumption plan** is unverified — locally the bridge buffers the full response. If streaming flushing turns out to be flaky on Consumption, fall back to non-streaming JSON or upgrade to Premium. Phase 6 hardening item.
 - **CORS** is currently permissive (`Access-Control-Allow-Origin: *`). Phase 6 locks it down to the production Static Web App origin.
 - **Hebrew localisation** of agent outputs is out of v1 scope. The Telegram bot stays bilingual.
+- **Multi-tool-call rendering**: CopilotKit's `useLazyToolRenderer` only renders `message.toolCalls[0]`. We force sequential tool calls via `parallelToolCalls: false`. If a future tool needs to fan out (e.g., "best teams for every team I track"), it has to do so server-side inside one `execute` and return a list — the LLM cannot emit N parallel tool calls and expect N React renders.
 
 ### Key files
 
 | File | Role |
 |---|---|
 | `src/cores/<feature>Core.js` | Pure logic core, returned JSON only. |
+| `src/cores/bestTeamsCore.js` | `computeBestTeams({chatId, teamId?, teamName?, rankBy?, mustInclude*, mustExclude*})` — status-tagged result, normalises codes via `NAME_TO_CODE_MAPPING`, returns `unknown_filter` when a name can't be resolved. |
+| `src/cores/userTeamsCore.js` | `listUserTeams({chatId})` — array of `{teamId, teamName, isLeague, isSelected, chip, …}`. |
+| `src/bestTeamsCalculator.js` | Accepts an optional 5th `options` arg with `mustInclude*`/`mustExclude*` filters, `rankBy: null \| 'points' \| 'points_per_million' \| 'budget_adjusted'`, and `resultCount`. Empty/absent options preserve legacy 4-arg behaviour byte-for-byte. |
 | `src/agent/identity.js` | Reads `AGENT_HARDCODED_CHAT_ID`, exposes `getAgentChatId()`. |
-| `src/agent/systemPrompt.js` | Minimal English system prompt; extended per phase. |
+| `src/agent/cacheBootstrap.js` | `ensureCacheReady()` — lazy `initializeCaches(noopBot)` for the agent process; resets on failure for retry-on-next-call. |
+| `src/agent/systemPrompt.js` | English system prompt; extended per phase. |
 | `src/agent/tools.js` | Tool catalogue (`defineTool` array). |
-| `src/agent/runtime.js` | Builds Azure model → `BuiltInAgent` → `CopilotRuntime` → `createCopilotRuntimeHandler`. Caches the handler per process. |
+| `src/agent/runtime.js` | Builds Azure model → `BuiltInAgent` (with `parallelToolCalls: false`) → `CopilotRuntime` → `createCopilotRuntimeHandler`. Caches the handler per process. |
 | `agentWebhook/function.json` | Azure Functions httpTrigger config (route `agent/{*restOfPath}`). |
 | `agentWebhook/index.js` | Bridges Azure Functions v3 (context, req) onto a Web Request; handles OPTIONS preflight + CORS; tolerant of both `Uint8Array` and string body chunks. |
 | `web/src/App.tsx` | Mounts `<CopilotKit>` + `<CopilotChat />`; reads `VITE_AGENT_API_URL`. |
-| `web/src/components/*.tsx` | Per-tool render components, each registered via `useCopilotAction({ available: 'frontend', render })`. |
+| `web/src/components/NextRacesTable.tsx` | `get_next_races` rich render. |
+| `web/src/components/BestTeamsTable.tsx` | `get_best_teams` rich render (top-10 table, captain badge, must-include highlights, penalty markers). |
+| `web/src/components/UserTeamsList.tsx` | `list_user_teams` rich render (card grid). |
 | `scripts/dev-agent-server.js` | Local dev wrapper around `agentWebhook/index.js`. Not deployed. |
 
 ---

--- a/docs/agent-rollout-plan.md
+++ b/docs/agent-rollout-plan.md
@@ -1,0 +1,341 @@
+# Agent rollout plan — F1 Fantasy web-chat agent
+
+This is the working plan for adding a **web-chat agent** as a second
+user-facing surface for the Telegram bot, plus the cost-cap data fix
+that fell out of Phase 2. It's structured so anyone can pick up where
+we left off without prior context.
+
+**Current state (2026-05-15):** Phase 1 shipped + merged to `main`
+(PR #180). Phase 2 + the cost-cap fix are open as two coordinated PRs
+([f1-fantasy-api-data#19](https://github.com/F1-fantazy-bot/f1-fantasy-api-data/pull/19)
+and [f1-fantazy-bot#181](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/181));
+both are review-ready and waiting on the operator. Phases 3–6 are
+planned but not started.
+
+> Read [`AGENTS.md`](../AGENTS.md) → "Agent (Web Chat)" first if you're
+> new to this codebase. That section is the authoritative reference for
+> architecture, dev workflow, and the "add a new tool" checklist. This
+> file is the roadmap that AGENTS.md slots into.
+
+---
+
+## Problem statement
+
+Today the bot is reachable only via Telegram. We want a **second
+channel**: a chat-style web app that talks to an LLM agent that runs the
+same underlying logic as the Telegram bot, plus richer post-processing
+(filtering best-teams by must-include/must-exclude drivers, alternative
+rankings, filtering races by country, cross-league queries…).
+
+The Telegram bot **must keep working at every step**. We refuse to ship
+a phase that risks Telegram regressions. Each existing handler is being
+refactored into `(pure core in src/cores/) + (thin Telegram adapter)`,
+with the new core shared between the Telegram path and the agent tool.
+
+## Locked decisions (recap)
+
+| Decision           | Value                                                                                                                                                                                        |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Channel            | Web chat — **Vite + React + CopilotKit** frontend                                                                                                                                            |
+| Frontend UX        | CopilotKit `<CopilotChat />` + `useCopilotAction({ render })` per tool                                                                                                                       |
+| LLM runtime        | **CopilotKit v2 `BuiltInAgent`** wraps Zod-typed `defineTool` entries; runs them via Vercel AI SDK `streamText` internally. Model built from **`@ai-sdk/azure`** (`azure.chat(deployment)`). |
+| Tool param schemas | **Zod** (Standard Schema V1) via `defineTool({ parameters: z.object({…}), execute })`                                                                                                        |
+| Backend hosting    | **Separate Azure Function App** for the agent (independent deploy/scale/failure from the Telegram bot)                                                                                       |
+| Identity (v1)      | Hardcoded chatId via `AGENT_HARDCODED_CHAT_ID` env var                                                                                                                                       |
+| Telegram isolation | Cores are shared — Telegram surface stays byte-identical                                                                                                                                     |
+| Language v1        | English-only                                                                                                                                                                                 |
+
+See `AGENTS.md` → "Agent (Web Chat)" → "Why this stack" for the full
+rationale, including the gotchas we hit (CopilotKit v2 silently ignores
+bare `actions:`, Azure OpenAI URL shape, parallel-tool-calls breaking
+the React rendering, etc.).
+
+## Phasing principles
+
+Each phase ends with:
+
+1. **Telegram bot fully working** — `npm test` green, no behaviour changes.
+2. **Web app working** with all capabilities from previous phases **plus**
+   one new capability slice.
+3. **A clear acceptance test** the user can run before approving the next phase.
+
+If a phase breaks (1) or (2), we stop and fix before moving on.
+
+---
+
+## Phase 1 — Thin vertical slice (foundation + first tool + first rich component) — ✅ MERGED (PR #180, commit `cb5fbe1`)
+
+**Goal:** prove the entire pipeline end-to-end with the simplest
+possible capability — "what are the next races?" → rich `<NextRacesTable />`.
+
+**What shipped:**
+
+- `agentWebhook/` — Azure Functions v3 ↔ Web Request bridge with permissive dev CORS, tolerant of both `Uint8Array` and string body chunks.
+- `src/agent/{identity,systemPrompt,tools,runtime}.js` — `BuiltInAgent` + `CopilotRuntime` + `createCopilotRuntimeHandler({ mode: 'single-route' })`.
+- `src/cores/nextRacesCore.js` — first pure core (template shape for every future core).
+- `src/commandsHandler/nextRacesHandler.js` — refactored to thin adapter. 711/711 tests stayed green.
+- `web/` — Vite + React + TS frontend with `<CopilotKit>` + `<CopilotChat>`.
+- `web/src/components/NextRacesTable.tsx` — pattern for every future render component.
+- `scripts/dev-agent-server.js` — local Node HTTP wrapper around the same handler the function uses; no `func` CLI required.
+- `npm run dev` / `dev:agent` / `dev:web` via `concurrently`.
+
+**Remaining Phase-1 todo:** `p1-frontend-deploy` — provision Azure
+Static Web App for `web/` and Azure Function App for `agentWebhook/`.
+This is **operator-side** (needs cloud credentials) and is deferred
+until ready. The agent is fully functional locally via `npm run dev`.
+
+---
+
+## Phase 2 — Best teams + filtering (the headline feature) — 🟡 OPEN as PR #181
+
+**Goal:** the marquee user request works:
+_"Best teams for kilzid3 with Verstappen but no Alonso."_
+Result renders as a rich `<BestTeamsTable />` with each team's roster,
+captain, projected points, and filter highlights.
+
+**Branch:** `feature/doronkilzi/agent-best-teams`
+**PR:** [#181](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/181)
+**Status:** open, review-ready. **754/754 tests, lint clean,
+Playwright-verified end-to-end.** Depends on (sequenced with) the
+companion cost-cap fix in
+[f1-fantasy-api-data#19](https://github.com/F1-fantazy-bot/f1-fantasy-api-data/pull/19).
+
+**What shipped on the branch:**
+
+1. ✅ `src/bestTeamsCalculator.js` — optional 5th `options` arg with `mustInclude{Drivers,Constructors}` / `mustExclude{Drivers,Constructors}` filters (applied BEFORE the top-K slice so candidates outside the legacy top-K don't get lost), `rankBy: null | 'points' | 'budget_adjusted' | 'points_per_million'`, and `resultCount`. Empty/absent options preserve legacy 4-arg behaviour **byte-for-byte** — the existing 11 `bestTeamsHandler.test.js` cases pass unchanged because the refactored Telegram handler calls the calculator with the historical 4 positional args.
+2. ✅ `src/cores/bestTeamsCore.js` — `computeBestTeams({chatId, teamId?, teamName?, rankBy?, mustInclude*, mustExclude*})` with status-tagged result: `no_teams | unknown_team | ambiguous_team | missing_cache | missing_remaining_race_count | unknown_filter | ok`. Driver / constructor codes normalised through `NAME_TO_CODE_MAPPING` (the LLM can pass `'VER'` or `'m. verstappen'` interchangeably). Unresolved names surface as `unknown_filter` so the LLM can ask for clarification — no silent drops.
+3. ✅ `src/cores/userTeamsCore.js` — `listUserTeams({chatId})` returns `[{teamId, teamName, isLeague, isSelected, chip, drivers, constructors, boost, freeTransfers, costCapRemaining}]`.
+4. ✅ `src/commandsHandler/bestTeamsHandler.js` — refactored to thin adapter. `validateJsonData` is now properly `await`ed (was previously a Promise being `!`'d — silent latent bug). All 11 existing handler tests pass byte-for-byte unchanged.
+5. ✅ `src/agent/cacheBootstrap.js` — `ensureCacheReady()` lazily runs `initializeCaches(noopBot)` once per agent process. Resets on failure for retry-on-next-call. The agent runs in a separate process from the Telegram bot so it needs to populate `currentTeamCache`/`driversCache`/etc. before tools that read them can run. The noop bot is `{ sendMessage: async () => undefined }` — the log-side-effect calls in `initializeCaches` become no-ops since the agent process has no Telegram token.
+6. ✅ `src/agent/tools.js` — adds `list_user_teams` (no args) and `get_best_teams` (`{teamId?, teamName?, rankBy?, mustInclude*, mustExclude*}`). Both `await ensureCacheReady()` first. `get_best_teams` returns a compact DTO (~10 teams × ~10 numeric fields) — kept small so the streamed tool payload doesn't bloat.
+7. ✅ `src/agent/systemPrompt.js` — workflow rules teaching the LLM to call `get_best_teams` DIRECTLY with `teamName` (avoids the multi-tool-call rendering limitation — see #5 in the gotchas table).
+8. ✅ `src/agent/runtime.js` — `providerOptions: { openai: { parallelToolCalls: false } }` on the `BuiltInAgent`. Without this Azure OpenAI emits parallel tool calls in one assistant message; CopilotKit's `useLazyToolRenderer` only renders `toolCalls[0]` (see `node_modules/@copilotkit/react-core/src/hooks/use-lazy-tool-renderer.tsx:15`). Forcing sequential calls makes each tool's React render component mount correctly.
+9. ✅ `web/src/components/BestTeamsTable.tsx` — top-10 table; captain ⭐, mega-captain ⭐⭐, must-include drivers highlighted green, penalty markers, conditional budget-adjusted / points-per-million columns.
+10. ✅ `web/src/components/UserTeamsList.tsx` — responsive card grid; ACTIVE badge for the selected team, chip pill, league/screenshot tag.
+11. ✅ `web/src/App.tsx` wires both new actions alongside the Phase 1 `useNextRacesAction`.
+12. ✅ +32 new tests (711 → 743 → 754 with the mapper unit-test suite added for the cost-cap fix).
+
+**Acceptance test for Phase 2 (PASSED):**
+
+- Web app: _"Best teams for Kilzid 3 with Verstappen but no Alonso."_ → `<BestTeamsTable />` shows 10 teams, every row has VER, none has ALO, captain ⭐ on LEC.
+- Web app: _"What teams am I tracking?"_ → `<UserTeamsList />` shows 5 cards (Kilzid2 marked ACTIVE).
+- Web app: _"Next races in Italy?"_ (Phase 1) → still works.
+- Telegram `/best_teams` → identical to pre-refactor (all 11 existing tests pass byte-for-byte).
+- `npm test` → 754/754 green.
+
+### Phase 2 companion: cost-cap data fix — 🟡 OPEN as f1-fantasy-api-data#19
+
+The new `<UserTeamsList />` UI surfaced a pre-existing bug: every league
+team showed `costCapRemaining: 0`. Root cause: `teams-data.json#budget`
+was `team_info.teamVal` (the team's current value, i.e. sum of roster
+prices) rather than the user's cost cap, so the bot's
+`mapLeagueTeamToBotTeam` formula `budget − Σ_prices` always yielded 0.
+
+We considered three approaches and landed on **fix at the data source**:
+
+1. ~~Bot-only: extra blob fetch + workaround logic.~~ Rejected — wrong layer.
+2. ~~Bot-only with additive `maxTeambal` field on the scraper.~~ Rejected after consumer audit: nothing semantically depends on the old `budget = teamVal` (only one informational `console.log` line in the scraper itself + the bot's mapper). Carrying two fields where one will do adds noise.
+3. **✅ Rename `budget` to mean the cap.** The scraper now writes `team_info.maxTeambal` as `budget` on each team row in `teams-data.json` (and locked snapshots). The old semantic is retired.
+
+**PR A — [f1-fantasy-api-data#19](https://github.com/F1-fantazy-bot/f1-fantasy-api-data/pull/19)** (branch `feature/doronkilzi/teams-data-maxteambal`): 3 commits — 2 prettier-reformat + 1 functional (`feat: redefine teams-data.json#budget as the user's cost cap`).
+
+- `src/budget.js`: `extractStartBudget` deleted; `extractBudget` returns `maxTeambal`.
+- `src/fetchLeagueData.js`: single `budget` variable carries the cap. Reused for both `teamsComposition` row and `raceBudgets[matchday_N]` entry.
+- `src/fetchLockedLeagueData.js`: call site unchanged; helper just returns the right thing.
+- `AGENTS.md` redefined.
+
+**PR B — [f1-fantazy-bot#181](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/181)** (this branch, this plan): the mapper now reads `leagueTeam.budget` as the cap unconditionally (one `Number(leagueTeam.budget)` read). No additive field, no shim.
+
+**Transition risk: zero.** Stale blobs (written before PR A merges) carry `budget = teamVal`. The mapper subtracts `Σ_prices` from `budget` and gets `teamVal − Σ_prices ≈ 0` — exactly the value the bot reported in production today. No regression at any point during the deployment window. The moment the next scrape repopulates a blob, that team's cap-remaining becomes correct.
+
+**Live verification** (after a local scrape with the renamed scraper, against fresh blobs in Azure):
+
+| Team      | budget written | cap remaining (UI) | F1 Fantasy site |
+| --------- | -------------- | ------------------ | --------------- |
+| Kilzid    | 109.2          | **2.4**            | 2.4 ✓           |
+| Kilzid2   | 110.8          | **1.4**            | 1.4 ✓           |
+| Kilzid 3  | 112.8          | **0.0**            | 0 ✓             |
+| dorsegal1 | 110.4          | **1.3**            | 1.3 ✓           |
+| Cooperon  | 111.6          | **0.9**            | 0.9 ✓           |
+
+All five exact-match the F1 Fantasy site.
+
+### How to finish Phase 2 / cost-cap fix (operator handoff)
+
+1. **Review and merge** [f1-fantasy-api-data#19](https://github.com/F1-fantazy-bot/f1-fantasy-api-data/pull/19).
+2. **Trigger** `deploy-aci.yml` `workflow_dispatch` in the f1-fantasy-api-data repo (or wait for Monday 03:00 UTC — the scheduler will pick up the new image).
+3. **Verify** one blob in Azure now has the new shape (e.g. via `az storage blob download --container-name f1-fantasy-scraper-json --name leagues/<code>/teams-data.json -f /tmp/td.json && jq '.teams[0]' /tmp/td.json` — `budget` should be a sensible cap value, e.g. ≥ team value).
+4. **Review and merge** [f1-fantazy-bot#181](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/181).
+5. (No follow-up cleanup PR needed — the rename collapses everything into a single clean field.)
+
+---
+
+## Phase 3 — Cross-league / followed teams
+
+**Goal:** the second user request works:
+_"Best teams by points-per-million for every team I track."_
+Rendered as a stack of `<BestTeamsTable />` instances, one per followed
+team, each labeled with its team name + league(s).
+
+**Telegram surface changes:** `leaderboardHandler.js` and the
+followed-teams helpers get core extractions. No user-visible change.
+
+**Tasks:**
+
+1. Extract `src/cores/followedTeamsCore.js`. Returns the user's followed teams across all leagues, deduplicated by `teamId`: `[{ teamId, teamName, leagues: [{ leagueCode, leagueName, position }] }]`.
+2. Extract `src/cores/leaderboardCore.js` from `leaderboardHandler.js`. Returns `{ leagueCode, leagueName, standings: [{ position, teamName, totalScore, ... }] }`.
+3. Refactor both handlers to thin adapters; run their Jest tests — must pass unchanged.
+4. Add three agent tools:
+   - `list_followed_teams` (no args).
+   - `get_leaderboard` (args: `leagueCode`).
+   - `list_user_leagues` (no args) — small helper so the LLM knows which leagues to choose from.
+5. Build rich components:
+   - `web/src/components/FollowedTeamsGrid.tsx` — cards with team name, leagues + positions.
+   - `web/src/components/LeaderboardTable.tsx` — standings with position, name, total score; sortable.
+   - Register both via `useCopilotAction({ available: 'frontend', render })`.
+6. Update system prompt to guide the LLM on cross-team workflows ("when the user says 'every team I track', call `list_followed_teams` then call `get_best_teams` for each").
+7. Tests for the new cores + tools.
+
+**Acceptance test:**
+
+- Web app: _"Best teams by points-per-million for every team I track."_ → multiple `<BestTeamsTable />` cards, one per followed team.
+- Web app: _"Show me the leaderboard for league X."_ → `<LeaderboardTable />`.
+- Phase 1+2 questions still work.
+- Telegram: `/leaderboard`, `/teams_tracker` → identical to before.
+- `npm test` → all green.
+
+**Open question for Phase 3:** the LLM has to fan out one "best teams for every team I track" question into N tool calls. Because of the parallel-tool-calls limitation (see "Pitfalls" in `AGENTS.md`), each `get_best_teams` call has to land in its own assistant message → each rich component renders in order. Verify in Playwright that the chat doesn't get visually janky with 5–6 sequential tables.
+
+---
+
+## Phase 4 — Race info, weather, deadline
+
+**Goal:** the agent can answer all "next race" questions in detail
+(weather, schedule, lock deadline, full race info) — each rendered
+with a tailored component.
+
+**Tasks:**
+
+1. Extract cores:
+   - `src/cores/nextRaceInfoCore.js` from `nextRaceInfoHandler.js`
+   - `src/cores/raceWeatherCore.js` from `nextRaceWeatherHandler.js`
+   - `src/cores/deadlineCore.js` from `deadlineHandler.js`
+2. Refactor handlers to adapters; run their Jest tests.
+3. Add three agent tools:
+   - `get_next_race_info` (no args).
+   - `get_race_weather` (no args; pulls next race's location).
+   - `get_deadline` (no args).
+4. Build rich components:
+   - `web/src/components/RaceInfoCard.tsx` — circuit map (if available), full session schedule (FP1/FP2/FP3/Quali/Sprint/Race), countdown.
+   - `web/src/components/WeatherForecast.tsx` — per-session weather: icon, temperature, rain probability.
+   - `web/src/components/DeadlineCountdown.tsx` — live ticking countdown to the next deadline.
+   - Register all three via `useCopilotAction`.
+5. Tests for new cores + tools.
+
+**Acceptance test:**
+
+- Web app: _"What's the weather forecast for the next race?"_ → renders `<WeatherForecast />`.
+- Web app: _"How long until the next deadline?"_ → renders `<DeadlineCountdown />` with a live ticking clock.
+- Web app: _"Tell me about the next race."_ → renders `<RaceInfoCard />`.
+- Phase 1–3 questions still work.
+- Telegram: all related commands → identical to before.
+- `npm test` → all green.
+
+---
+
+## Phase 5 — Current team + live score (last v1 capabilities)
+
+**Goal:** complete the v1 capability scope. After this phase the agent
+covers every read-only thing the Telegram bot can do, each with a
+tailored component.
+
+**Tasks:**
+
+1. Extract cores:
+   - `src/cores/currentTeamCore.js` from `currentTeamInfoHandler.js`
+   - `src/cores/liveScoreCore.js` from `liveScoreHandler.js`
+2. Refactor handlers to adapters; run their Jest tests.
+3. Add two agent tools:
+   - `get_current_team` (args: optional `teamId`).
+   - `get_live_score` (args: `leagueCode`, optional `teamName` — omitted means "all teams").
+4. Build rich components:
+   - `web/src/components/CurrentTeamCard.tsx` — current roster, boost driver, free transfers, cost cap.
+   - `web/src/components/LiveScoreBreakdown.tsx` — per-driver and per-constructor scoring breakdown with captain/mega-captain multipliers visualized.
+   - `web/src/components/LiveScoreLeaderboard.tsx` — all-teams variant.
+   - Register all via `useCopilotAction`.
+5. Tests for new cores + tools.
+
+**Acceptance test:**
+
+- Web app: _"How is my current team doing this race?"_ → renders `<LiveScoreBreakdown />`.
+- Web app: _"Compare my live score across all my followed teams."_ → renders `<LiveScoreLeaderboard />`.
+- Phase 1–4 questions still work.
+- Telegram: `/current_team_info`, `/live_score` → identical to before.
+- `npm test` → all green.
+
+---
+
+## Phase 6 — Polish & hardening
+
+**Goal:** make this maintainable in production. No new capabilities.
+
+**Tasks:**
+
+1. **Token usage logging**: per-turn `prompt/completion/total` tokens logged to the existing `LOG_CHANNEL_ID` via `sendLogMessage` (mirror `askHandler.js` pattern).
+2. **Error UX**: when a tool throws or the LLM fails, render a friendly message in the web chat. Log full error to a new Application Insights instance scoped to the agent Function App.
+3. **CORS hardening**: lock CORS allowlist to the production Static Web App URL only (currently permissive `*` for dev).
+4. **History persistence (optional)**: persist the last 20 user turns in browser localStorage so reloading doesn't lose context.
+5. **Docs**: refresh `AGENTS.md` "Agent (Web Chat)" section to capture any new gotchas discovered across Phases 3–5. Make sure the new-tool checklist still reflects current best practices.
+6. **Final regression sweep**: run full `npm test` + manual smoke on Telegram for the top-10 commands.
+
+**Acceptance test:**
+
+- Token usage shows up in `LOG_CHANNEL_ID`.
+- Forcing a tool error shows a friendly message in the web chat.
+- All previous-phase acceptance tests still pass.
+
+---
+
+## Cross-phase invariant — cores ↔ Telegram-adapter pattern
+
+For every capability that needs to be on **both** surfaces:
+
+1. **Extract the pure logic** into `src/cores/<feature>Core.js` — structured JSON return, no `bot`, no `t()`, no `sendMessage`.
+2. **Refactor the existing Telegram handler** in `src/commandsHandler/<feature>Handler.js` to a thin adapter: call the core, format the result for Telegram, `bot.sendMessage`. **External behaviour must stay byte-identical** — existing handler tests must keep passing unchanged. If a test breaks, the refactor changed behaviour; fix the refactor, not the test.
+3. **Wrap the same core** in an agent tool via `defineTool` in `src/agent/tools.js`.
+4. **If the agent should render a rich UI**, add a `<FeatureComponent />` in `web/src/components/` and register it via `useCopilotAction({ name, available: 'frontend', render })`.
+5. **Verify in-browser with Playwright MCP** before declaring "done". The browser is the source of truth for UI changes.
+
+The full per-tool checklist (including the **cache bootstrap** and
+**parallel-tool-calls** gotchas) lives in
+[`AGENTS.md`](../AGENTS.md#adding-a-new-tool-checklist).
+
+---
+
+## Risks & open questions
+
+- **SSE on Consumption plan**: Phase 1 verified end-to-end locally, but the local dev bridge currently buffers the full response before flushing — streaming behaviour on Azure Functions Consumption is unverified. If streaming flushing turns out to be flaky, fall back to non-streaming JSON or upgrade to Premium. Phase 6 hardening item.
+- **Hebrew localisation**: out of v1 scope. The Telegram bot stays bilingual.
+- **Token cost**: function-calling is more expensive than the current ASK pattern. Phase 6 adds monitoring; first cost reading is after Phase 1 deploys.
+- **Cold-start cache init**: agent re-initialises caches from Azure Storage on first request. Reuses `cacheReady` promise pattern. Should be ≤5s — acceptable.
+
+## Future work (beyond v1)
+
+- Proper auth (drop `AGENT_HARDCODED_CHAT_ID`).
+- Hebrew localisation of agent outputs.
+- Voice input/output.
+- MCP server façade so Copilot/Claude/Cursor can call the same tools.
+- Write capabilities (e.g. set chip, switch team) — currently read-only.
+
+---
+
+## Where to start if you're picking this up
+
+1. **Read [`AGENTS.md`](../AGENTS.md) → "Agent (Web Chat)"** end-to-end. It has the architecture, dev workflow, every gotcha we hit, and the **"Adding a new tool" checklist** that every phase below 3 follows.
+2. **Boot the dev environment** to confirm everything works: `npm install`, `cd web && npm install && cd ..`, then `npm run dev`. Open `http://localhost:5173/` and try _"Best teams for Kilzid 3 with Verstappen but no Alonso"_ — if it renders `<BestTeamsTable />` with 10 rows you're good.
+3. **Finish Phase 2 / cost-cap rollout** (see the operator-handoff steps above) — merge PR #19 then PR #181.
+4. **Pick the next phase.** Phase 3 is the natural next step. Spin up a feature branch `feature/<you>/agent-phase3` and follow the tasks listed above. Use Phase 2's commits + PR as the template for shape, commit-message style, and test scope.
+5. **Run the rubber-duck agent** on your plan before implementing each phase — Phase 1 and Phase 2 each caught real design flaws this way that would have been expensive to fix mid-implementation.
+
+Per-step approval policy (from the team rules): commits, pushes, and PR
+creates are **separate approval points**. Don't chain them.

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ A **web-chat agent** (preview) provides a second channel for the same functional
 - **Second channel** for the bot: a Vite + React + CopilotKit chat UI talking to a CopilotKit v2 `BuiltInAgent` running on Azure OpenAI
 - **Same business logic** as the Telegram bot — both surfaces call pure cores in `src/cores/`
 - **Generative UI**: tool results render as tailored React components (e.g. `<NextRacesTable />`) rather than plain text
-- Currently ships one tool (`get_next_races`); more capabilities land phase by phase
+- Currently ships three tools (`get_next_races`, `list_user_teams`, `get_best_teams` with must-include / must-exclude filters); more capabilities land phase by phase
 
 ### Bot Administration
 
@@ -144,7 +144,7 @@ A **web-chat agent** (preview) provides a second channel for the same functional
    - Agent backend on `http://localhost:7071/api/agent/copilotkit` (a thin Node HTTP wrapper around the same handler that `agentWebhook/` exposes to Azure Functions — no Azure Functions Core Tools required)
    - Vite frontend on `http://localhost:5173/` (or `:5174` if `:5173` is busy)
 
-   Open the Vite URL and ask the agent a question (e.g. _"What are the next races in USA?"_). See [`AGENTS.md` → Agent (Web Chat)](AGENTS.md#agent-web-chat) for the full architecture and the pattern for adding new tools.
+   Open the Vite URL and ask the agent a question (e.g. _"What are the next races in USA?"_ or _"Best teams for kilzid3 with Verstappen but no Alonso"_). See [`AGENTS.md` → Agent (Web Chat)](AGENTS.md#agent-web-chat) for the full architecture and the pattern for adding new tools.
 
 ## Available Commands and Inputs
 

--- a/src/agent/cacheBootstrap.js
+++ b/src/agent/cacheBootstrap.js
@@ -1,0 +1,46 @@
+// Lazy cache bootstrap for the web-chat agent.
+//
+// In the Telegram process, `bot.js` calls `initializeCaches(bot)` at
+// startup so every command handler can read from `driversCache`,
+// `currentTeamCache`, etc. The agent function runs in a separate process
+// (Azure Function App) and must populate the same in-memory caches
+// before its tools can answer questions.
+//
+// `initializeCaches(bot)` only uses `bot` for the logging side-effects
+// (`sendLogMessage`, `sendErrorMessage`, `sendMessageToAdmins`, and
+// `saveUserTeam` for refreshed league rosters). We hand it a no-op
+// "bot" whose `sendMessage` simply resolves — the agent process has no
+// Telegram token. Note: cache init still touches Azure Storage (read +
+// occasionally write refreshed league teams), so the agent function
+// needs the same Azure credentials the bot does.
+
+const { initializeCaches } = require('../cacheInitializer');
+
+let pendingCacheReady = null;
+
+function getNoopBot() {
+  return {
+    sendMessage: async () => undefined,
+  };
+}
+
+function ensureCacheReady() {
+  if (!pendingCacheReady) {
+    pendingCacheReady = initializeCaches(getNoopBot()).catch((err) => {
+      // Reset on failure so the next tool invocation retries from
+      // scratch (transient Azure errors should not brick the agent
+      // until the process restarts).
+      pendingCacheReady = null;
+      console.error('Agent cache initialization failed:', err);
+      throw err;
+    });
+  }
+
+  return pendingCacheReady;
+}
+
+function resetCacheReadyForTests() {
+  pendingCacheReady = null;
+}
+
+module.exports = { ensureCacheReady, resetCacheReadyForTests };

--- a/src/agent/runtime.js
+++ b/src/agent/runtime.js
@@ -73,6 +73,16 @@ function buildAgent(cfg) {
     // final assistant message in one run. Without this it stops after
     // emitting the tool call and never synthesises a reply.
     maxSteps: AGENT_MAX_STEPS,
+    // CopilotKit's `useLazyToolRenderer` only renders `toolCalls[0]` of
+    // an assistant message (see node_modules/.../use-lazy-tool-renderer.tsx
+    // line 15). When Azure OpenAI emits PARALLEL tool calls in one
+    // message (default behaviour), only the first tool's React render
+    // hook fires — the rest are silently dropped from the UI. Forcing
+    // sequential tool calls makes each tool call land in its own
+    // assistant message, so each gets its own rich UI render.
+    providerOptions: {
+      openai: { parallelToolCalls: false },
+    },
   });
 }
 

--- a/src/agent/systemPrompt.js
+++ b/src/agent/systemPrompt.js
@@ -1,8 +1,9 @@
 // System prompt for the F1 Fantasy web-chat agent.
 //
-// This is intentionally minimal in Phase 1 — only the `get_next_races`
-// tool exists. Subsequent phases extend the prompt as each new tool
-// is added, teaching the model when and how to chain tool calls.
+// Each phase adds a section here as new tools are introduced — the LLM
+// uses these instructions to decide which tool to call, what arguments
+// to pass, and how to summarise the result for the user once a rich
+// frontend component has rendered the data.
 
 const SYSTEM_PROMPT = `You are an assistant for an F1 Fantasy player.
 
@@ -11,13 +12,46 @@ When the user asks a question, decide which tool(s) to call, then process
 the tool's JSON output (filter, sort, summarise) to answer the user's
 question.
 
+Available tools:
+- get_next_races — upcoming F1 races for the current season.
+- list_user_teams — the user's tracked teams (teamId + friendly teamName).
+- get_best_teams — top-scoring fantasy team combinations for one of the
+  user's teams. Supports must-include / must-exclude filters on drivers
+  and constructors, and three ranking modes ('points', 'budget_adjusted',
+  'points_per_million').
+
+Workflow rules:
+- When the user names a team in a "best teams" question (e.g. "best teams
+  for kilzid3 with X but no Y"), call get_best_teams DIRECTLY with the
+  user-provided name as \`teamName\` — the backend matches teamName
+  exactly. Do NOT call list_user_teams first in that case (each extra
+  tool call costs latency and only one rich UI component can render
+  per assistant turn).
+- Only call list_user_teams when the user explicitly asks to see their
+  teams, or when get_best_teams returns status="unknown_team" /
+  "ambiguous_team" — then call list_user_teams to disambiguate and
+  retry get_best_teams with the canonical teamId.
+- Driver and constructor identifiers are 3-letter codes. Examples:
+  VER (Verstappen), HAM (Hamilton), ALO (Alonso), LEC (Leclerc),
+  NOR (Norris), PIA (Piastri), RUS (Russell), SAI (Sainz), MCL (McLaren),
+  FER (Ferrari), MER (Mercedes), RED (Red Bull Racing), AST (Aston Martin).
+  Pass codes when possible; the backend also accepts full names but codes
+  avoid ambiguity.
+- For requests like "best teams with X but no Y", populate
+  mustIncludeDrivers/mustExcludeDrivers (or the constructor variants).
+- If get_best_teams returns status="unknown_filter", tell the user which
+  filter names you could not resolve and ask them to clarify.
+- If status="ambiguous_team" or "no_teams", explain plainly and suggest
+  the next step.
+
 Style rules:
 - Answer in English.
 - Be concise. Prefer tables and lists over long paragraphs.
 - When you call a tool that has a rich UI component registered on the
   frontend, the user will see that component automatically. Do not
   re-render its data as a markdown table — just describe what was
-  shown briefly.
+  shown briefly and answer any follow-up question (e.g. "Top team has
+  VER+NOR+...").
 - If a tool returns no data or an error, say so plainly and suggest
   what the user can do next.
 
@@ -28,3 +62,4 @@ function getSystemPrompt() {
 }
 
 module.exports = { getSystemPrompt };
+

--- a/src/agent/tools.js
+++ b/src/agent/tools.js
@@ -13,6 +13,42 @@
 const { defineTool } = require('@copilotkit/runtime/v2');
 const z = require('zod');
 const { getNextRaces } = require('../cores/nextRacesCore');
+const { computeBestTeams } = require('../cores/bestTeamsCore');
+const { listUserTeams } = require('../cores/userTeamsCore');
+const { getAgentChatId } = require('./identity');
+const { ensureCacheReady } = require('./cacheBootstrap');
+
+// Trim a best-teams calculator row down to the fields the React component
+// actually renders. Sending the full driver/constructor dictionaries (which
+// the calculator pulls in transitively through its inputs) would balloon
+// the streamed tool payload for no benefit.
+function summariseBestTeam(team) {
+  return {
+    row: team.row,
+    drivers: team.drivers,
+    constructors: team.constructors,
+    boostDriver: team.boost_driver,
+    extraBoostDriver: team.extra_boost_driver || null,
+    totalPrice: Number(team.total_price?.toFixed?.(2) ?? team.total_price),
+    transfersNeeded: team.transfers_needed,
+    penalty: team.penalty,
+    projectedPoints: Number(
+      team.projected_points?.toFixed?.(2) ?? team.projected_points,
+    ),
+    budgetAdjustedPoints:
+      typeof team.budget_adjusted_points === 'number'
+        ? Number(team.budget_adjusted_points.toFixed(2))
+        : null,
+    expectedPriceChange:
+      typeof team.expected_price_change === 'number'
+        ? Number(team.expected_price_change.toFixed(2))
+        : null,
+    pointsPerMillion:
+      team.total_price > 0
+        ? Number((team.projected_points / team.total_price).toFixed(3))
+        : null,
+  };
+}
 
 const tools = [
   defineTool({
@@ -22,6 +58,106 @@ const tools = [
     parameters: z.object({}),
     execute: async () => {
       return getNextRaces();
+    },
+  }),
+
+  defineTool({
+    name: 'list_user_teams',
+    description:
+      'List the F1 Fantasy teams the user is tracking. Returns an array of teams with `teamId` (canonical identifier — pass this to other tools), `teamName` (friendly label like "kilzid3"), `isSelected`, `chip`, current drivers, current constructors, and roster metadata. ALWAYS call this first when the user mentions a team by name so you can resolve the name to a teamId before calling `get_best_teams`.',
+    parameters: z.object({}),
+    execute: async () => {
+      await ensureCacheReady();
+      const chatId = getAgentChatId();
+
+      return { teams: listUserTeams({ chatId }) };
+    },
+  }),
+
+  defineTool({
+    name: 'get_best_teams',
+    description:
+      'Compute the top scoring F1 Fantasy teams the user could field next race. Supports must-include / must-exclude filters on drivers and constructors so you can answer questions like "best teams with Verstappen but no Alonso". Pass driver/constructor codes (e.g. VER, ALO, MCL, FER) — full names like "Verstappen" or "McLaren" are also accepted but codes are safer. Identify the user\'s team by `teamId` (preferred, obtained from list_user_teams) or `teamName` (exact match). Result shape: { status, teamId, teamName, chip, rankBy, bestTeams: [...] }. On status "unknown_filter" the result includes a `filters` field listing which inputs failed to resolve — tell the user which names you could not map.',
+    parameters: z.object({
+      teamId: z
+        .string()
+        .optional()
+        .describe(
+          'Canonical team identifier returned by list_user_teams. Preferred over teamName.',
+        ),
+      teamName: z
+        .string()
+        .optional()
+        .describe(
+          'Exact teamName from list_user_teams. Used only when teamId is not provided.',
+        ),
+      rankBy: z
+        .enum(['points', 'budget_adjusted', 'points_per_million'])
+        .optional()
+        .describe(
+          'Sort criterion. Defaults to the user\'s preferred ranking (matching the Telegram bot). Use "points" for raw projected points, "points_per_million" for value-for-money, "budget_adjusted" for the budget-adjusted score.',
+        ),
+      mustIncludeDrivers: z
+        .array(z.string())
+        .optional()
+        .describe('Driver codes the team MUST contain (e.g. ["VER"]).'),
+      mustExcludeDrivers: z
+        .array(z.string())
+        .optional()
+        .describe('Driver codes the team MUST NOT contain.'),
+      mustIncludeConstructors: z
+        .array(z.string())
+        .optional()
+        .describe(
+          'Constructor codes the team MUST contain (e.g. ["MCL"]).',
+        ),
+      mustExcludeConstructors: z
+        .array(z.string())
+        .optional()
+        .describe('Constructor codes the team MUST NOT contain.'),
+    }),
+    execute: async (args) => {
+      await ensureCacheReady();
+      const chatId = getAgentChatId();
+      // Web component renders up to 10 teams at a time — anything beyond
+      // that bloats the streamed tool payload and the LLM context.
+      const result = await computeBestTeams({
+        chatId,
+        teamId: args.teamId,
+        teamName: args.teamName,
+        rankBy: args.rankBy ?? null,
+        resultCount: 10,
+        mustIncludeDrivers: args.mustIncludeDrivers,
+        mustExcludeDrivers: args.mustExcludeDrivers,
+        mustIncludeConstructors: args.mustIncludeConstructors,
+        mustExcludeConstructors: args.mustExcludeConstructors,
+      });
+
+      if (result.status !== 'ok') {
+        // Strip caches/heavy fields out of non-ok results — the LLM only
+        // needs the status + the identifiers to phrase its reply.
+        const { currentTeam: _currentTeam, ...rest } = result;
+
+        return rest;
+      }
+
+      return {
+        status: 'ok',
+        teamId: result.teamId,
+        teamName: result.teamName,
+        chip: result.chip || null,
+        rankBy: result.rankBy,
+        budgetChangePointsPerMillion: result.budgetChangePointsPerMillion,
+        filters: {
+          mustIncludeDrivers: result.filters.mustIncludeDrivers.resolved,
+          mustExcludeDrivers: result.filters.mustExcludeDrivers.resolved,
+          mustIncludeConstructors:
+            result.filters.mustIncludeConstructors.resolved,
+          mustExcludeConstructors:
+            result.filters.mustExcludeConstructors.resolved,
+        },
+        bestTeams: result.bestTeams.map(summariseBestTeam),
+      };
     },
   }),
 ];

--- a/src/bestTeamsCalculator.js
+++ b/src/bestTeamsCalculator.js
@@ -11,12 +11,31 @@ const {
   calculateBudgetAdjustedPoints,
 } = require('./utils');
 
+// eslint-disable-next-line max-params
 exports.calculateBestTeams = function (
   cachedJsonData,
   selectedChip,
   budgetChangePointsPerMillion = 0,
   remainingRaceCount = 0,
+  options = {},
 ) {
+  // `options` is consumed by callers that want to re-rank / filter / cap the
+  // top-K list (notably the web-chat agent). Keys (all optional):
+  //   mustIncludeDrivers, mustExcludeDrivers,
+  //   mustIncludeConstructors, mustExcludeConstructors: arrays of codes (e.g. 'VER').
+  //   rankBy: null | 'points' | 'budget_adjusted' | 'points_per_million'.
+  //     null preserves legacy ranking (`ranking_score`, then `projected_points`).
+  //   resultCount: number — defaults to BEST_TEAMS_RESULT_COUNT.
+  // When `options` is omitted/empty, behaviour matches the legacy 4-arg call
+  // byte-for-byte (the Telegram bot relies on this).
+  const {
+    mustIncludeDrivers = [],
+    mustExcludeDrivers = [],
+    mustIncludeConstructors = [],
+    mustExcludeConstructors = [],
+    rankBy = null,
+    resultCount = BEST_TEAMS_RESULT_COUNT,
+  } = options;
   // Data for drivers
   const drivers_dict = cachedJsonData.Drivers;
 
@@ -194,15 +213,62 @@ exports.calculateBestTeams = function (
     }
   }
 
-  // Sort the teams by ranking score in descending order and keep a fixed number of results
-  teams.sort((a, b) => {
-    if (b.ranking_score !== a.ranking_score) {
-      return b.ranking_score - a.ranking_score;
-    }
+  // Sort the teams by the requested ranking, then keep the configured number
+  // of results. `rankBy === null` preserves the legacy behaviour exactly
+  // (the Telegram bot path) — `ranking_score` is the budget-adjusted value
+  // (or `projected_points` when budgetChangePointsPerMillion === 0).
+  if (rankBy === 'points') {
+    teams.sort((a, b) => b.projected_points - a.projected_points);
+  } else if (rankBy === 'points_per_million') {
+    const ppm = (team) =>
+      team.total_price > 0 ? team.projected_points / team.total_price : 0;
+    teams.sort((a, b) => ppm(b) - ppm(a));
+  } else if (rankBy === 'budget_adjusted') {
+    teams.sort((a, b) => b.ranking_score - a.ranking_score);
+  } else {
+    teams.sort((a, b) => {
+      if (b.ranking_score !== a.ranking_score) {
+        return b.ranking_score - a.ranking_score;
+      }
 
-    return b.projected_points - a.projected_points;
-  });
-  const top_teams = teams.slice(0, BEST_TEAMS_RESULT_COUNT);
+      return b.projected_points - a.projected_points;
+    });
+  }
+
+  // Apply optional must-include / must-exclude filters BEFORE slicing the
+  // top-K. Filtering after slice would lose teams that rank just below
+  // the original top-K cut and only become visible after filtering.
+  let candidateTeams = teams;
+  if (
+    mustIncludeDrivers.length ||
+    mustExcludeDrivers.length ||
+    mustIncludeConstructors.length ||
+    mustExcludeConstructors.length
+  ) {
+    const includeDrivers = new Set(mustIncludeDrivers);
+    const excludeDrivers = new Set(mustExcludeDrivers);
+    const includeConstructors = new Set(mustIncludeConstructors);
+    const excludeConstructors = new Set(mustExcludeConstructors);
+    candidateTeams = teams.filter((team) => {
+      const driverSet = new Set(team.drivers);
+      const consSet = new Set(team.constructors);
+      for (const code of includeDrivers) {
+        if (!driverSet.has(code)) {return false;}
+      }
+      for (const code of excludeDrivers) {
+        if (driverSet.has(code)) {return false;}
+      }
+      for (const code of includeConstructors) {
+        if (!consSet.has(code)) {return false;}
+      }
+      for (const code of excludeConstructors) {
+        if (consSet.has(code)) {return false;}
+      }
+
+      return true;
+    });
+  }
+  const top_teams = candidateTeams.slice(0, resultCount);
 
   // If LIMITLESS_CHIP is selected, set expected_price_change to current team's expected price change
   if (selectedChip === LIMITLESS_CHIP) {

--- a/src/bestTeamsCalculator.options.test.js
+++ b/src/bestTeamsCalculator.options.test.js
@@ -1,0 +1,139 @@
+const { calculateBestTeams } = require('./bestTeamsCalculator');
+
+describe('calculateBestTeams options', () => {
+  // Six drivers, three constructors — yields C(6,5)*C(3,2) = 6*3 = 18 team
+  // candidates, enough to exercise filters + ranking without being slow.
+  const mockDrivers = {
+    VER: { DR: 'VER', price: 30, expectedPoints: 50, expectedPriceChange: 0.2 },
+    HAM: { DR: 'HAM', price: 28, expectedPoints: 40, expectedPriceChange: 0.1 },
+    PER: { DR: 'PER', price: 25, expectedPoints: 30, expectedPriceChange: -0.1 },
+    SAI: { DR: 'SAI', price: 23, expectedPoints: 25, expectedPriceChange: 0.3 },
+    LEC: { DR: 'LEC', price: 24, expectedPoints: 35, expectedPriceChange: 0.1 },
+    ALO: { DR: 'ALO', price: 20, expectedPoints: 15, expectedPriceChange: 0 },
+  };
+  const mockConstructors = {
+    RED: { CN: 'RED', price: 35, expectedPoints: 45, expectedPriceChange: 0.5 },
+    MER: { CN: 'MER', price: 32, expectedPoints: 35, expectedPriceChange: 0.2 },
+    FER: { CN: 'FER', price: 30, expectedPoints: 30, expectedPriceChange: -0.1 },
+  };
+  const mockCurrentTeam = {
+    drivers: ['VER', 'HAM', 'PER', 'SAI', 'LEC'],
+    constructors: ['RED', 'MER'],
+    boost: 'VER',
+    freeTransfers: 2,
+    costCapRemaining: 100,
+  };
+  const mockJsonData = {
+    Drivers: mockDrivers,
+    Constructors: mockConstructors,
+    CurrentTeam: mockCurrentTeam,
+  };
+
+  it('mustIncludeDrivers filters to only teams with required drivers', () => {
+    const result = calculateBestTeams(mockJsonData, undefined, 0, 0, {
+      mustIncludeDrivers: ['VER'],
+    });
+    expect(result.length).toBeGreaterThan(0);
+    for (const team of result) {
+      expect(team.drivers).toContain('VER');
+    }
+  });
+
+  it('mustExcludeDrivers filters out teams with banned drivers', () => {
+    const withAlo = calculateBestTeams(mockJsonData, undefined, 0, 0, {});
+    expect(withAlo.some((t) => t.drivers.includes('ALO'))).toBe(true);
+
+    const result = calculateBestTeams(mockJsonData, undefined, 0, 0, {
+      mustExcludeDrivers: ['ALO'],
+    });
+    expect(result.length).toBeGreaterThan(0);
+    for (const team of result) {
+      expect(team.drivers).not.toContain('ALO');
+    }
+  });
+
+  it('combines include + exclude filters', () => {
+    const result = calculateBestTeams(mockJsonData, undefined, 0, 0, {
+      mustIncludeDrivers: ['VER'],
+      mustExcludeDrivers: ['ALO'],
+    });
+    for (const team of result) {
+      expect(team.drivers).toContain('VER');
+      expect(team.drivers).not.toContain('ALO');
+    }
+  });
+
+  it('mustIncludeConstructors filters to teams with required constructor', () => {
+    const result = calculateBestTeams(mockJsonData, undefined, 0, 0, {
+      mustIncludeConstructors: ['FER'],
+    });
+    for (const team of result) {
+      expect(team.constructors).toContain('FER');
+    }
+  });
+
+  it('mustExcludeConstructors filters out teams with banned constructor', () => {
+    const result = calculateBestTeams(mockJsonData, undefined, 0, 0, {
+      mustExcludeConstructors: ['RED'],
+    });
+    for (const team of result) {
+      expect(team.constructors).not.toContain('RED');
+    }
+  });
+
+  it('rankBy: "points" sorts strictly by projected_points desc', () => {
+    const result = calculateBestTeams(mockJsonData, undefined, 0, 0, {
+      rankBy: 'points',
+    });
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i - 1].projected_points).toBeGreaterThanOrEqual(
+        result[i].projected_points,
+      );
+    }
+  });
+
+  it('rankBy: "points_per_million" sorts by points/price', () => {
+    const result = calculateBestTeams(mockJsonData, undefined, 0, 0, {
+      rankBy: 'points_per_million',
+    });
+    expect(result.length).toBeGreaterThan(1);
+    for (let i = 1; i < result.length; i++) {
+      const prev = result[i - 1].projected_points / result[i - 1].total_price;
+      const curr = result[i].projected_points / result[i].total_price;
+      expect(prev).toBeGreaterThanOrEqual(curr);
+    }
+  });
+
+  it('rankBy: "budget_adjusted" sorts by budget_adjusted_points', () => {
+    const result = calculateBestTeams(mockJsonData, undefined, 1.5, 10, {
+      rankBy: 'budget_adjusted',
+    });
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i - 1].budget_adjusted_points).toBeGreaterThanOrEqual(
+        result[i].budget_adjusted_points,
+      );
+    }
+  });
+
+  it('resultCount caps the returned list', () => {
+    const result = calculateBestTeams(mockJsonData, undefined, 0, 0, {
+      resultCount: 3,
+    });
+    expect(result.length).toBeLessThanOrEqual(3);
+  });
+
+  it('empty options object preserves legacy behaviour', () => {
+    const legacy = calculateBestTeams(mockJsonData, undefined, 0, 0);
+    const sameViaOptions = calculateBestTeams(mockJsonData, undefined, 0, 0, {});
+    expect(sameViaOptions).toEqual(legacy);
+  });
+
+  it('returns empty list when filter rules out all teams', () => {
+    const result = calculateBestTeams(mockJsonData, undefined, 0, 0, {
+      // Impossible: require both VER and force-exclude RED+MER+FER (only
+      // constructors that exist) — no constructor combos left.
+      mustExcludeConstructors: ['RED', 'MER', 'FER'],
+    });
+    expect(result).toEqual([]);
+  });
+});

--- a/src/commandsHandler/bestTeamsHandler.js
+++ b/src/commandsHandler/bestTeamsHandler.js
@@ -1,17 +1,14 @@
 const { validateJsonData } = require('../utils');
-const { calculateBestTeams } = require('../bestTeamsCalculator');
 const {
   bestTeamsCache,
   driversCache,
   constructorsCache,
   currentTeamCache,
-  selectedChipCache,
   sharedKey,
   resolveSelectedTeam,
-  getBestTeamBudgetChangePointsPerMillion,
-  remainingRaceCountCache,
 } = require('../cache');
 const { t } = require('../i18n');
+const { computeBestTeams } = require('../cores/bestTeamsCore');
 
 async function handleBestTeamsMessage(bot, chatId) {
   const teamId = await resolveSelectedTeam(bot, chatId);
@@ -41,15 +38,12 @@ async function handleBestTeamsMessage(bot, chatId) {
     return;
   }
 
-  // Build cachedJsonData object
-  const cachedJsonData = {
-    Drivers: drivers,
-    Constructors: constructors,
-    CurrentTeam: currentTeam,
-  };
-
+  // `validateJsonData` is intentionally side-effecty: it sends a user-facing
+  // "Invalid JSON" message via `bot.sendMessage` when the cached data is
+  // malformed. Keep calling it here so the Telegram surface keeps the same
+  // observable behaviour. The agent's core does its own pure validation.
   if (
-    !validateJsonData(
+    !(await validateJsonData(
       bot,
       {
         Drivers: Object.values(drivers),
@@ -57,18 +51,13 @@ async function handleBestTeamsMessage(bot, chatId) {
         CurrentTeam: currentTeam,
       },
       chatId,
-    )
+    ))
   ) {
     return;
   }
-  const budgetChangePointsPerMillion =
-    getBestTeamBudgetChangePointsPerMillion(chatId, teamId);
-  const remainingRaceCount = remainingRaceCountCache[sharedKey];
 
-  if (
-    budgetChangePointsPerMillion > 0 &&
-    !Number.isFinite(remainingRaceCount)
-  ) {
+  const result = await computeBestTeams({ chatId, teamId });
+  if (result.status === 'missing_remaining_race_count') {
     await bot
       .sendMessage(
         chatId,
@@ -78,23 +67,27 @@ async function handleBestTeamsMessage(bot, chatId) {
         ),
       )
       .catch((err) =>
-        console.error('Error sending remaining race count unavailable message:', err),
+        console.error(
+          'Error sending remaining race count unavailable message:',
+          err,
+        ),
       );
 
     return;
   }
 
-  const bestTeams = calculateBestTeams(
-    cachedJsonData,
-    selectedChipCache[chatId]?.[teamId],
-    budgetChangePointsPerMillion,
-    Number.isFinite(remainingRaceCount) ? remainingRaceCount : 0,
-  );
+  // Any other non-ok status here would only fire if cache state changed
+  // between our pre-checks above and the core's checks — defensive guard.
+  if (result.status !== 'ok') {
+    return;
+  }
+
+  const { bestTeams, budgetChangePointsPerMillion } = result;
   if (!bestTeamsCache[chatId]) {
     bestTeamsCache[chatId] = {};
   }
   bestTeamsCache[chatId][teamId] = {
-    currentTeam: cachedJsonData.CurrentTeam,
+    currentTeam,
     bestTeams,
   };
 

--- a/src/cores/bestTeamsCore.js
+++ b/src/cores/bestTeamsCore.js
@@ -1,0 +1,246 @@
+// Pure best-teams core — no `bot`, no `t()`, no `sendMessage`. Both the
+// Telegram adapter (`commandsHandler/bestTeamsHandler.js`) and the web-chat
+// agent tool (`agent/tools.js`) call into this.
+//
+// Returns a status-tagged result the caller can map onto its preferred
+// surface (Telegram message vs. structured JSON for the LLM).
+
+const { calculateBestTeams } = require('../bestTeamsCalculator');
+const {
+  driversCache,
+  constructorsCache,
+  currentTeamCache,
+  selectedChipCache,
+  sharedKey,
+  remainingRaceCountCache,
+  getSelectedTeam,
+  getUserTeamIds,
+  getBestTeamBudgetChangePointsPerMillion,
+} = require('../cache');
+const { NAME_TO_CODE_MAPPING } = require('../constants');
+
+// Normalize a single user-supplied driver / constructor token to its canonical
+// 3-letter code. Accepts already-uppercase codes (`'VER'`) and lowercased
+// human-friendly names (`'m. verstappen'`, `'mclaren'`). Returns null when
+// the input cannot be resolved.
+function normalizeCode(rawCode) {
+  if (typeof rawCode !== 'string') {return null;}
+  const trimmed = rawCode.trim();
+  if (!trimmed) {return null;}
+
+  const upper = trimmed.toUpperCase();
+  if (/^[A-Z]{3}$/.test(upper)) {
+    // Already a canonical 3-letter code. We trust it without verifying it
+    // exists in the current drivers/constructors data — the calculator
+    // simply yields zero matching teams if it doesn't.
+    return upper;
+  }
+
+  const mapped = NAME_TO_CODE_MAPPING[trimmed.toLowerCase()];
+
+  return mapped || null;
+}
+
+function resolveCodes(rawList) {
+  const requested = Array.isArray(rawList) ? rawList.filter(Boolean) : [];
+  const resolved = [];
+  const unknown = [];
+  for (const raw of requested) {
+    const code = normalizeCode(raw);
+    if (code) {
+      resolved.push(code);
+    } else {
+      unknown.push(String(raw));
+    }
+  }
+
+  return { requested, resolved, unknown };
+}
+
+function resolveAllFilters({
+  mustIncludeDrivers,
+  mustExcludeDrivers,
+  mustIncludeConstructors,
+  mustExcludeConstructors,
+}) {
+  return {
+    mustIncludeDrivers: resolveCodes(mustIncludeDrivers),
+    mustExcludeDrivers: resolveCodes(mustExcludeDrivers),
+    mustIncludeConstructors: resolveCodes(mustIncludeConstructors),
+    mustExcludeConstructors: resolveCodes(mustExcludeConstructors),
+  };
+}
+
+function pickTeamId({ chatId, requestedTeamId, requestedTeamName }) {
+  const teamIds = getUserTeamIds(chatId);
+  if (teamIds.length === 0) {
+    return { status: 'no_teams' };
+  }
+
+  if (requestedTeamId) {
+    if (!teamIds.includes(requestedTeamId)) {
+      return { status: 'unknown_team', teamId: requestedTeamId, teamIds };
+    }
+
+    return { status: 'ok', teamId: requestedTeamId };
+  }
+
+  if (requestedTeamName) {
+    // Exact match against the cached `teamName` of each team. We do NOT
+    // fuzzy-match — that would re-introduce all the ambiguity that
+    // driving via `list_user_teams` first is supposed to avoid.
+    const matches = teamIds.filter(
+      (id) => currentTeamCache[chatId]?.[id]?.teamName === requestedTeamName,
+    );
+    if (matches.length === 1) {
+      return { status: 'ok', teamId: matches[0] };
+    }
+    if (matches.length > 1) {
+      return { status: 'ambiguous_team', teamIds: matches };
+    }
+
+    return { status: 'unknown_team', teamName: requestedTeamName, teamIds };
+  }
+
+  if (teamIds.length === 1) {
+    return { status: 'ok', teamId: teamIds[0] };
+  }
+
+  const selected = getSelectedTeam(chatId);
+  if (selected && teamIds.includes(selected)) {
+    return { status: 'ok', teamId: selected };
+  }
+
+  return { status: 'ambiguous_team', teamIds };
+}
+
+function hasAnyFilter(filters) {
+  return (
+    filters.mustIncludeDrivers.resolved.length > 0 ||
+    filters.mustExcludeDrivers.resolved.length > 0 ||
+    filters.mustIncludeConstructors.resolved.length > 0 ||
+    filters.mustExcludeConstructors.resolved.length > 0
+  );
+}
+
+function buildCalculatorOptions({ filters, rankBy, resultCount }) {
+  // Only emit an options object when the caller actually requested something
+  // beyond the legacy 4-arg behaviour. This keeps the Telegram handler
+  // path (no filters, no rankBy) calling `calculateBestTeams` with the
+  // historical 4 positional args, which the existing handler tests rely
+  // on via `toHaveBeenCalledWith(data, chip, ppm, rrc)`.
+  if (!hasAnyFilter(filters) && rankBy === null && resultCount === undefined) {
+    return null;
+  }
+
+  return {
+    mustIncludeDrivers: filters.mustIncludeDrivers.resolved,
+    mustExcludeDrivers: filters.mustExcludeDrivers.resolved,
+    mustIncludeConstructors: filters.mustIncludeConstructors.resolved,
+    mustExcludeConstructors: filters.mustExcludeConstructors.resolved,
+    rankBy,
+    ...(Number.isFinite(resultCount) ? { resultCount } : {}),
+  };
+}
+
+// eslint-disable-next-line max-statements
+async function computeBestTeams({
+  chatId,
+  teamId: requestedTeamId,
+  teamName: requestedTeamName,
+  rankBy = null,
+  resultCount,
+  mustIncludeDrivers,
+  mustExcludeDrivers,
+  mustIncludeConstructors,
+  mustExcludeConstructors,
+}) {
+  const pick = pickTeamId({ chatId, requestedTeamId, requestedTeamName });
+  if (pick.status !== 'ok') {
+    return pick;
+  }
+  const { teamId } = pick;
+
+  const drivers = driversCache[chatId] || driversCache[sharedKey];
+  const constructors =
+    constructorsCache[chatId] || constructorsCache[sharedKey];
+  const currentTeam = currentTeamCache[chatId]?.[teamId];
+
+  if (!drivers || !constructors || !currentTeam) {
+    return { status: 'missing_cache', teamId };
+  }
+
+  const budgetChangePointsPerMillion = getBestTeamBudgetChangePointsPerMillion(
+    chatId,
+    teamId,
+  );
+  const remainingRaceCount = remainingRaceCountCache[sharedKey];
+  if (
+    budgetChangePointsPerMillion > 0 &&
+    !Number.isFinite(remainingRaceCount)
+  ) {
+    return { status: 'missing_remaining_race_count', teamId };
+  }
+
+  const filters = resolveAllFilters({
+    mustIncludeDrivers,
+    mustExcludeDrivers,
+    mustIncludeConstructors,
+    mustExcludeConstructors,
+  });
+  const anyUnknown =
+    filters.mustIncludeDrivers.unknown.length > 0 ||
+    filters.mustExcludeDrivers.unknown.length > 0 ||
+    filters.mustIncludeConstructors.unknown.length > 0 ||
+    filters.mustExcludeConstructors.unknown.length > 0;
+  if (anyUnknown) {
+    return { status: 'unknown_filter', teamId, filters };
+  }
+
+  const chip = selectedChipCache[chatId]?.[teamId];
+  const cachedJsonData = {
+    Drivers: drivers,
+    Constructors: constructors,
+    CurrentTeam: currentTeam,
+  };
+  const calculatorOptions = buildCalculatorOptions({
+    filters,
+    rankBy,
+    resultCount,
+  });
+
+  const bestTeams = calculatorOptions
+    ? calculateBestTeams(
+        cachedJsonData,
+        chip,
+        budgetChangePointsPerMillion,
+        Number.isFinite(remainingRaceCount) ? remainingRaceCount : 0,
+        calculatorOptions,
+      )
+    : calculateBestTeams(
+        cachedJsonData,
+        chip,
+        budgetChangePointsPerMillion,
+        Number.isFinite(remainingRaceCount) ? remainingRaceCount : 0,
+      );
+
+  return {
+    status: 'ok',
+    teamId,
+    teamName: currentTeam.teamName || teamId,
+    currentTeam,
+    bestTeams,
+    chip,
+    rankBy,
+    budgetChangePointsPerMillion,
+    filters,
+  };
+}
+
+module.exports = {
+  computeBestTeams,
+  // exported for unit tests / advanced callers
+  normalizeCode,
+  resolveCodes,
+};
+

--- a/src/cores/bestTeamsCore.test.js
+++ b/src/cores/bestTeamsCore.test.js
@@ -1,0 +1,234 @@
+const { KILZI_CHAT_ID } = require('../constants');
+
+const mockCalculateBestTeams = jest.fn();
+jest.mock('../bestTeamsCalculator', () => ({
+  calculateBestTeams: (...args) => mockCalculateBestTeams(...args),
+}));
+
+const {
+  driversCache,
+  constructorsCache,
+  currentTeamCache,
+  selectedChipCache,
+  sharedKey,
+  remainingRaceCountCache,
+  userCache,
+} = require('../cache');
+
+const { computeBestTeams, normalizeCode } = require('./bestTeamsCore');
+
+const TEAM_ID = 'T1';
+const TEAM_ID_2 = 'T2';
+
+function seedValidCache({
+  drivers = { VER: { price: 30 }, HAM: { price: 28 } },
+  constructors = { RED: { price: 35 }, MER: { price: 32 } },
+  currentTeam = {
+    drivers: ['VER', 'HAM'],
+    constructors: ['RED', 'MER'],
+    boost: 'VER',
+    freeTransfers: 2,
+    costCapRemaining: 5,
+    teamName: 'kilzid3',
+  },
+} = {}) {
+  driversCache[KILZI_CHAT_ID] = drivers;
+  constructorsCache[KILZI_CHAT_ID] = constructors;
+  currentTeamCache[KILZI_CHAT_ID] = { [TEAM_ID]: currentTeam };
+}
+
+function clearCaches() {
+  delete driversCache[KILZI_CHAT_ID];
+  delete driversCache[sharedKey];
+  delete constructorsCache[KILZI_CHAT_ID];
+  delete constructorsCache[sharedKey];
+  delete currentTeamCache[KILZI_CHAT_ID];
+  delete selectedChipCache[KILZI_CHAT_ID];
+  delete remainingRaceCountCache[sharedKey];
+  delete userCache[String(KILZI_CHAT_ID)];
+}
+
+describe('normalizeCode', () => {
+  it('returns uppercase 3-letter codes as-is', () => {
+    expect(normalizeCode('VER')).toBe('VER');
+    expect(normalizeCode('ver')).toBe('VER');
+    expect(normalizeCode(' Ver ')).toBe('VER');
+  });
+
+  it('resolves full driver names through NAME_TO_CODE_MAPPING', () => {
+    expect(normalizeCode('M. Verstappen')).toBe('VER');
+    expect(normalizeCode('mclaren')).toBe('MCL');
+    expect(normalizeCode('Red Bull Racing')).toBe('RED');
+  });
+
+  it('returns null for unknown names', () => {
+    expect(normalizeCode('Some Random Driver')).toBeNull();
+    expect(normalizeCode('')).toBeNull();
+    expect(normalizeCode(null)).toBeNull();
+    expect(normalizeCode(42)).toBeNull();
+  });
+});
+
+describe('computeBestTeams', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearCaches();
+  });
+
+  it('returns no_teams when chat has no tracked teams', async () => {
+    const result = await computeBestTeams({ chatId: KILZI_CHAT_ID });
+    expect(result.status).toBe('no_teams');
+    expect(mockCalculateBestTeams).not.toHaveBeenCalled();
+  });
+
+  it('returns unknown_team when requested teamId not in cache', async () => {
+    seedValidCache();
+    const result = await computeBestTeams({
+      chatId: KILZI_CHAT_ID,
+      teamId: 'does_not_exist',
+    });
+    expect(result.status).toBe('unknown_team');
+    expect(mockCalculateBestTeams).not.toHaveBeenCalled();
+  });
+
+  it('resolves teamName via exact match against cached teamName', async () => {
+    seedValidCache();
+    mockCalculateBestTeams.mockReturnValue([]);
+    const result = await computeBestTeams({
+      chatId: KILZI_CHAT_ID,
+      teamName: 'kilzid3',
+    });
+    expect(result.status).toBe('ok');
+    expect(result.teamId).toBe(TEAM_ID);
+  });
+
+  it('returns ambiguous_team when teamName matches multiple teams', async () => {
+    seedValidCache();
+    currentTeamCache[KILZI_CHAT_ID][TEAM_ID_2] = {
+      drivers: ['VER', 'HAM'],
+      constructors: ['RED', 'MER'],
+      teamName: 'kilzid3',
+    };
+    const result = await computeBestTeams({
+      chatId: KILZI_CHAT_ID,
+      teamName: 'kilzid3',
+    });
+    expect(result.status).toBe('ambiguous_team');
+    expect(result.teamIds).toEqual([TEAM_ID, TEAM_ID_2]);
+  });
+
+  it('returns ambiguous_team when multiple teams + no selectedTeam', async () => {
+    seedValidCache();
+    currentTeamCache[KILZI_CHAT_ID][TEAM_ID_2] = {
+      drivers: ['VER', 'HAM'],
+      constructors: ['RED', 'MER'],
+      teamName: 'second',
+    };
+    const result = await computeBestTeams({ chatId: KILZI_CHAT_ID });
+    expect(result.status).toBe('ambiguous_team');
+  });
+
+  it('uses selectedTeam when multiple teams', async () => {
+    seedValidCache();
+    currentTeamCache[KILZI_CHAT_ID][TEAM_ID_2] = {
+      drivers: ['VER', 'HAM'],
+      constructors: ['RED', 'MER'],
+      teamName: 'second',
+    };
+    userCache[String(KILZI_CHAT_ID)] = { selectedTeam: TEAM_ID_2 };
+    mockCalculateBestTeams.mockReturnValue([]);
+    const result = await computeBestTeams({ chatId: KILZI_CHAT_ID });
+    expect(result.status).toBe('ok');
+    expect(result.teamId).toBe(TEAM_ID_2);
+  });
+
+  it('returns missing_cache when drivers cache is absent', async () => {
+    currentTeamCache[KILZI_CHAT_ID] = {
+      [TEAM_ID]: { drivers: ['VER'], constructors: ['RED'] },
+    };
+    const result = await computeBestTeams({ chatId: KILZI_CHAT_ID });
+    expect(result.status).toBe('missing_cache');
+  });
+
+  it('returns missing_remaining_race_count when ppm>0 + no race count', async () => {
+    seedValidCache();
+    userCache[String(KILZI_CHAT_ID)] = {
+      bestTeamBudgetChangePointsPerMillion: { [TEAM_ID]: 1.5 },
+    };
+    const result = await computeBestTeams({ chatId: KILZI_CHAT_ID });
+    expect(result.status).toBe('missing_remaining_race_count');
+  });
+
+  it('returns unknown_filter when must-include contains unresolvable name', async () => {
+    seedValidCache();
+    const result = await computeBestTeams({
+      chatId: KILZI_CHAT_ID,
+      mustIncludeDrivers: ['M. Verstappen', 'Some Driver That Does Not Exist'],
+    });
+    expect(result.status).toBe('unknown_filter');
+    expect(result.filters.mustIncludeDrivers.resolved).toEqual(['VER']);
+    expect(result.filters.mustIncludeDrivers.unknown).toEqual([
+      'Some Driver That Does Not Exist',
+    ]);
+    expect(mockCalculateBestTeams).not.toHaveBeenCalled();
+  });
+
+  it('passes filters + rankBy + resultCount through to calculator', async () => {
+    seedValidCache();
+    mockCalculateBestTeams.mockReturnValue([]);
+    await computeBestTeams({
+      chatId: KILZI_CHAT_ID,
+      mustIncludeDrivers: ['VER'],
+      mustExcludeDrivers: ['ALO'],
+      mustIncludeConstructors: ['MCL'],
+      mustExcludeConstructors: ['FER'],
+      rankBy: 'points_per_million',
+      resultCount: 5,
+    });
+    expect(mockCalculateBestTeams).toHaveBeenCalledTimes(1);
+    const optionsArg = mockCalculateBestTeams.mock.calls[0][4];
+    expect(optionsArg).toEqual({
+      mustIncludeDrivers: ['VER'],
+      mustExcludeDrivers: ['ALO'],
+      mustIncludeConstructors: ['MCL'],
+      mustExcludeConstructors: ['FER'],
+      rankBy: 'points_per_million',
+      resultCount: 5,
+    });
+  });
+
+  it('skips the options arg entirely when no filters / rankBy', async () => {
+    seedValidCache();
+    mockCalculateBestTeams.mockReturnValue([]);
+    await computeBestTeams({ chatId: KILZI_CHAT_ID });
+    expect(mockCalculateBestTeams).toHaveBeenCalledTimes(1);
+    // Telegram path must call calculator with exactly 4 positional args.
+    expect(mockCalculateBestTeams.mock.calls[0]).toHaveLength(4);
+  });
+
+  it('returns teamName from cache when status is ok', async () => {
+    seedValidCache();
+    mockCalculateBestTeams.mockReturnValue([
+      { row: 1, drivers: ['VER'], constructors: ['RED'] },
+    ]);
+    const result = await computeBestTeams({ chatId: KILZI_CHAT_ID });
+    expect(result.status).toBe('ok');
+    expect(result.teamName).toBe('kilzid3');
+  });
+
+  it('falls back to teamId when no teamName cached', async () => {
+    seedValidCache({
+      currentTeam: {
+        drivers: ['VER', 'HAM'],
+        constructors: ['RED', 'MER'],
+        boost: 'VER',
+        freeTransfers: 2,
+        costCapRemaining: 5,
+        // teamName intentionally omitted (screenshot team)
+      },
+    });
+    mockCalculateBestTeams.mockReturnValue([]);
+    const result = await computeBestTeams({ chatId: KILZI_CHAT_ID });
+    expect(result.teamName).toBe(TEAM_ID);
+  });
+});

--- a/src/cores/userTeamsCore.js
+++ b/src/cores/userTeamsCore.js
@@ -1,0 +1,40 @@
+// Pure user-teams core — enumerates the user's tracked teams plus the
+// minimal per-team metadata the LLM needs to resolve a name like "kilzid3"
+// to a canonical teamId before calling `get_best_teams`.
+
+const {
+  currentTeamCache,
+  selectedChipCache,
+  isLeagueTeamId,
+  getSelectedTeam,
+  getUserTeamIds,
+} = require('../cache');
+
+function listUserTeams({ chatId }) {
+  const teamIds = getUserTeamIds(chatId);
+  const selected = getSelectedTeam(chatId);
+
+  return teamIds.map((teamId) => {
+    const team = currentTeamCache[chatId]?.[teamId] || {};
+    const chip = selectedChipCache[chatId]?.[teamId] || null;
+
+    return {
+      teamId,
+      teamName: team.teamName || teamId,
+      isLeague: isLeagueTeamId(teamId),
+      isSelected: selected === teamId,
+      chip,
+      drivers: Array.isArray(team.drivers) ? [...team.drivers] : [],
+      constructors: Array.isArray(team.constructors) ? [...team.constructors] : [],
+      boost: team.boost || null,
+      freeTransfers:
+        typeof team.freeTransfers === 'number' ? team.freeTransfers : null,
+      costCapRemaining:
+        typeof team.costCapRemaining === 'number'
+          ? team.costCapRemaining
+          : null,
+    };
+  });
+}
+
+module.exports = { listUserTeams };

--- a/src/cores/userTeamsCore.test.js
+++ b/src/cores/userTeamsCore.test.js
@@ -1,0 +1,81 @@
+const { KILZI_CHAT_ID } = require('../constants');
+const {
+  currentTeamCache,
+  selectedChipCache,
+  userCache,
+} = require('../cache');
+
+const { listUserTeams } = require('./userTeamsCore');
+
+describe('listUserTeams', () => {
+  beforeEach(() => {
+    delete currentTeamCache[KILZI_CHAT_ID];
+    delete selectedChipCache[KILZI_CHAT_ID];
+    delete userCache[String(KILZI_CHAT_ID)];
+  });
+
+  it('returns empty array when chat has no teams', () => {
+    expect(listUserTeams({ chatId: KILZI_CHAT_ID })).toEqual([]);
+  });
+
+  it('returns shaped data for screenshot teams (no underscore in teamId)', () => {
+    currentTeamCache[KILZI_CHAT_ID] = {
+      T1: {
+        drivers: ['VER', 'HAM'],
+        constructors: ['RED'],
+        boost: 'VER',
+        freeTransfers: 1,
+        costCapRemaining: 2.5,
+      },
+    };
+    const result = listUserTeams({ chatId: KILZI_CHAT_ID });
+    expect(result).toEqual([
+      {
+        teamId: 'T1',
+        teamName: 'T1',
+        isLeague: false,
+        isSelected: false,
+        chip: null,
+        drivers: ['VER', 'HAM'],
+        constructors: ['RED'],
+        boost: 'VER',
+        freeTransfers: 1,
+        costCapRemaining: 2.5,
+      },
+    ]);
+  });
+
+  it('marks league teams (underscore in teamId) and exposes teamName', () => {
+    currentTeamCache[KILZI_CHAT_ID] = {
+      Doron_3: {
+        drivers: ['VER'],
+        constructors: ['RED'],
+        teamName: 'kilzid3',
+      },
+    };
+    const [team] = listUserTeams({ chatId: KILZI_CHAT_ID });
+    expect(team.isLeague).toBe(true);
+    expect(team.teamName).toBe('kilzid3');
+  });
+
+  it('marks the selected team via userCache.selectedTeam', () => {
+    currentTeamCache[KILZI_CHAT_ID] = {
+      T1: { drivers: [], constructors: [] },
+      T2: { drivers: [], constructors: [] },
+    };
+    userCache[String(KILZI_CHAT_ID)] = { selectedTeam: 'T2' };
+
+    const result = listUserTeams({ chatId: KILZI_CHAT_ID });
+    expect(result.find((t) => t.teamId === 'T2').isSelected).toBe(true);
+    expect(result.find((t) => t.teamId === 'T1').isSelected).toBe(false);
+  });
+
+  it('passes the active chip per team', () => {
+    currentTeamCache[KILZI_CHAT_ID] = {
+      T1: { drivers: [], constructors: [] },
+    };
+    selectedChipCache[KILZI_CHAT_ID] = { T1: 'EXTRA_BOOST' };
+    const [team] = listUserTeams({ chatId: KILZI_CHAT_ID });
+    expect(team.chip).toBe('EXTRA_BOOST');
+  });
+});

--- a/src/utils/leagueTeamHelpers.js
+++ b/src/utils/leagueTeamHelpers.js
@@ -31,6 +31,20 @@ function mapNameToCode(name) {
 
 /**
  * Map one league team entry (from teams-data.json) to the bot's team cache shape.
+ *
+ * `costCapRemaining` is derived from `leagueTeam.budget` — which is the
+ * user's cost cap going into the upcoming matchday (`team_info.maxTeambal`
+ * from the upstream F1 Fantasy API). See the companion scraper PR
+ * f1-fantasy-api-data#19 for the field's definition.
+ *
+ * Transition / backwards-compat: before that scraper PR shipped, `budget`
+ * on cached blobs carried `team_info.teamVal` (the team's current value,
+ * i.e. the sum of driver + constructor prices). Reading those stale
+ * blobs through this mapper trivially yields `costCapRemaining =
+ * teamVal − Σ_prices ≈ 0` — the same value the bot reported in
+ * production before the cap-cap fix landed. No regression during the
+ * deployment window; the moment the next scrape repopulates a blob the
+ * mapper starts emitting correct values for that team.
  */
 function mapLeagueTeamToBotTeam(leagueTeam) {
   const drivers = Array.isArray(leagueTeam.drivers) ? leagueTeam.drivers : [];
@@ -47,10 +61,10 @@ function mapLeagueTeamToBotTeam(leagueTeam) {
     drivers[0];
   const boost = captain ? mapNameToCode(captain.name) : null;
 
-  const budget = Number(leagueTeam.budget);
-  const costCapRemaining = Number.isFinite(budget)
-    ? Math.round((budget - sumPrices(drivers) - sumPrices(constructors)) * 100) /
-      100
+  const teamValue = sumPrices(drivers) + sumPrices(constructors);
+  const cap = Number(leagueTeam.budget);
+  const costCapRemaining = Number.isFinite(cap)
+    ? Math.max(0, Math.round((cap - teamValue) * 100) / 100)
     : 0;
 
   const transfersRemainingRaw = Number(leagueTeam.transfersRemaining);

--- a/src/utils/leagueTeamHelpers.test.js
+++ b/src/utils/leagueTeamHelpers.test.js
@@ -1,0 +1,135 @@
+const { mapLeagueTeamToBotTeam } = require('./leagueTeamHelpers');
+
+describe('mapLeagueTeamToBotTeam', () => {
+  // A representative league-team blob as the scraper writes it after
+  // f1-fantasy-api-data PR #19 (where `budget` is the user's cost cap
+  // = team_info.maxTeambal). Prices match the real Kilzid team observed
+  // in production: drivers sum to 53.4, constructors sum to 53.4
+  // → team value 106.8, cost cap 109.2 → 2.4 cap remaining.
+  function fixture(overrides = {}) {
+    return {
+      teamName: 'Kilzid',
+      userName: 'Doron Kilzi',
+      teamNo: 1,
+      position: 4,
+      budget: 109.2,
+      transfersRemaining: 2,
+      drivers: [
+        { id: '1', name: 'M. Verstappen', price: 15.0, isCaptain: true },
+        { id: '2', name: 'L. Norris', price: 12.0 },
+        { id: '3', name: 'L. Hamilton', price: 10.0 },
+        { id: '4', name: 'O. Bearman', price: 9.4 },
+        { id: '5', name: 'L. Stroll', price: 7.0 },
+      ],
+      constructors: [
+        { id: '6', name: 'McLaren', price: 30.0 },
+        { id: '7', name: 'Ferrari', price: 23.4 },
+      ],
+      ...overrides,
+    };
+  }
+
+  it('maps the canonical happy-path team shape', () => {
+    const result = mapLeagueTeamToBotTeam(fixture());
+    expect(result).toEqual({
+      drivers: ['VER', 'NOR', 'HAM', 'BEA', 'STR'],
+      constructors: ['MCL', 'FER'],
+      boost: 'VER',
+      freeTransfers: 2,
+      costCapRemaining: 2.4,
+      teamName: 'Kilzid',
+      userName: 'Doron Kilzi',
+      teamNo: 1,
+    });
+  });
+
+  it('treats leagueTeam.budget as the cost cap', () => {
+    // Team value is 106.8, varying the cap should move cap-remaining 1:1.
+    expect(mapLeagueTeamToBotTeam(fixture()).costCapRemaining).toBe(2.4);
+    expect(
+      mapLeagueTeamToBotTeam(fixture({ budget: 108.5 })).costCapRemaining,
+    ).toBe(1.7);
+    expect(
+      mapLeagueTeamToBotTeam(fixture({ budget: 106.8 })).costCapRemaining,
+    ).toBe(0);
+  });
+
+  it('gracefully degrades to 0 for stale blobs where budget = teamValue', () => {
+    // Documents the transition-window contract: blobs written before
+    // f1-fantasy-api-data PR #19 carry `budget = team_info.teamVal`
+    // (= Σ_prices). The mapper subtracts Σ_prices from budget, getting
+    // ~0 — same as production today, no regression.
+    expect(
+      mapLeagueTeamToBotTeam(fixture({ budget: 106.8 })).costCapRemaining,
+    ).toBe(0);
+  });
+
+  it('clamps negative caps to 0 (over-budget team)', () => {
+    // If the upstream API ever returns a cap below the team value
+    // (mid-week price drops dipping the cap below the roster total),
+    // don't propagate negative numbers.
+    expect(
+      mapLeagueTeamToBotTeam(fixture({ budget: 100 })).costCapRemaining,
+    ).toBe(0);
+  });
+
+  it('rounds costCapRemaining to 2 decimals', () => {
+    expect(
+      mapLeagueTeamToBotTeam(fixture({ budget: 109.234 })).costCapRemaining,
+    ).toBe(2.43);
+    expect(
+      mapLeagueTeamToBotTeam(fixture({ budget: 109.235 })).costCapRemaining,
+    ).toBe(2.44);
+  });
+
+  it('returns 0 cap when budget is absent', () => {
+    const team = fixture();
+    delete team.budget;
+    expect(mapLeagueTeamToBotTeam(team).costCapRemaining).toBe(0);
+  });
+
+  it('picks a captain via isCaptain', () => {
+    expect(mapLeagueTeamToBotTeam(fixture()).boost).toBe('VER');
+  });
+
+  it('picks an isMegaCaptain when no isCaptain is set', () => {
+    const team = fixture({
+      drivers: [
+        { id: '1', name: 'M. Verstappen', price: 15.0 },
+        { id: '2', name: 'L. Norris', price: 12.0, isMegaCaptain: true },
+        { id: '3', name: 'L. Hamilton', price: 10.0 },
+        { id: '4', name: 'O. Bearman', price: 9.4 },
+        { id: '5', name: 'L. Stroll', price: 7.0 },
+      ],
+    });
+    expect(mapLeagueTeamToBotTeam(team).boost).toBe('NOR');
+  });
+
+  it('falls back to the first driver when no captain flag is set', () => {
+    const team = fixture({
+      drivers: [
+        { id: '1', name: 'M. Verstappen', price: 15.0 },
+        { id: '2', name: 'L. Norris', price: 12.0 },
+      ],
+    });
+    expect(mapLeagueTeamToBotTeam(team).boost).toBe('VER');
+  });
+
+  it('clamps a negative transfersRemaining to 0', () => {
+    expect(
+      mapLeagueTeamToBotTeam(fixture({ transfersRemaining: -2 })).freeTransfers,
+    ).toBe(0);
+  });
+
+  it('omits optional metadata fields when absent', () => {
+    const team = fixture();
+    delete team.teamName;
+    delete team.userName;
+    delete team.teamNo;
+    const result = mapLeagueTeamToBotTeam(team);
+    expect(result).not.toHaveProperty('teamName');
+    expect(result).not.toHaveProperty('userName');
+    expect(result).not.toHaveProperty('teamNo');
+  });
+});
+

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,8 @@ import { CopilotKit } from '@copilotkit/react-core';
 import { CopilotChat } from '@copilotkit/react-ui';
 import '@copilotkit/react-ui/styles.css';
 import { useNextRacesAction } from './components/NextRacesTable';
+import { useBestTeamsAction } from './components/BestTeamsTable';
+import { useUserTeamsAction } from './components/UserTeamsList';
 
 const RUNTIME_URL =
   (import.meta.env.VITE_AGENT_API_URL as string | undefined) ??
@@ -9,6 +11,8 @@ const RUNTIME_URL =
 
 function AgentActions() {
   useNextRacesAction();
+  useUserTeamsAction();
+  useBestTeamsAction();
   return null;
 }
 
@@ -17,16 +21,17 @@ export default function App() {
     <div className="app-shell">
       <h1 className="app-header">F1 Fantasy Agent</h1>
       <p className="app-subheader">
-        Ask about upcoming races. The Telegram bot is unaffected.
+        Ask about upcoming races or your best teams. The Telegram bot is unaffected.
       </p>
       <CopilotKit runtimeUrl={RUNTIME_URL}>
         <AgentActions />
         <div className="chat-wrapper">
           <CopilotChat
-            instructions="You are an assistant for an F1 Fantasy player. Use the registered tools to answer questions about upcoming races; the user will see rich UI components automatically when you call them."
+            instructions="You are an assistant for an F1 Fantasy player. Use the registered tools to answer questions; the user will see rich UI components automatically when you call them."
             labels={{
               title: 'F1 Fantasy Agent',
-              initial: 'Hi! Ask me about upcoming F1 races.',
+              initial:
+                'Hi! Try: "best teams for kilzid3 with Verstappen but no Alonso".',
             }}
           />
         </div>

--- a/web/src/components/BestTeamsTable.tsx
+++ b/web/src/components/BestTeamsTable.tsx
@@ -1,0 +1,362 @@
+import { useCopilotAction } from '@copilotkit/react-core';
+
+type BestTeamRow = {
+  row: number;
+  drivers: string[];
+  constructors: string[];
+  boostDriver: string;
+  extraBoostDriver: string | null;
+  totalPrice: number;
+  transfersNeeded: number;
+  penalty: number;
+  projectedPoints: number;
+  budgetAdjustedPoints: number | null;
+  expectedPriceChange: number | null;
+  pointsPerMillion: number | null;
+};
+
+type GetBestTeamsOkResult = {
+  status: 'ok';
+  teamId: string;
+  teamName: string;
+  chip: string | null;
+  rankBy: 'points' | 'budget_adjusted' | 'points_per_million' | null;
+  budgetChangePointsPerMillion: number;
+  filters: {
+    mustIncludeDrivers: string[];
+    mustExcludeDrivers: string[];
+    mustIncludeConstructors: string[];
+    mustExcludeConstructors: string[];
+  };
+  bestTeams: BestTeamRow[];
+};
+
+type GetBestTeamsErrorResult = {
+  status:
+    | 'no_teams'
+    | 'ambiguous_team'
+    | 'unknown_team'
+    | 'missing_cache'
+    | 'invalid_data'
+    | 'missing_remaining_race_count'
+    | 'unknown_filter';
+  teamId?: string;
+  teamIds?: string[];
+  teamName?: string;
+  filters?: {
+    mustIncludeDrivers?: { resolved: string[]; unknown: string[] };
+    mustExcludeDrivers?: { resolved: string[]; unknown: string[] };
+    mustIncludeConstructors?: { resolved: string[]; unknown: string[] };
+    mustExcludeConstructors?: { resolved: string[]; unknown: string[] };
+  };
+};
+
+type GetBestTeamsResult = GetBestTeamsOkResult | GetBestTeamsErrorResult;
+
+const STATUS_MESSAGES: Record<GetBestTeamsErrorResult['status'], string> = {
+  no_teams:
+    'No teams found for this user. Follow a league and pick teams to track first.',
+  ambiguous_team:
+    'You have multiple teams — please tell me which one (use the teamName).',
+  unknown_team:
+    'I could not find that team. Try `list user teams` to see the options.',
+  missing_cache:
+    'The bot does not have cached drivers/constructors/current-team data yet. Send the screenshots first.',
+  invalid_data:
+    'The cached data looks malformed (wrong driver/constructor counts). Please re-upload.',
+  missing_remaining_race_count:
+    'Remaining race count is unavailable right now. Switch to Pure Points ranking or try again later.',
+  unknown_filter:
+    'I could not resolve some of the driver/constructor names you mentioned.',
+};
+
+function chipLabel(chip: string | null | undefined): string {
+  if (!chip) return 'No chip';
+  switch (chip) {
+    case 'EXTRA_BOOST':
+      return 'Extra Boost';
+    case 'WILDCARD':
+      return 'Wildcard';
+    case 'LIMITLESS':
+      return 'Limitless';
+    case 'WITHOUT_CHIP':
+      return 'No chip';
+    default:
+      return chip;
+  }
+}
+
+function rankByLabel(
+  rankBy: GetBestTeamsOkResult['rankBy'],
+  budgetChangePointsPerMillion: number,
+): string {
+  if (rankBy === 'points') return 'projected points';
+  if (rankBy === 'budget_adjusted') return 'budget-adjusted points';
+  if (rankBy === 'points_per_million') return 'points per million';
+  return budgetChangePointsPerMillion > 0
+    ? 'budget-adjusted points'
+    : 'projected points';
+}
+
+function BestTeamsError({ result }: { result: GetBestTeamsErrorResult }) {
+  const base = STATUS_MESSAGES[result.status] || `Error: ${result.status}`;
+  const unknown =
+    result.status === 'unknown_filter' && result.filters
+      ? [
+          ...(result.filters.mustIncludeDrivers?.unknown || []),
+          ...(result.filters.mustExcludeDrivers?.unknown || []),
+          ...(result.filters.mustIncludeConstructors?.unknown || []),
+          ...(result.filters.mustExcludeConstructors?.unknown || []),
+        ]
+      : [];
+
+  return (
+    <div
+      style={{
+        padding: 12,
+        border: '1px solid #f0d5d5',
+        borderRadius: 8,
+        background: '#fff7f7',
+        color: '#7a2222',
+        fontSize: 14,
+      }}
+    >
+      <div style={{ fontWeight: 600, marginBottom: 4 }}>
+        Could not compute best teams
+      </div>
+      <div>{base}</div>
+      {unknown.length > 0 ? (
+        <div style={{ marginTop: 6, fontSize: 13 }}>
+          Unresolved: {unknown.join(', ')}
+        </div>
+      ) : null}
+      {result.teamIds && result.teamIds.length > 1 ? (
+        <div style={{ marginTop: 6, fontSize: 13 }}>
+          Candidates: {result.teamIds.join(', ')}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function HighlightedCode({
+  code,
+  isIncluded,
+  isCaptain,
+  isMega,
+}: {
+  code: string;
+  isIncluded: boolean;
+  isCaptain: boolean;
+  isMega: boolean;
+}) {
+  const style: React.CSSProperties = {
+    display: 'inline-block',
+    padding: '2px 6px',
+    margin: '2px 3px 2px 0',
+    borderRadius: 4,
+    fontSize: 12,
+    fontWeight: 600,
+    border: '1px solid #d5dbe7',
+    background: isIncluded ? '#e6f4ea' : '#fafbfd',
+    color: isIncluded ? '#1e4d2b' : '#222',
+  };
+  return (
+    <span style={style}>
+      {code}
+      {isMega ? ' ⭐⭐' : isCaptain ? ' ⭐' : ''}
+    </span>
+  );
+}
+
+function BestTeamsTable({ result }: { result?: GetBestTeamsResult }) {
+  if (!result) return null;
+  if (result.status !== 'ok') {
+    return <BestTeamsError result={result} />;
+  }
+  if (!result.bestTeams || result.bestTeams.length === 0) {
+    return (
+      <div style={{ padding: 12, color: '#555' }}>
+        No teams match those filters.
+      </div>
+    );
+  }
+
+  const includeDrivers = new Set(result.filters.mustIncludeDrivers);
+  const includeConstructors = new Set(result.filters.mustIncludeConstructors);
+  const showBudgetAdjusted = result.budgetChangePointsPerMillion > 0;
+  const showPointsPerMillion = result.rankBy === 'points_per_million';
+
+  return (
+    <div
+      style={{
+        margin: '8px 0',
+        border: '1px solid #e2e6ee',
+        borderRadius: 8,
+        background: '#fff',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          padding: '10px 14px',
+          borderBottom: '1px solid #e2e6ee',
+          background: '#f8fafc',
+          fontSize: 14,
+        }}
+      >
+        <div style={{ fontWeight: 600 }}>
+          Best teams — {result.teamName}
+        </div>
+        <div style={{ color: '#555', fontSize: 12, marginTop: 2 }}>
+          Ranked by {rankByLabel(result.rankBy, result.budgetChangePointsPerMillion)}
+          {' · '}
+          Chip: {chipLabel(result.chip)}
+          {includeDrivers.size > 0
+            ? ` · must include ${[...includeDrivers].join(', ')}`
+            : ''}
+          {result.filters.mustExcludeDrivers.length > 0
+            ? ` · must exclude ${result.filters.mustExcludeDrivers.join(', ')}`
+            : ''}
+          {includeConstructors.size > 0
+            ? ` · constructor includes ${[...includeConstructors].join(', ')}`
+            : ''}
+          {result.filters.mustExcludeConstructors.length > 0
+            ? ` · constructor excludes ${result.filters.mustExcludeConstructors.join(', ')}`
+            : ''}
+        </div>
+      </div>
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
+        <thead>
+          <tr style={{ background: '#fafbfd', textAlign: 'left' }}>
+            <th style={cellHeader}>#</th>
+            <th style={cellHeader}>Drivers</th>
+            <th style={cellHeader}>Constructors</th>
+            <th style={cellHeader}>Price</th>
+            <th style={cellHeader}>Pts</th>
+            {showBudgetAdjusted ? <th style={cellHeader}>Budget-adj</th> : null}
+            {showPointsPerMillion ? <th style={cellHeader}>Pts/$M</th> : null}
+            <th style={cellHeader}>Tr</th>
+            <th style={cellHeader}>Δ price</th>
+          </tr>
+        </thead>
+        <tbody>
+          {result.bestTeams.map((team) => (
+            <tr key={team.row} style={{ borderTop: '1px solid #f0f2f7' }}>
+              <td style={cellBody}>
+                <strong>{team.row}</strong>
+                {team.transfersNeeded === 0 ? (
+                  <div style={{ fontSize: 11, color: '#1e4d2b' }}>current</div>
+                ) : null}
+              </td>
+              <td style={cellBody}>
+                {team.drivers.map((code) => (
+                  <HighlightedCode
+                    key={code}
+                    code={code}
+                    isIncluded={includeDrivers.has(code)}
+                    isCaptain={code === team.boostDriver}
+                    isMega={code === team.extraBoostDriver}
+                  />
+                ))}
+              </td>
+              <td style={cellBody}>
+                {team.constructors.map((code) => (
+                  <HighlightedCode
+                    key={code}
+                    code={code}
+                    isIncluded={includeConstructors.has(code)}
+                    isCaptain={false}
+                    isMega={false}
+                  />
+                ))}
+              </td>
+              <td style={cellBody}>{team.totalPrice.toFixed(1)}</td>
+              <td style={cellBody}>
+                <strong>{team.projectedPoints.toFixed(1)}</strong>
+                {team.penalty > 0 ? (
+                  <div style={{ fontSize: 11, color: '#7a2222' }}>
+                    -{team.penalty} pen
+                  </div>
+                ) : null}
+              </td>
+              {showBudgetAdjusted ? (
+                <td style={cellBody}>
+                  {team.budgetAdjustedPoints != null
+                    ? team.budgetAdjustedPoints.toFixed(1)
+                    : '—'}
+                </td>
+              ) : null}
+              {showPointsPerMillion ? (
+                <td style={cellBody}>
+                  {team.pointsPerMillion != null
+                    ? team.pointsPerMillion.toFixed(2)
+                    : '—'}
+                </td>
+              ) : null}
+              <td style={cellBody}>{team.transfersNeeded}</td>
+              <td style={cellBody}>
+                {team.expectedPriceChange != null
+                  ? `${team.expectedPriceChange >= 0 ? '+' : ''}${team.expectedPriceChange.toFixed(2)}`
+                  : '—'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div
+        style={{
+          padding: '6px 14px',
+          borderTop: '1px solid #e2e6ee',
+          fontSize: 12,
+          color: '#666',
+        }}
+      >
+        ⭐ captain · ⭐⭐ mega captain · green = required by filter
+      </div>
+    </div>
+  );
+}
+
+const cellHeader: React.CSSProperties = {
+  padding: '8px 12px',
+  fontWeight: 600,
+  fontSize: 12,
+  textTransform: 'uppercase',
+  color: '#666',
+  letterSpacing: 0.4,
+};
+
+const cellBody: React.CSSProperties = {
+  padding: '10px 12px',
+  verticalAlign: 'top',
+};
+
+export function useBestTeamsAction() {
+  useCopilotAction({
+    name: 'get_best_teams',
+    description:
+      'Compute the top scoring fantasy team combinations for the user with optional driver/constructor filters.',
+    parameters: [],
+    available: 'frontend',
+    render: ({ status, result }) => {
+      if (status === 'inProgress' || status === 'executing') {
+        return (
+          <div style={{ padding: 10, color: '#666' }}>
+            Computing best teams…
+          </div>
+        );
+      }
+      const parsed = typeof result === 'string' ? safeParse(result) : result;
+      return <BestTeamsTable result={parsed as GetBestTeamsResult | undefined} />;
+    },
+  });
+}
+
+function safeParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}

--- a/web/src/components/UserTeamsList.tsx
+++ b/web/src/components/UserTeamsList.tsx
@@ -1,0 +1,144 @@
+import { useCopilotAction } from '@copilotkit/react-core';
+
+type UserTeam = {
+  teamId: string;
+  teamName: string;
+  isLeague: boolean;
+  isSelected: boolean;
+  chip: string | null;
+  drivers: string[];
+  constructors: string[];
+  boost: string | null;
+  freeTransfers: number | null;
+  costCapRemaining: number | null;
+};
+
+type ListUserTeamsResult = {
+  teams?: UserTeam[];
+};
+
+function chipBadge(chip: string | null) {
+  if (!chip) return null;
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        padding: '2px 8px',
+        borderRadius: 999,
+        fontSize: 11,
+        fontWeight: 600,
+        background: '#fff4d6',
+        color: '#7a4a00',
+        marginLeft: 6,
+      }}
+    >
+      {chip.replace('_', ' ').toLowerCase()}
+    </span>
+  );
+}
+
+function UserTeamsList({ result }: { result?: ListUserTeamsResult }) {
+  const teams = result?.teams ?? [];
+  if (teams.length === 0) {
+    return (
+      <div style={{ padding: 12, color: '#555' }}>
+        No tracked teams. Run <code>/follow_league</code> + <code>/teams_tracker</code> in the
+        Telegram bot first.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        margin: '8px 0',
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
+        gap: 8,
+      }}
+    >
+      {teams.map((team) => (
+        <div
+          key={team.teamId}
+          style={{
+            border: team.isSelected ? '2px solid #2c6fd1' : '1px solid #e2e6ee',
+            borderRadius: 8,
+            padding: '10px 12px',
+            background: '#fff',
+            fontSize: 13,
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
+            <strong style={{ fontSize: 15 }}>{team.teamName}</strong>
+            {team.isSelected ? (
+              <span
+                style={{
+                  marginLeft: 6,
+                  fontSize: 11,
+                  color: '#1c4f99',
+                  fontWeight: 600,
+                }}
+              >
+                ACTIVE
+              </span>
+            ) : null}
+            {chipBadge(team.chip)}
+          </div>
+          <div style={{ color: '#666', fontSize: 11, marginTop: 2 }}>
+            id: <code>{team.teamId}</code>
+            {team.isLeague ? ' · league' : ' · screenshot'}
+          </div>
+          <div style={{ marginTop: 6, color: '#444' }}>
+            <div>
+              <span style={{ color: '#888', fontSize: 11 }}>Drivers: </span>
+              {team.drivers.length > 0 ? team.drivers.join(', ') : '—'}
+            </div>
+            <div>
+              <span style={{ color: '#888', fontSize: 11 }}>Constructors: </span>
+              {team.constructors.length > 0 ? team.constructors.join(', ') : '—'}
+            </div>
+            <div>
+              <span style={{ color: '#888', fontSize: 11 }}>Boost: </span>
+              {team.boost ?? '—'}
+            </div>
+            <div style={{ color: '#666', fontSize: 12, marginTop: 4 }}>
+              {team.freeTransfers != null ? `${team.freeTransfers} free transfers` : ''}
+              {team.costCapRemaining != null
+                ? ` · ${team.costCapRemaining.toFixed?.(1) ?? team.costCapRemaining} cap left`
+                : ''}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function useUserTeamsAction() {
+  useCopilotAction({
+    name: 'list_user_teams',
+    description:
+      'List the teams the user is tracking. Returns teamId + teamName + roster summary.',
+    parameters: [],
+    available: 'frontend',
+    render: ({ status, result }) => {
+      if (status === 'inProgress' || status === 'executing') {
+        return (
+          <div style={{ padding: 10, color: '#666' }}>
+            Loading your teams…
+          </div>
+        );
+      }
+      const parsed = typeof result === 'string' ? safeParse(result) : result;
+      return <UserTeamsList result={parsed as ListUserTeamsResult | undefined} />;
+    },
+  });
+}
+
+function safeParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the web-chat agent: ships the headline _"Best teams for X with Verstappen but no Alonso"_ capability, plus a `list_user_teams` introspection tool. Both registered as rich generative-UI renders in the existing CopilotKit chat. Telegram surface unchanged.

Also includes the bot half of the cost-cap fix (the scraper half is in [`f1-fantasy-api-data#19`](https://github.com/F1-fantazy-bot/f1-fantasy-api-data/pull/19), which redefines `teams-data.json#budget` as the user's cost cap).

## Phase 2 — best-teams agent capability

**Tools**
- `list_user_teams` — array of the user's teams (`{teamId, teamName, isLeague, isSelected, chip, drivers, constructors, boost, freeTransfers, costCapRemaining}`).
- `get_best_teams` — top-K projected teams with optional `mustInclude{Drivers,Constructors}` / `mustExclude{Drivers,Constructors}` filters and a `rankBy` of `points | budget_adjusted | points_per_million`. Driver / constructor codes normalised through `NAME_TO_CODE_MAPPING` so the LLM can pass `VER` or `m. verstappen` interchangeably. Unresolved names surface as `status: 'unknown_filter'`.

**Cores (pure logic, shared with Telegram)**
- `src/cores/bestTeamsCore.js` → `computeBestTeams({...})` with status-tagged result: `no_teams | unknown_team | ambiguous_team | missing_cache | missing_remaining_race_count | unknown_filter | ok`.
- `src/cores/userTeamsCore.js` → `listUserTeams({chatId})`.
- `src/bestTeamsCalculator.js` accepts an optional 5th `options` arg (filters + rankBy + resultCount). When the options object is empty/absent the calculator is **byte-for-byte identical** to before — the Telegram bot's existing 11 `bestTeamsHandler` tests pass unchanged.

**Frontend**
- `<BestTeamsTable />` — top-10 table; captain ⭐, mega-captain ⭐⭐, must-include drivers highlighted green, penalty markers, conditional budget-adjusted / points-per-million columns.
- `<UserTeamsList />` — responsive card grid; ACTIVE badge, chip pill, league/screenshot tag.

**Backend agent setup**
- `src/agent/cacheBootstrap.js` — `ensureCacheReady()` lazily runs `initializeCaches(noopBot)` once per agent process; resets on failure for retry-on-next-call.
- `src/agent/runtime.js` — `providerOptions: { openai: { parallelToolCalls: false } }` on the `BuiltInAgent`. Without this, Azure OpenAI emits parallel tool calls in one assistant message; CopilotKit's `useLazyToolRenderer` only renders `toolCalls[0]` and the second tool's component silently never mounts.
- `src/agent/systemPrompt.js` extended with workflow rules.

**Telegram regression-free**
- `src/commandsHandler/bestTeamsHandler.js` is now a thin adapter over `computeBestTeams`. All 11 existing handler tests pass byte-for-byte. (One silent latent improvement: `validateJsonData` is now properly `await`ed —

**Tests:** 754/754. Lint clean (4 pre-existing baseline warnings).

## Cost-cap fix (cross-repo)

**Bug** (pre-existing; the new `<UserTeamsList />` UI made it visible): `mapLeagueTeamToBotTeam` computed `costCapRemaining = leagueTeam.budget − Σ_prices`. But `teams-data.json#budget` was `team_info.teamVal` — the team's current value, not the user's cost cap — so the subtraction structurally yielded 0 for every league team.

**Fix** — at the data source:
- [`f1-fantasy-api-data#19`](https://github.com/F1-fantazy-bot/f1-fantasy-api-data/pull/19) redefines `teams-data.json#budget` as the user's cost cap (`team_info.maxTeambal`). The old `teamVal` semantic was never used by any downstream consumer (only a log line in the scraper + this exact mapper).
- This PR updates `mapLeagueTeamToBotTeam` to treat `leagueTeam.budget` as the cap unconditionally — a single `Number(leagueTeam.budget)` read. No additive field, no fallback shim.

**Transition / backwards-compat:** stale blobs (written before #19 ships) carry `budget = teamVal`. The mapper subtracts `Σ_prices` from `budget` and gets `teamVal − Σ_prices ≈ 0` — exactly the value the bot reported in production today, so no regression at any point. The moment the next scrape repopulates a blob, that team's cap-remaining becomes correct.

**+11 new mapper unit tests** in `src/utils/leagueTeamHelpers.test.js` covering happy path, cap math, rounding, over-budget clamping, stale-blob graceful degradation, captain selection, transfer clamping, and optional metadata.

## Sequencing

1. Merge [`f1-fantasy-api-data#19`](https://github.com/F1-fantazy-bot/f1-fantasy-api-data/pull/19).
2. Manually trigger `deploy-aci.yml` (or wait for Monday 03:00 UTC).
3. Merge this PR. Agent UI shows correct cap values.

## Acceptance tests (PASSED via Playwright MCP)

- _"List my teams"_ → `<UserTeamsList />` shows 5 cards with cap-remaining: Kilzid **2.4** / Kilzid2 **1.4** / Kilzid 3 **0.0** / dorsegal1 **1.3** / Cooperon **0.9** — exact match with the F1 Fantasy site.
- _"Best teams for Kilzid 3 with Verstappen but no Alonso"_ → `<BestTeamsTable />` shows 10 teams, every row has VER, none has ALO, captain ⭐ on LEC.
- Phase 1 _"Next races in Italy?"_ still works.
- Telegram `/best_teams` → identical to pre-refactor (existing tests pass).
- `npm test` → 754/754 green.

🤖 Generated with [GitHub Copilot CLI](https://github.com/github/copilot-cli)

Co-Authored-By: Copilot <223556219+Copilot@users.noreply.github.com>