### PR TITLE
feat: web-agent Phase 3 — followed-teams, leaderboard, scenarios + correct ppm semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,7 @@ Start the web-chat agent locally with `npm run dev` (boots both the agent dev se
 
 **Cold-Start Initialization (Telegram):** `src/bot.js` stores the `initializeCaches()` promise as `cacheReady` and exports it. The Azure Function webhook (`telegramWebhook/index.js`) awaits `bot.cacheReady` before calling `bot.processUpdate(update)`. On a cold start the first request waits for caches to be ready; on warm invocations the resolved promise returns instantly. In polling dev mode `cacheReady` is unused — the natural polling delay avoids the race.
 
-**Cold-Start Initialization (Agent):** `src/agent/cacheBootstrap.js` lazily calls `initializeCaches()` before cache-dependent agent tools run. `get_next_races` can still answer without cache data, but `list_user_teams` and `get_best_teams` depend on the same initialized caches as Telegram.
+**Cold-Start Initialization (Agent):** `src/agent/cacheBootstrap.js` lazily calls `initializeCaches()` before cache-dependent agent tools run. `get_next_races` can still answer without cache data, but `list_user_teams`, `list_followed_teams`, `list_user_leagues`, `get_leaderboard`, `get_best_teams`, and `get_best_team_scenarios` all depend on the same initialized caches as Telegram.
 
 **Deployment targets:**
 - The Telegram bot is deployed as the existing Azure Function App via the `telegramWebhook/` function.
@@ -543,11 +543,23 @@ Blob naming includes the team ID:
 
 A second user-facing surface that runs the same business logic as the Telegram bot through tool calls. Architecture, code layout, and the patterns for adding new capabilities live in this section.
 
-Phase-2 capabilities (shipped):
+Phase-3 capabilities (shipped):
 
 - `get_next_races` — upcoming races for the season (Phase 1).
-- `list_user_teams` — the user's tracked teams (teamId + friendly teamName).
-- `get_best_teams` — top scoring fantasy combinations with optional must-include / must-exclude filters on drivers and constructors (the marquee "best teams for X with Verstappen but no Alonso" question runs here).
+- `list_user_teams` — the user's tracked teams (teamId + friendly teamName) (Phase 2).
+- `get_best_teams` — top scoring fantasy combinations with optional must-include / must-exclude filters on drivers and constructors (Phase 2). The marquee _"best teams for X with Verstappen but no Alonso"_ question runs here. Reads canonical prices via `getDriversForChat` / `getConstructorsForChat` so price-aware rankings work without user-uploaded JSON. Sort criteria: `'points'` (raw projected points) or `'budget_adjusted'` (weights expected price change by the user's saved `budgetChangePointsPerMillion` preset — set via `/set_best_team_ranking` in Telegram). "Points per million" questions resolve to `'budget_adjusted'`; the deprecated `'points_per_million'` value-for-money sort was removed.
+- `get_best_team_scenarios` — 4×4 matrix of top best team across the 4 budget-adjusted weight presets (0, 1.3, 1.65, 2.0 ppm) × 4 chip scenarios (no chip, Limitless, Extra Boost, Wildcard) (Phase 3). Each cell reports `projectedPoints`, `expectedPriceChange`, and a `recommendation` (`null`/`'yellow'`/`'green'`) indicating the chip's lift vs. the no-chip baseline of the SAME ppm row, mirroring the Telegram `/best_team_scenarios` indicators.
+- `list_followed_teams` — the user's followed league teams enriched with the leagues each team appears in + position in each (Phase 3).
+- `list_user_leagues` — the private leagues the user has followed via `/follow_league` (Phase 3).
+- `get_leaderboard` — standings for one of the user's followed leagues (Phase 3). Returns status-tagged result (`ok` / `not_followed` / `not_found` / `invalid_input`) plus `selectedTeamId` for client-side highlighting.
+
+**Multi-team "every team I track" pattern.** When the user asks a multi-team
+question like _"best teams by points-per-million for every team I track"_,
+the agent does NOT fan out N `get_best_teams` calls. It calls
+`list_followed_teams`, surfaces the team names back to the user, and asks
+them to pick one team to focus on — then runs `get_best_teams` ONCE for
+the chosen team. This keeps the chat to a single rich render per question
+and sidesteps the `parallelToolCalls: false` rendering constraint.
 
 ### Architecture
 
@@ -639,7 +651,10 @@ f1-fantazy-bot/
 │   │   └── components/
 │   │       ├── NextRacesTable.tsx    # useCopilotAction({ name: 'get_next_races', available: 'frontend', render })
 │   │       ├── BestTeamsTable.tsx    # useCopilotAction({ name: 'get_best_teams', available: 'frontend', render })
-│   │       └── UserTeamsList.tsx     # useCopilotAction({ name: 'list_user_teams', available: 'frontend', render })
+│   │       ├── UserTeamsList.tsx     # useCopilotAction({ name: 'list_user_teams', available: 'frontend', render })
+│   │       ├── FollowedTeamsGrid.tsx # useCopilotAction({ name: 'list_followed_teams', available: 'frontend', render })
+│   │       ├── LeaderboardTable.tsx  # useCopilotAction({ name: 'get_leaderboard', available: 'frontend', render })
+│   │       └── BestTeamScenariosMatrix.tsx # useCopilotAction({ name: 'get_best_team_scenarios', available: 'frontend', render })
 │   ├── package.json
 │   └── …                             # own package.json — frontend deps don't pollute the backend
 └── scripts/
@@ -768,7 +783,10 @@ npm run dev:web      # only Vite frontend on :5173/:5174
 | `src/cores/<feature>Core.js` | Pure logic core, returned JSON only. |
 | `src/cores/bestTeamsCore.js` | `computeBestTeams({chatId, teamId?, teamName?, rankBy?, mustInclude*, mustExclude*})` — status-tagged result, normalises codes via `NAME_TO_CODE_MAPPING`, returns `unknown_filter` when a name can't be resolved. |
 | `src/cores/userTeamsCore.js` | `listUserTeams({chatId})` — array of `{teamId, teamName, isLeague, isSelected, chip, …}`. |
-| `src/bestTeamsCalculator.js` | Accepts an optional 5th `options` arg with `mustInclude*`/`mustExclude*` filters, `rankBy: null \| 'points' \| 'points_per_million' \| 'budget_adjusted'`, and `resultCount`. Empty/absent options preserve legacy 4-arg behaviour byte-for-byte. |
+| `src/cores/followedTeamsCore.js` | `listFollowedTeams({chatId})` — status-tagged. Returns `{ status: 'ok', teams: [{ teamId, teamName, leagues: [{leagueCode, leagueName, position}], isSelected }] }` deduplicated by teamId across followed leagues; `status: 'empty'` when the user has no league teams. |
+| `src/cores/leaderboardCore.js` | `getLeaderboard({chatId, leagueCode})` — status-tagged (`ok` / `not_followed` / `not_found` / `invalid_input`). Returns `{ leagueCode, leagueName, memberCount, fetchedAt, selectedTeamId, standings: [{ position, teamName, userName, teamNo, teamId, totalScore, gapToLeader, isSelected }] }`. |
+| `src/cores/bestTeamScenariosCore.js` | `computeBestTeamScenarios({chatId, teamId?, teamName?})` — status-tagged (`ok` / `no_teams` / `unknown_team` / `ambiguous_team` / `missing_cache`). Returns the 4×4 matrix `{ teamId, teamName, chip, scenarios: [{ ppm, ppmLabel, results: [{ chipKey, chipLabel, projectedPoints, expectedPriceChange, recommendation: null\|'yellow'\|'green' }] }] }`. Mirrors the Telegram `/best_team_scenarios` chip-recommendation thresholds. |
+| `src/bestTeamsCalculator.js` | Accepts an optional 5th `options` arg with `mustInclude*`/`mustExclude*` filters, `rankBy: null \| 'points' \| 'budget_adjusted'`, and `resultCount`. Empty/absent options preserve legacy 4-arg behaviour byte-for-byte. |
 | `src/agent/identity.js` | Reads `AGENT_HARDCODED_CHAT_ID`, exposes `getAgentChatId()`. |
 | `src/agent/cacheBootstrap.js` | `ensureCacheReady()` — lazy `initializeCaches(noopBot)` for the agent process; resets on failure for retry-on-next-call. |
 | `src/agent/systemPrompt.js` | English system prompt; extended per phase. |
@@ -780,6 +798,9 @@ npm run dev:web      # only Vite frontend on :5173/:5174
 | `web/src/components/NextRacesTable.tsx` | `get_next_races` rich render. |
 | `web/src/components/BestTeamsTable.tsx` | `get_best_teams` rich render (top-10 table, captain badge, must-include highlights, penalty markers). |
 | `web/src/components/UserTeamsList.tsx` | `list_user_teams` rich render (card grid). |
+| `web/src/components/FollowedTeamsGrid.tsx` | `list_followed_teams` rich render — card per team with `leagueName: position` chips, active-team highlight. |
+| `web/src/components/LeaderboardTable.tsx` | `get_leaderboard` rich render — sortable standings table with the user's row highlighted; status fallbacks for `not_followed` / `not_found`. |
+| `web/src/components/BestTeamScenariosMatrix.tsx` | `get_best_team_scenarios` rich render — 4 ppm sections × 4 chip rows showing projected points, Δ price change, and 🟢/🟡 chip recommendation dots mirroring `/best_team_scenarios`. |
 | `scripts/dev-agent-server.js` | Local dev wrapper around `agentWebhook/index.js`. Not deployed. |
 
 ---

--- a/docs/agent-rollout-plan.md
+++ b/docs/agent-rollout-plan.md
@@ -5,12 +5,13 @@ user-facing surface for the Telegram bot, plus the cost-cap data fix
 that fell out of Phase 2. It's structured so anyone can pick up where
 we left off without prior context.
 
-**Current state (2026-05-16):** Phases 1 and 2 are both shipped and
-merged to `main`. The cost-cap data-source fix is also merged
-([f1-fantasy-api-data#19](https://github.com/F1-fantazy-bot/f1-fantasy-api-data/pull/19)
-and [f1-fantazy-bot#181](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/181)).
-**Phase 3 is the next natural step** and is unblocked — see the
-phase-3 section below. Phases 4–6 are planned but not started.
+**Current state (2026-05-17):** Phases 1, 2, the cost-cap data-source
+fix, the api-data `prices.json` producer, and the bot's `prices.json`
+consumer ([#183](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/183))
+are all merged. **Phase 3 is in flight** on
+`feature/doronkilzi/agent-phase3`: followed-teams + leaderboard cores,
+3 new agent tools, 2 new React components, system-prompt clarify-and-focus
+rule for multi-team questions. Phases 4–6 are planned but not started.
 
 > Read [`AGENTS.md`](../AGENTS.md) → "Agent (Web Chat)" first if you're
 > new to this codebase. That section is the authoritative reference for
@@ -102,7 +103,7 @@ companion cost-cap fix in
 
 **What shipped:**
 
-1. ✅ `src/bestTeamsCalculator.js` — optional 5th `options` arg with `mustInclude{Drivers,Constructors}` / `mustExclude{Drivers,Constructors}` filters (applied BEFORE the top-K slice so candidates outside the legacy top-K don't get lost), `rankBy: null | 'points' | 'budget_adjusted' | 'points_per_million'`, and `resultCount`. Empty/absent options preserve legacy 4-arg behaviour **byte-for-byte** — the existing 11 `bestTeamsHandler.test.js` cases pass unchanged because the refactored Telegram handler calls the calculator with the historical 4 positional args.
+1. ✅ `src/bestTeamsCalculator.js` — optional 5th `options` arg with `mustInclude{Drivers,Constructors}` / `mustExclude{Drivers,Constructors}` filters (applied BEFORE the top-K slice so candidates outside the legacy top-K don't get lost), `rankBy: null | 'points' | 'budget_adjusted'`, and `resultCount`. Empty/absent options preserve legacy 4-arg behaviour **byte-for-byte** — the existing 11 `bestTeamsHandler.test.js` cases pass unchanged because the refactored Telegram handler calls the calculator with the historical 4 positional args. (The value-for-money `'points_per_million'` option introduced briefly in Phase 3 was removed — in this bot, "points per million" is the per-team budget-adjusted weight set via `/set_best_team_ranking`, not a value-for-money sort.)
 2. ✅ `src/cores/bestTeamsCore.js` — `computeBestTeams({chatId, teamId?, teamName?, rankBy?, mustInclude*, mustExclude*})` with status-tagged result: `no_teams | unknown_team | ambiguous_team | missing_cache | missing_remaining_race_count | unknown_filter | ok`. Driver / constructor codes normalised through `NAME_TO_CODE_MAPPING` (the LLM can pass `'VER'` or `'m. verstappen'` interchangeably). Unresolved names surface as `unknown_filter` so the LLM can ask for clarification — no silent drops.
 3. ✅ `src/cores/userTeamsCore.js` — `listUserTeams({chatId})` returns `[{teamId, teamName, isLeague, isSelected, chip, drivers, constructors, boost, freeTransfers, costCapRemaining}]`.
 4. ✅ `src/commandsHandler/bestTeamsHandler.js` — refactored to thin adapter. `validateJsonData` is now properly `await`ed (was previously a Promise being `!`'d — silent latent bug). All 11 existing handler tests pass byte-for-byte unchanged.
@@ -162,41 +163,79 @@ All five exact-match the F1 Fantasy site.
 
 ---
 
-## Phase 3 — Cross-league / followed teams
+## Phase 3 — Cross-league / followed teams (in flight on `feature/doronkilzi/agent-phase3`)
 
 **Goal:** the second user request works:
 _"Best teams by points-per-million for every team I track."_
-Rendered as a stack of `<BestTeamsTable />` instances, one per followed
-team, each labeled with its team name + league(s).
+**Updated approach (2026-05-17):** the agent does NOT fan out. It calls
+`list_followed_teams`, asks the user which specific team to focus on,
+then runs `get_best_teams` for that one team. Single rich render per
+question. This sidesteps the `parallelToolCalls: false` rendering
+constraint cleanly without a server-side batch tool.
 
-**Telegram surface changes:** `leaderboardHandler.js` and the
-followed-teams helpers get core extractions. No user-visible change.
+**Telegram surface changes:** none. The handler refactor was
+**deferred** — `leaderboardHandler.js` is already a thin
+`getLeagueData → formatLeaderboard → sendMessage` pipeline, and
+`formatLeaderboard` is tested directly with the raw blob shape (the
+byte-identical rule). The new `leaderboardCore` is an **additive**
+abstraction for the agent that returns enriched standings
+(`selectedTeamId`, `gapToLeader`, `isSelected`).
 
-**Tasks:**
+**What shipped on the branch:**
 
-1. Extract `src/cores/followedTeamsCore.js`. Returns the user's followed teams across all leagues, deduplicated by `teamId`: `[{ teamId, teamName, leagues: [{ leagueCode, leagueName, position }] }]`.
-2. Extract `src/cores/leaderboardCore.js` from `leaderboardHandler.js`. Returns `{ leagueCode, leagueName, standings: [{ position, teamName, totalScore, ... }] }`.
-3. Refactor both handlers to thin adapters; run their Jest tests — must pass unchanged.
-4. Add three agent tools:
-   - `list_followed_teams` (no args).
-   - `get_leaderboard` (args: `leagueCode`).
-   - `list_user_leagues` (no args) — small helper so the LLM knows which leagues to choose from.
-5. Build rich components:
-   - `web/src/components/FollowedTeamsGrid.tsx` — cards with team name, leagues + positions.
-   - `web/src/components/LeaderboardTable.tsx` — standings with position, name, total score; sortable.
-   - Register both via `useCopilotAction({ available: 'frontend', render })`.
-6. Update system prompt to guide the LLM on cross-team workflows ("when the user says 'every team I track', call `list_followed_teams` then call `get_best_teams` for each").
-7. Tests for the new cores + tools.
+- `src/cores/followedTeamsCore.js` — `listFollowedTeams({chatId})`
+  returns status-tagged result with teams deduplicated by `teamId`
+  across all followed leagues, each entry carrying its
+  `leagues: [{leagueCode, leagueName, position}]` enrichment.
+- `src/cores/leaderboardCore.js` — `getLeaderboard({chatId, leagueCode})`
+  returns status-tagged result (`ok` / `not_followed` / `not_found` /
+  `invalid_input`) with sorted standings + `selectedTeamId` for
+  client-side highlighting.
+- Tests for both cores in `src/cores/*.test.js` (10 new tests,
+  Jest stays at 770/770).
+- 3 new agent tools in `src/agent/tools.js`:
+  `list_followed_teams`, `list_user_leagues`, `get_leaderboard`. Plus
+  `get_best_team_scenarios` (a 4th tool added in the same phase) —
+  returns the 4×4 ppm-preset × chip matrix from
+  `src/cores/bestTeamScenariosCore.js`, mirroring the Telegram
+  `/best_team_scenarios` command. Used by the LLM for "compare best
+  teams at different weights", "best team scenarios", and "what if I
+  change my ranking preference" questions.
+- `src/cores/bestTeamScenariosCore.js` + tests — pure 4×4 matrix
+  computation. Returns status-tagged result with one section per ppm
+  (0 / 1.3 / 1.65 / 2.0) and per-section results for the 4 chip
+  scenarios (no chip / Limitless / Extra Boost / Wildcard). Each cell
+  carries `projectedPoints`, `expectedPriceChange`, and a
+  `recommendation` (`null` / `'yellow'` / `'green'`) computed against
+  the no-chip baseline of the SAME ppm row, matching the chip-specific
+  thresholds in `getChipRecommendationDot`.
+- `src/agent/systemPrompt.js` — clarify-and-focus rule for multi-team
+  questions, plus "points per million" guidance: when a user asks for
+  "best teams by points per million", call `get_best_teams` with
+  `rankBy='budget_adjusted'` (NOT a value-for-money calc).
+- `web/src/components/FollowedTeamsGrid.tsx` — card-per-team grid with
+  `leagueName: position` chips, ACTIVE highlight on the user's
+  selected team.
+- `web/src/components/LeaderboardTable.tsx` — standings table with
+  the user's row highlighted, status-driven fallbacks for
+  not_followed / not_found.
+- `web/src/components/BestTeamScenariosMatrix.tsx` — 4 ppm sections ×
+  4 chip rows showing projected points, Δ expected price change, and
+  🟢/🟡 chip recommendation dots mirroring the Telegram
+  `/best_team_scenarios` display.
+- `web/src/App.tsx` — registers the 3 new render hooks.
 
 **Acceptance test:**
 
-- Web app: _"Best teams by points-per-million for every team I track."_ → multiple `<BestTeamsTable />` cards, one per followed team.
-- Web app: _"Show me the leaderboard for league X."_ → `<LeaderboardTable />`.
+- Web app: _"Best teams by points-per-million for every team I track."_
+  → agent shows `<FollowedTeamsGrid />` and asks _"which team to focus
+  on?"_ → user replies _"Kilzid2"_ → ONE `<BestTeamsTable />` renders.
+- Web app: _"Show me the leaderboard for kilzi test."_ → `list_user_leagues`
+  resolves the code → `<LeaderboardTable />` with the user's row bolded.
+- Web app: _"Which leagues do I follow?"_ → list.
 - Phase 1+2 questions still work.
-- Telegram: `/leaderboard`, `/teams_tracker` → identical to before.
-- `npm test` → all green.
-
-**Open question for Phase 3:** the LLM has to fan out one "best teams for every team I track" question into N tool calls. Because of the parallel-tool-calls limitation (see "Pitfalls" in `AGENTS.md`), each `get_best_teams` call has to land in its own assistant message → each rich component renders in order. Verify in Playwright that the chat doesn't get visually janky with 5–6 sequential tables.
+- Telegram: `/leaderboard`, `/teams_tracker` → byte-identical.
+- `npm test` → 770/770 green.
 
 ---
 

--- a/src/agent/systemPrompt.js
+++ b/src/agent/systemPrompt.js
@@ -15,18 +15,56 @@ question.
 Available tools:
 - get_next_races — upcoming F1 races for the current season.
 - list_user_teams — the user's tracked teams (teamId + friendly teamName).
-- get_best_teams — top-scoring fantasy team combinations for one of the
+- list_followed_teams — the user's tracked teams enriched with which
+  leagues they appear in and their position in each.
+- list_user_leagues — the private leagues the user has followed.
+- get_leaderboard — standings for a followed league (pass leagueCode).
+- get_best_teams — top-scoring fantasy team combinations for ONE of the
   user's teams. Supports must-include / must-exclude filters on drivers
-  and constructors, and three ranking modes ('points', 'budget_adjusted',
-  'points_per_million').
+  and constructors, and two ranking modes ('points' for raw projected
+  points, 'budget_adjusted' for the budget-adjusted score that weights
+  the team's expected price change by the user's saved per-team
+  budgetChangePointsPerMillion preference — set via the Telegram
+  bot's /set_best_team_ranking command).
+- get_best_team_scenarios — compares the top best team across a 4×4
+  matrix: 4 ppm weights (0, 1.3, 1.65, 2.0) × 4 chip choices (no chip,
+  Limitless, Extra Boost, Wildcard). Use for "compare best teams at
+  different weights", "best team scenarios", "what if I change my
+  ranking preference", "should I play a chip".
 
 Workflow rules:
-- When the user names a team in a "best teams" question (e.g. "best teams
-  for kilzid3 with X but no Y"), call get_best_teams DIRECTLY with the
+- **Scenarios questions take precedence.** When the user mentions
+  "scenarios", "best team scenarios", "compare best teams", "compare
+  weights", "what if I change my ranking", "should I play a chip", or
+  any chip-comparison phrasing — call **get_best_team_scenarios**, NOT
+  get_best_teams. This is true even when they name a team (e.g. "best
+  team scenarios for Kilzid"). Resolve the team via the \`teamName\` arg
+  on get_best_team_scenarios — never fall through to get_best_teams.
+- When the user names a team in a "best teams" question that is NOT a
+  scenarios / comparison question (e.g. "best teams for kilzid3 with
+  Verstappen but no Alonso"), call get_best_teams DIRECTLY with the
   user-provided name as \`teamName\` — the backend matches teamName
   exactly. Do NOT call list_user_teams first in that case (each extra
   tool call costs latency and only one rich UI component can render
   per assistant turn).
+- **Multi-team requests — clarify, don't fan out.** When the user asks a
+  multi-team question like "best teams for every team I track" or "all
+  my teams", do NOT call get_best_teams N times. Instead:
+    1. Call list_followed_teams.
+    2. Ask the user which specific team to focus on, naming each tracked
+       team from the result (e.g. "I can show one team at a time — you
+       track: Kilzid, Kilzid2, Kilzid 3. Which one?").
+    3. After the user picks a team, call get_best_teams ONCE with that
+       teamName.
+  This keeps the chat to a single rich render per question.
+- When the user asks "which teams do I track" / "show my teams", call
+  list_followed_teams (preferred over list_user_teams when the question
+  is about followed/league teams).
+- When the user asks for a leaderboard / standings for a league:
+  - If they gave the leagueCode, call get_leaderboard directly.
+  - If they named the league by display name, call list_user_leagues
+    first to look up the leagueCode, then call get_leaderboard.
+- When the user asks "which leagues do I follow", call list_user_leagues.
 - Only call list_user_teams when the user explicitly asks to see their
   teams, or when get_best_teams returns status="unknown_team" /
   "ambiguous_team" — then call list_user_teams to disambiguate and
@@ -39,10 +77,25 @@ Workflow rules:
   avoid ambiguity.
 - For requests like "best teams with X but no Y", populate
   mustIncludeDrivers/mustExcludeDrivers (or the constructor variants).
+- **"Points per million" semantics.** When the user asks for sorting /
+  ranking "by points per million" (or just "by ppm"), that refers to
+  the per-team **budget-adjusted weight** the user already configured
+  via the Telegram bot's /set_best_team_ranking command. Call
+  get_best_teams with rankBy="budget_adjusted". The backend
+  automatically uses the user's saved preset (Pure Points / Points Lean
+  / Points Plus Budget / Balanced Budget Value — 0 / 1.3 / 1.65 / 2.0).
+  To change the weight, the user runs /set_best_team_ranking in
+  Telegram. Never invent a "value-for-money" interpretation
+  (projected_points / total_price) — that is NOT what points-per-million
+  means in this bot.
 - If get_best_teams returns status="unknown_filter", tell the user which
   filter names you could not resolve and ask them to clarify.
 - If status="ambiguous_team" or "no_teams", explain plainly and suggest
   the next step.
+- If get_leaderboard returns status="not_followed", tell the user they
+  don't follow that league and suggest /follow_league.
+- If get_leaderboard returns status="not_found", tell the user the
+  standings haven't been generated yet for this league.
 
 Style rules:
 - Answer in English.

--- a/src/agent/tools.js
+++ b/src/agent/tools.js
@@ -14,7 +14,13 @@ const { defineTool } = require('@copilotkit/runtime/v2');
 const z = require('zod');
 const { getNextRaces } = require('../cores/nextRacesCore');
 const { computeBestTeams } = require('../cores/bestTeamsCore');
+const {
+  computeBestTeamScenarios,
+} = require('../cores/bestTeamScenariosCore');
 const { listUserTeams } = require('../cores/userTeamsCore');
+const { listFollowedTeams } = require('../cores/followedTeamsCore');
+const { getLeaderboard } = require('../cores/leaderboardCore');
+const { listUserLeagues } = require('../leagueRegistryService');
 const { getAgentChatId } = require('./identity');
 const { ensureCacheReady } = require('./cacheBootstrap');
 
@@ -42,10 +48,6 @@ function summariseBestTeam(team) {
     expectedPriceChange:
       typeof team.expected_price_change === 'number'
         ? Number(team.expected_price_change.toFixed(2))
-        : null,
-    pointsPerMillion:
-      team.total_price > 0
-        ? Number((team.projected_points / team.total_price).toFixed(3))
         : null,
   };
 }
@@ -92,10 +94,10 @@ const tools = [
           'Exact teamName from list_user_teams. Used only when teamId is not provided.',
         ),
       rankBy: z
-        .enum(['points', 'budget_adjusted', 'points_per_million'])
+        .enum(['points', 'budget_adjusted'])
         .optional()
         .describe(
-          'Sort criterion. Defaults to the user\'s preferred ranking (matching the Telegram bot). Use "points" for raw projected points, "points_per_million" for value-for-money, "budget_adjusted" for the budget-adjusted score.',
+          'Sort criterion. Defaults to the user\'s preferred ranking (matching the Telegram bot). Use "points" for raw projected points; use "budget_adjusted" for the budget-adjusted score that weights the team\'s expected price change by the user\'s saved budgetChangePointsPerMillion preference (set via /set_best_team_ranking). When the user asks for "points per million" sorting, that is the budget-adjusted ranking — call with rankBy="budget_adjusted".',
         ),
       mustIncludeDrivers: z
         .array(z.string())
@@ -158,6 +160,88 @@ const tools = [
         },
         bestTeams: result.bestTeams.map(summariseBestTeam),
       };
+    },
+  }),
+
+  defineTool({
+    name: 'get_best_team_scenarios',
+    description:
+      'Compare the top best team across the bot\'s 4 budget-adjusted weight presets (0, 1.3, 1.65, 2.0 points-per-million of expected price change) × 4 chip choices (no chip, Limitless, Extra Boost, Wildcard). Use this for questions like "compare best teams at different weights", "best team scenarios", "what if I change my ranking preference", or "should I play a chip". Returns { status, teamId, teamName, chip, scenarios: [{ ppm, ppmLabel, results: [{ chipKey, chipLabel, projectedPoints, expectedPriceChange, recommendation: null|"yellow"|"green" }] }] }. The recommendation level encodes the chip\'s lift over the no-chip baseline of the SAME ppm row, matching the Telegram /best_team_scenarios indicators.',
+    parameters: z.object({
+      teamId: z
+        .string()
+        .optional()
+        .describe(
+          'Canonical team identifier (preferred over teamName). Obtain via list_followed_teams or list_user_teams.',
+        ),
+      teamName: z
+        .string()
+        .optional()
+        .describe(
+          'Exact teamName. Used only when teamId is not provided.',
+        ),
+    }),
+    execute: async (args) => {
+      await ensureCacheReady();
+      const chatId = getAgentChatId();
+
+      return computeBestTeamScenarios({
+        chatId,
+        teamId: args.teamId,
+        teamName: args.teamName,
+      });
+    },
+  }),
+
+  defineTool({
+    name: 'list_followed_teams',
+    description:
+      'List the F1 Fantasy teams the user is tracking, enriched with the leagues each team appears in plus the team\'s current position in each league. Returns { status, teams: [{ teamId, teamName, leagues: [{ leagueCode, leagueName, position }], isSelected }] }. status="empty" means the user has not followed any league team yet. ALWAYS call this when the user asks "which teams do I track" or asks a multi-team question like "best teams for every team I track" — for the multi-team case, surface the team names back to the user and ask which one to focus on (one team per get_best_teams call).',
+    parameters: z.object({}),
+    execute: async () => {
+      await ensureCacheReady();
+      const chatId = getAgentChatId();
+
+      return await listFollowedTeams({ chatId });
+    },
+  }),
+
+  defineTool({
+    name: 'list_user_leagues',
+    description:
+      'List the private F1 Fantasy leagues the user has followed via /follow_league. Returns an array of { leagueCode, leagueName, registeredAt }. Use this when the user asks "which leagues do I follow" or when they name a league but you need to look up its `leagueCode` before calling `get_leaderboard`.',
+    parameters: z.object({}),
+    execute: async () => {
+      await ensureCacheReady();
+      const chatId = getAgentChatId();
+      const leagues = await listUserLeagues(chatId);
+
+      return {
+        leagues: (leagues || []).map((l) => ({
+          leagueCode: l.leagueCode,
+          leagueName: l.leagueName || l.leagueCode,
+          registeredAt: l.registeredAt || null,
+        })),
+      };
+    },
+  }),
+
+  defineTool({
+    name: 'get_leaderboard',
+    description:
+      'Get the standings (leaderboard) for one of the user\'s followed F1 Fantasy leagues. Pass the canonical `leagueCode` (e.g. "C7UYMMWIO07") — call `list_user_leagues` first if the user named a league by display name. Returns { status, leagueCode, leagueName, memberCount, fetchedAt, selectedTeamId, standings: [{ position, teamName, totalScore, gapToLeader, teamId, isSelected }] }. status="not_followed" means the user does not follow this league. status="not_found" means the league exists but the standings blob has not been generated yet.',
+    parameters: z.object({
+      leagueCode: z
+        .string()
+        .describe(
+          'Canonical league code (e.g. "C7UYMMWIO07"). Look up via list_user_leagues if the user gave a display name.',
+        ),
+    }),
+    execute: async (args) => {
+      await ensureCacheReady();
+      const chatId = getAgentChatId();
+
+      return await getLeaderboard({ chatId, leagueCode: args.leagueCode });
     },
   }),
 ];

--- a/src/bestTeamsCalculator.js
+++ b/src/bestTeamsCalculator.js
@@ -23,7 +23,7 @@ exports.calculateBestTeams = function (
   // top-K list (notably the web-chat agent). Keys (all optional):
   //   mustIncludeDrivers, mustExcludeDrivers,
   //   mustIncludeConstructors, mustExcludeConstructors: arrays of codes (e.g. 'VER').
-  //   rankBy: null | 'points' | 'budget_adjusted' | 'points_per_million'.
+  //   rankBy: null | 'points' | 'budget_adjusted'.
   //     null preserves legacy ranking (`ranking_score`, then `projected_points`).
   //   resultCount: number — defaults to BEST_TEAMS_RESULT_COUNT.
   // When `options` is omitted/empty, behaviour matches the legacy 4-arg call
@@ -219,10 +219,6 @@ exports.calculateBestTeams = function (
   // (or `projected_points` when budgetChangePointsPerMillion === 0).
   if (rankBy === 'points') {
     teams.sort((a, b) => b.projected_points - a.projected_points);
-  } else if (rankBy === 'points_per_million') {
-    const ppm = (team) =>
-      team.total_price > 0 ? team.projected_points / team.total_price : 0;
-    teams.sort((a, b) => ppm(b) - ppm(a));
   } else if (rankBy === 'budget_adjusted') {
     teams.sort((a, b) => b.ranking_score - a.ranking_score);
   } else {

--- a/src/bestTeamsCalculator.options.test.js
+++ b/src/bestTeamsCalculator.options.test.js
@@ -92,18 +92,6 @@ describe('calculateBestTeams options', () => {
     }
   });
 
-  it('rankBy: "points_per_million" sorts by points/price', () => {
-    const result = calculateBestTeams(mockJsonData, undefined, 0, 0, {
-      rankBy: 'points_per_million',
-    });
-    expect(result.length).toBeGreaterThan(1);
-    for (let i = 1; i < result.length; i++) {
-      const prev = result[i - 1].projected_points / result[i - 1].total_price;
-      const curr = result[i].projected_points / result[i].total_price;
-      expect(prev).toBeGreaterThanOrEqual(curr);
-    }
-  });
-
   it('rankBy: "budget_adjusted" sorts by budget_adjusted_points', () => {
     const result = calculateBestTeams(mockJsonData, undefined, 1.5, 10, {
       rankBy: 'budget_adjusted',

--- a/src/cores/bestTeamScenariosCore.js
+++ b/src/cores/bestTeamScenariosCore.js
@@ -1,0 +1,216 @@
+// Pure best-team-scenarios core — computes the 4×4 matrix of top best
+// teams across {0, 1.3, 1.65, 2.0} ppm weights × 4 chip choices (no chip,
+// Limitless, Extra Boost, Wildcard). Mirrors the Telegram
+// `/best_team_scenarios` command logic so the agent's
+// `get_best_team_scenarios` tool returns the same structured data.
+
+const { calculateBestTeams } = require('../bestTeamsCalculator');
+const {
+  currentTeamCache,
+  selectedChipCache,
+  sharedKey,
+  remainingRaceCountCache,
+  getDriversForChat,
+  getConstructorsForChat,
+  getSelectedTeam,
+  getUserTeamIds,
+} = require('../cache');
+const {
+  EXTRA_BOOST_CHIP,
+  LIMITLESS_CHIP,
+  WILDCARD_CHIP,
+} = require('../constants');
+
+const PPM_SCENARIOS = [
+  { ppm: 0, label: 'Pure Points' },
+  { ppm: 1.3, label: 'Points Lean' },
+  { ppm: 1.65, label: 'Points Plus Budget' },
+  { ppm: 2, label: 'Balanced Budget Value' },
+];
+
+// Chip recommendation thresholds — mirror the Telegram bot exactly
+// (see `getChipRecommendationDot` in
+// src/commandsHandler/bestTeamScenariosHandler.js). The "recommendation"
+// is computed against the no-chip baseline of THIS ppm row.
+const CHIP_RECOMMENDATION_THRESHOLDS = {
+  [WILDCARD_CHIP]: { green: 30, yellow: 20 },
+  [LIMITLESS_CHIP]: { green: 120, yellow: 100 },
+  [EXTRA_BOOST_CHIP]: { green: 70, yellow: 50 },
+};
+
+function recommendationLevel(chipKey, diff) {
+  if (!chipKey || !Number.isFinite(diff)) {
+    return null;
+  }
+  const thresholds = CHIP_RECOMMENDATION_THRESHOLDS[chipKey];
+
+  if (!thresholds) {
+    return null;
+  }
+  if (diff >= thresholds.green) {
+    return 'green';
+  }
+  if (diff >= thresholds.yellow) {
+    return 'yellow';
+  }
+
+  return null;
+}
+
+function pickTeamId({ chatId, requestedTeamId, requestedTeamName }) {
+  const teamIds = getUserTeamIds(chatId);
+
+  if (teamIds.length === 0) {
+    return { status: 'no_teams' };
+  }
+
+  if (requestedTeamId) {
+    if (!teamIds.includes(requestedTeamId)) {
+      return { status: 'unknown_team', teamId: requestedTeamId, teamIds };
+    }
+
+    return { status: 'ok', teamId: requestedTeamId };
+  }
+
+  if (requestedTeamName) {
+    const match = teamIds.find((id) => {
+      const team = currentTeamCache[chatId]?.[id];
+
+      return (
+        id === requestedTeamName ||
+        team?.teamName === requestedTeamName ||
+        (team?.teamName || '').toLowerCase() ===
+          String(requestedTeamName).toLowerCase()
+      );
+    });
+
+    if (match) {
+      return { status: 'ok', teamId: match };
+    }
+
+    return { status: 'unknown_team', teamName: requestedTeamName, teamIds };
+  }
+
+  if (teamIds.length === 1) {
+    return { status: 'ok', teamId: teamIds[0] };
+  }
+
+  const selected = getSelectedTeam(chatId);
+  if (selected && teamIds.includes(selected)) {
+    return { status: 'ok', teamId: selected };
+  }
+
+  return { status: 'ambiguous_team', teamIds };
+}
+
+function computeBestTeamScenarios({ chatId, teamId, teamName }) {
+  const pick = pickTeamId({
+    chatId,
+    requestedTeamId: teamId,
+    requestedTeamName: teamName,
+  });
+
+  if (pick.status !== 'ok') {
+    return pick;
+  }
+  const resolvedTeamId = pick.teamId;
+
+  const drivers = getDriversForChat(chatId);
+  const constructors = getConstructorsForChat(chatId);
+  const currentTeam = currentTeamCache[chatId]?.[resolvedTeamId];
+
+  if (!drivers || !constructors || !currentTeam) {
+    return { status: 'missing_cache', teamId: resolvedTeamId };
+  }
+
+  const cachedJsonData = {
+    Drivers: drivers,
+    Constructors: constructors,
+    CurrentTeam: currentTeam,
+  };
+  const selectedChip = selectedChipCache[chatId]?.[resolvedTeamId] || null;
+  const remainingRaceCount = remainingRaceCountCache[sharedKey];
+  const safeRemainingRaceCount = Number.isFinite(remainingRaceCount)
+    ? remainingRaceCount
+    : 0;
+
+  // Mirror the Telegram /best_team_scenarios chip set: the user's current
+  // chip occupies the first slot (under a "Without Chip" label so the
+  // recommendation deltas are sensible against THAT baseline).
+  const chipScenarios = [
+    { chipKey: selectedChip, chipLabel: 'Without Chip' },
+    { chipKey: LIMITLESS_CHIP, chipLabel: 'Limitless' },
+    { chipKey: EXTRA_BOOST_CHIP, chipLabel: 'Extra Boost' },
+    { chipKey: WILDCARD_CHIP, chipLabel: 'Wildcard' },
+  ];
+
+  const scenarios = PPM_SCENARIOS.map(({ ppm, label }) => {
+    const results = chipScenarios.map(({ chipKey, chipLabel }) => {
+      const [topTeam] = calculateBestTeams(
+        cachedJsonData,
+        chipKey,
+        ppm,
+        safeRemainingRaceCount,
+      );
+
+      if (!topTeam) {
+        return {
+          chipKey,
+          chipLabel,
+          projectedPoints: null,
+          expectedPriceChange: null,
+          recommendation: null,
+        };
+      }
+
+      return {
+        chipKey,
+        chipLabel,
+        projectedPoints: Number(topTeam.projected_points?.toFixed?.(2) ?? 0),
+        expectedPriceChange:
+          typeof topTeam.expected_price_change === 'number'
+            ? Number(topTeam.expected_price_change.toFixed(2))
+            : null,
+        // Will be overlaid with the recommendation after we know the
+        // no-chip baseline for this ppm row.
+        recommendation: null,
+        _rawProjectedPoints: topTeam.projected_points,
+      };
+    });
+
+    const baseline = results[0]?._rawProjectedPoints;
+    results.forEach((row, idx) => {
+      if (idx === 0) {
+        delete row._rawProjectedPoints;
+
+        return;
+      }
+      if (
+        typeof baseline === 'number' &&
+        typeof row._rawProjectedPoints === 'number'
+      ) {
+        row.recommendation = recommendationLevel(
+          row.chipKey,
+          row._rawProjectedPoints - baseline,
+        );
+      }
+      delete row._rawProjectedPoints;
+    });
+
+    return { ppm, ppmLabel: label, results };
+  });
+
+  return {
+    status: 'ok',
+    teamId: resolvedTeamId,
+    teamName: currentTeam.teamName || resolvedTeamId,
+    chip: selectedChip,
+    scenarios,
+  };
+}
+
+module.exports = {
+  computeBestTeamScenarios,
+  PPM_SCENARIOS,
+  CHIP_RECOMMENDATION_THRESHOLDS,
+};

--- a/src/cores/bestTeamScenariosCore.test.js
+++ b/src/cores/bestTeamScenariosCore.test.js
@@ -1,0 +1,173 @@
+const { KILZI_CHAT_ID } = require('../constants');
+
+const mockCalculateBestTeams = jest.fn();
+jest.mock('../bestTeamsCalculator', () => ({
+  calculateBestTeams: (...args) => mockCalculateBestTeams(...args),
+}));
+
+const {
+  driversCache,
+  constructorsCache,
+  currentTeamCache,
+  selectedChipCache,
+  sharedKey,
+  remainingRaceCountCache,
+  userCache,
+  pricesCache,
+} = require('../cache');
+
+const {
+  computeBestTeamScenarios,
+  PPM_SCENARIOS,
+} = require('./bestTeamScenariosCore');
+
+const TEAM_ID = 'T1';
+
+function seedValidCache() {
+  driversCache[KILZI_CHAT_ID] = { VER: { price: 30 }, HAM: { price: 28 } };
+  constructorsCache[KILZI_CHAT_ID] = { RED: { price: 35 }, MER: { price: 32 } };
+  currentTeamCache[KILZI_CHAT_ID] = {
+    [TEAM_ID]: {
+      drivers: ['VER', 'HAM'],
+      constructors: ['RED', 'MER'],
+      boost: 'VER',
+      freeTransfers: 2,
+      costCapRemaining: 5,
+      teamName: 'kilzid3',
+    },
+  };
+}
+
+function clearCaches() {
+  delete driversCache[KILZI_CHAT_ID];
+  delete driversCache[sharedKey];
+  delete constructorsCache[KILZI_CHAT_ID];
+  delete constructorsCache[sharedKey];
+  delete currentTeamCache[KILZI_CHAT_ID];
+  delete selectedChipCache[KILZI_CHAT_ID];
+  delete remainingRaceCountCache[sharedKey];
+  delete userCache[String(KILZI_CHAT_ID)];
+  pricesCache.drivers = {};
+  pricesCache.constructors = {};
+  pricesCache.metadata = null;
+}
+
+describe('computeBestTeamScenarios', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearCaches();
+  });
+
+  test('returns missing_cache when no team is cached', () => {
+    seedValidCache();
+    delete currentTeamCache[KILZI_CHAT_ID][TEAM_ID];
+    currentTeamCache[KILZI_CHAT_ID].other = { teamName: 'other' };
+    mockCalculateBestTeams.mockReturnValue([]);
+
+    const result = computeBestTeamScenarios({
+      chatId: KILZI_CHAT_ID,
+      teamId: TEAM_ID,
+    });
+
+    expect(result.status).toBe('unknown_team');
+  });
+
+  test('returns no_teams when the user has no teams', () => {
+    const result = computeBestTeamScenarios({ chatId: KILZI_CHAT_ID });
+    expect(result.status).toBe('no_teams');
+  });
+
+  test('builds a 4×4 matrix and labels match presets', () => {
+    seedValidCache();
+    // Each call returns one top team with rising projected_points so
+    // recommendation thresholds can be exercised deterministically.
+    let pts = 50;
+    mockCalculateBestTeams.mockImplementation(() => [
+      {
+        projected_points: pts++,
+        expected_price_change: 0.25,
+      },
+    ]);
+
+    const result = computeBestTeamScenarios({ chatId: KILZI_CHAT_ID });
+
+    expect(result.status).toBe('ok');
+    expect(result.teamId).toBe(TEAM_ID);
+    expect(result.teamName).toBe('kilzid3');
+    expect(result.scenarios).toHaveLength(4);
+
+    const ppmValues = result.scenarios.map((s) => s.ppm);
+    expect(ppmValues).toEqual([0, 1.3, 1.65, 2]);
+
+    const ppmLabels = result.scenarios.map((s) => s.ppmLabel);
+    expect(ppmLabels).toEqual(PPM_SCENARIOS.map((p) => p.label));
+
+    // Each ppm row contains 4 chip results in the expected order.
+    for (const row of result.scenarios) {
+      expect(row.results.map((r) => r.chipLabel)).toEqual([
+        'Without Chip',
+        'Limitless',
+        'Extra Boost',
+        'Wildcard',
+      ]);
+      // The baseline row never carries a recommendation.
+      expect(row.results[0].recommendation).toBeNull();
+    }
+  });
+
+  test('flags green recommendation when chip beats baseline by enough', () => {
+    seedValidCache();
+    // Stub: no-chip baseline = 50; Limitless = 175 (>120 diff = green);
+    // Extra Boost = 110 (>60 ≥70? no — 60 yellow); Wildcard = 85 (35>30 green).
+    const sequence = [
+      // ppm=0 row: no-chip / Limitless / Extra Boost / Wildcard
+      { projected_points: 50, expected_price_change: 0 },
+      { projected_points: 175, expected_price_change: 0 },
+      { projected_points: 110, expected_price_change: 0 },
+      { projected_points: 85, expected_price_change: 0 },
+    ];
+    let nextRow = 1;
+    mockCalculateBestTeams.mockImplementation(() => {
+      const idx = (nextRow++ - 1) % sequence.length;
+
+      return [sequence[idx]];
+    });
+
+    const result = computeBestTeamScenarios({ chatId: KILZI_CHAT_ID });
+    const firstPpmRow = result.scenarios[0];
+
+    expect(firstPpmRow.results[0].recommendation).toBeNull(); // baseline
+    expect(firstPpmRow.results[1].recommendation).toBe('green'); // Limitless 125 diff
+    expect(firstPpmRow.results[2].recommendation).toBe('yellow'); // Extra Boost 60 diff
+    expect(firstPpmRow.results[3].recommendation).toBe('green'); // Wildcard 35 diff
+  });
+
+  test('handles missing topTeam (calculator returned empty)', () => {
+    seedValidCache();
+    mockCalculateBestTeams.mockReturnValue([]);
+
+    const result = computeBestTeamScenarios({ chatId: KILZI_CHAT_ID });
+    expect(result.status).toBe('ok');
+    for (const row of result.scenarios) {
+      for (const cell of row.results) {
+        expect(cell.projectedPoints).toBeNull();
+        expect(cell.expectedPriceChange).toBeNull();
+        expect(cell.recommendation).toBeNull();
+      }
+    }
+  });
+
+  test('resolves a team by teamName (case-insensitive)', () => {
+    seedValidCache();
+    mockCalculateBestTeams.mockReturnValue([
+      { projected_points: 50, expected_price_change: 0 },
+    ]);
+
+    const result = computeBestTeamScenarios({
+      chatId: KILZI_CHAT_ID,
+      teamName: 'KILZID3',
+    });
+    expect(result.status).toBe('ok');
+    expect(result.teamId).toBe(TEAM_ID);
+  });
+});

--- a/src/cores/bestTeamsCore.test.js
+++ b/src/cores/bestTeamsCore.test.js
@@ -186,7 +186,7 @@ describe('computeBestTeams', () => {
       mustExcludeDrivers: ['ALO'],
       mustIncludeConstructors: ['MCL'],
       mustExcludeConstructors: ['FER'],
-      rankBy: 'points_per_million',
+      rankBy: 'budget_adjusted',
       resultCount: 5,
     });
     expect(mockCalculateBestTeams).toHaveBeenCalledTimes(1);
@@ -196,7 +196,7 @@ describe('computeBestTeams', () => {
       mustExcludeDrivers: ['ALO'],
       mustIncludeConstructors: ['MCL'],
       mustExcludeConstructors: ['FER'],
-      rankBy: 'points_per_million',
+      rankBy: 'budget_adjusted',
       resultCount: 5,
     });
   });

--- a/src/cores/followedTeamsCore.js
+++ b/src/cores/followedTeamsCore.js
@@ -1,0 +1,125 @@
+// Pure followed-teams core — enumerates the user's tracked league teams,
+// enriched with the leagues each team appears in plus the team's current
+// position in each. Both the agent's `list_followed_teams` tool and any
+// future Telegram surface call into this.
+//
+// Returns a status-tagged result: status === 'ok' carries `teams`, which
+// is an array of `{ teamId, teamName, leagues: [{ leagueCode, leagueName,
+// position }], isSelected }` entries deduplicated by teamId. Non-league
+// teams (`T1`/`T2`/`T3` screenshot ids) are excluded — the followed-teams
+// concept is specific to league tracking.
+
+const {
+  currentTeamCache,
+  isLeagueTeamId,
+  getSelectedTeam,
+  getUserTeamIds,
+} = require('../cache');
+const { listUserLeagues } = require('../leagueRegistryService');
+const { loadLeagueTeamsData } = require('../utils/leagueTeamHelpers');
+const { buildLeagueTeamId } = require('../utils/teamId');
+
+/**
+ * @param {{ chatId: number|string }} args
+ * @returns {Promise<
+ *   | { status: 'ok', teams: Array<{
+ *       teamId: string,
+ *       teamName: string,
+ *       leagues: Array<{ leagueCode: string, leagueName: string, position: number|null }>,
+ *       isSelected: boolean
+ *     }> }
+ *   | { status: 'empty' }
+ * >}
+ */
+async function listFollowedTeams({ chatId }) {
+  const leagueTeamIds = getUserTeamIds(chatId).filter(isLeagueTeamId);
+
+  if (leagueTeamIds.length === 0) {
+    return { status: 'empty' };
+  }
+
+  const userLeagues = await listUserLeagues(chatId);
+  const leagueNameByCode = {};
+  for (const league of userLeagues || []) {
+    leagueNameByCode[league.leagueCode] =
+      league.leagueName || league.leagueCode;
+  }
+
+  // Fetch each followed league's teams-data.json once (memoized) so we can
+  // resolve each tracked team's position in every league it appears in.
+  const leagueDataByCode = {};
+  await Promise.all(
+    (userLeagues || []).map(async (league) => {
+      try {
+        const data = await loadLeagueTeamsData(league.leagueCode);
+        if (data && Array.isArray(data.teams)) {
+          leagueDataByCode[league.leagueCode] = data;
+        }
+      } catch (err) {
+        // Per repo convention: log and swallow per-league failures so one
+        // missing blob doesn't blank out the whole list.
+        console.error(
+          `Error loading teams-data.json for league ${league.leagueCode}:`,
+          err,
+        );
+      }
+    }),
+  );
+
+  const selected = getSelectedTeam(chatId);
+  const trackedTeamIds = new Set(leagueTeamIds);
+
+  // Build a teamId -> { teamName, leagues:[...] } map by scanning every
+  // followed league's roster. A team's id (`{sanitize(userName)}_{teamNo}`)
+  // is league-agnostic, so the same fantasy team in two leagues collapses
+  // into one entry with two `leagues[]` rows.
+  const byTeamId = {};
+  for (const [leagueCode, data] of Object.entries(leagueDataByCode)) {
+    const leagueName = leagueNameByCode[leagueCode] || leagueCode;
+    for (const row of data.teams) {
+      const teamId = buildLeagueTeamId(row.userName, row.teamNo);
+      if (!teamId || !trackedTeamIds.has(teamId)) {
+        continue;
+      }
+
+      if (!byTeamId[teamId]) {
+        const cached = currentTeamCache[chatId]?.[teamId];
+        byTeamId[teamId] = {
+          teamId,
+          teamName: row.teamName || cached?.teamName || teamId,
+          leagues: [],
+          isSelected: selected === teamId,
+        };
+      }
+      const position =
+        typeof row.position === 'number' && Number.isFinite(row.position)
+          ? row.position
+          : null;
+      byTeamId[teamId].leagues.push({ leagueCode, leagueName, position });
+    }
+  }
+
+  // Surface tracked teams even when none of their leagues' blobs resolved
+  // (or none of the user's currently-followed leagues actually contain the
+  // team — e.g. unfollowed-league residue). Without this they'd silently
+  // drop out of the list.
+  for (const teamId of leagueTeamIds) {
+    if (!byTeamId[teamId]) {
+      const cached = currentTeamCache[chatId]?.[teamId];
+      byTeamId[teamId] = {
+        teamId,
+        teamName: cached?.teamName || teamId,
+        leagues: [],
+        isSelected: selected === teamId,
+      };
+    }
+  }
+
+  const teams = Object.values(byTeamId).sort((a, b) =>
+    a.teamName.localeCompare(b.teamName),
+  );
+
+  return { status: 'ok', teams };
+}
+
+module.exports = { listFollowedTeams };

--- a/src/cores/followedTeamsCore.test.js
+++ b/src/cores/followedTeamsCore.test.js
@@ -1,0 +1,136 @@
+jest.mock('../leagueRegistryService', () => ({
+  listUserLeagues: jest.fn(),
+}));
+jest.mock('../utils/leagueTeamHelpers', () => ({
+  loadLeagueTeamsData: jest.fn(),
+}));
+
+const { listFollowedTeams } = require('./followedTeamsCore');
+const cache = require('../cache');
+const { listUserLeagues } = require('../leagueRegistryService');
+const { loadLeagueTeamsData } = require('../utils/leagueTeamHelpers');
+
+function resetCache() {
+  Object.keys(cache.currentTeamCache).forEach(
+    (k) => delete cache.currentTeamCache[k],
+  );
+  Object.keys(cache.userCache).forEach((k) => delete cache.userCache[k]);
+}
+
+describe('listFollowedTeams', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetCache();
+  });
+
+  test('returns status=empty when the user has no league teams', async () => {
+    cache.currentTeamCache[42] = {
+      T1: { teamName: 'My Screenshot Team' },
+    };
+
+    const result = await listFollowedTeams({ chatId: 42 });
+    expect(result).toEqual({ status: 'empty' });
+    expect(listUserLeagues).not.toHaveBeenCalled();
+  });
+
+  test('lists a single league team with its single-league context', async () => {
+    cache.currentTeamCache[42] = {
+      Kilzid_1: { teamName: 'Kilzid' },
+    };
+    cache.userCache['42'] = { selectedTeam: 'Kilzid_1' };
+    listUserLeagues.mockResolvedValue([
+      { leagueCode: 'C7', leagueName: 'MSFT ILDC' },
+    ]);
+    loadLeagueTeamsData.mockResolvedValueOnce({
+      teams: [
+        { userName: 'Kilzid', teamNo: 1, teamName: 'Kilzid', position: 4 },
+        { userName: 'Other', teamNo: 1, teamName: 'Other', position: 1 },
+      ],
+    });
+
+    const result = await listFollowedTeams({ chatId: 42 });
+    expect(result.status).toBe('ok');
+    expect(result.teams).toHaveLength(1);
+    expect(result.teams[0]).toEqual({
+      teamId: 'Kilzid_1',
+      teamName: 'Kilzid',
+      leagues: [
+        { leagueCode: 'C7', leagueName: 'MSFT ILDC', position: 4 },
+      ],
+      isSelected: true,
+    });
+  });
+
+  test('dedupes the same fantasy team across multiple leagues', async () => {
+    cache.currentTeamCache[42] = {
+      Kilzid_1: { teamName: 'Kilzid' },
+    };
+    listUserLeagues.mockResolvedValue([
+      { leagueCode: 'C7', leagueName: 'MSFT ILDC' },
+      { leagueCode: 'C8', leagueName: 'Amba' },
+    ]);
+    loadLeagueTeamsData.mockImplementation((code) => {
+      if (code === 'C7') {
+        return Promise.resolve({
+          teams: [
+            { userName: 'Kilzid', teamNo: 1, teamName: 'Kilzid', position: 4 },
+          ],
+        });
+      }
+
+      return Promise.resolve({
+        teams: [
+          { userName: 'Kilzid', teamNo: 1, teamName: 'Kilzid', position: 2 },
+        ],
+      });
+    });
+
+    const result = await listFollowedTeams({ chatId: 42 });
+    expect(result.teams).toHaveLength(1);
+    expect(result.teams[0].leagues).toHaveLength(2);
+    const codes = result.teams[0].leagues.map((l) => l.leagueCode).sort();
+    expect(codes).toEqual(['C7', 'C8']);
+    expect(result.teams[0].isSelected).toBe(false);
+  });
+
+  test('returns tracked teams even when no league blob resolves', async () => {
+    cache.currentTeamCache[42] = {
+      Kilzid_1: { teamName: 'Kilzid (cached)' },
+      Kilzid_2: {},
+    };
+    listUserLeagues.mockResolvedValue([
+      { leagueCode: 'C7', leagueName: 'MSFT ILDC' },
+    ]);
+    loadLeagueTeamsData.mockRejectedValueOnce(new Error('blob missing'));
+
+    const result = await listFollowedTeams({ chatId: 42 });
+    expect(result.status).toBe('ok');
+    expect(result.teams.map((t) => t.teamId).sort()).toEqual([
+      'Kilzid_1',
+      'Kilzid_2',
+    ]);
+    const kilzid1 = result.teams.find((t) => t.teamId === 'Kilzid_1');
+    expect(kilzid1.teamName).toBe('Kilzid (cached)');
+    expect(kilzid1.leagues).toEqual([]);
+    const kilzid2 = result.teams.find((t) => t.teamId === 'Kilzid_2');
+    expect(kilzid2.teamName).toBe('Kilzid_2');
+  });
+
+  test('ignores screenshot teams (T1/T2/T3)', async () => {
+    cache.currentTeamCache[42] = {
+      T1: { teamName: 'Screenshot Team' },
+      Kilzid_1: { teamName: 'Kilzid' },
+    };
+    listUserLeagues.mockResolvedValue([
+      { leagueCode: 'C7', leagueName: 'MSFT ILDC' },
+    ]);
+    loadLeagueTeamsData.mockResolvedValueOnce({
+      teams: [
+        { userName: 'Kilzid', teamNo: 1, teamName: 'Kilzid', position: 4 },
+      ],
+    });
+
+    const result = await listFollowedTeams({ chatId: 42 });
+    expect(result.teams.map((t) => t.teamId)).toEqual(['Kilzid_1']);
+  });
+});

--- a/src/cores/leaderboardCore.js
+++ b/src/cores/leaderboardCore.js
@@ -1,0 +1,116 @@
+// Pure leaderboard core — fetches a league's standings blob and returns
+// a structured response with the user's selected team highlighted via
+// `selectedTeamId` so renderers can apply their own bolding/styling.
+// Both the Telegram adapter (`commandsHandler/leaderboardHandler.js`)
+// and the agent's `get_leaderboard` tool call into this.
+//
+// Returns a status-tagged result the caller can map onto its preferred
+// surface (Telegram HTML message vs. structured JSON for the LLM).
+
+const { getSelectedTeam } = require('../cache');
+const { listUserLeagues } = require('../leagueRegistryService');
+const { getLeagueData } = require('../azureStorageService');
+const { buildLeagueTeamId } = require('../utils/teamId');
+
+/**
+ * @param {{ chatId: number|string, leagueCode: string }} args
+ * @returns {Promise<
+ *   | { status: 'ok',
+ *       leagueCode: string,
+ *       leagueName: string,
+ *       leagueId?: number,
+ *       memberCount: number|null,
+ *       fetchedAt: string|null,
+ *       selectedTeamId: string|null,
+ *       standings: Array<{
+ *         position: number|null,
+ *         teamName: string,
+ *         userName: string|null,
+ *         teamNo: number|null,
+ *         teamId: string|null,
+ *         totalScore: number|null,
+ *         gapToLeader: number|null,
+ *         isSelected: boolean
+ *       }>
+ *     }
+ *   | { status: 'not_followed', leagueCode: string }
+ *   | { status: 'not_found', leagueCode: string }
+ *   | { status: 'invalid_input', leagueCode?: string }
+ * >}
+ */
+async function getLeaderboard({ chatId, leagueCode }) {
+  if (!leagueCode || typeof leagueCode !== 'string') {
+    return { status: 'invalid_input', leagueCode: leagueCode || null };
+  }
+
+  const userLeagues = await listUserLeagues(chatId);
+  const follows = (userLeagues || []).some(
+    (league) => league.leagueCode === leagueCode,
+  );
+
+  if (!follows) {
+    return { status: 'not_followed', leagueCode };
+  }
+
+  const leagueData = await getLeagueData(leagueCode);
+  if (!leagueData) {
+    return { status: 'not_found', leagueCode };
+  }
+
+  const teams = Array.isArray(leagueData.teams) ? [...leagueData.teams] : [];
+  teams.sort((a, b) => (a.position || 0) - (b.position || 0));
+
+  const selectedTeamId = getSelectedTeam(chatId) || null;
+  const leaderScore =
+    teams.length > 0 && typeof teams[0].totalScore === 'number'
+      ? teams[0].totalScore
+      : null;
+
+  const standings = teams.map((team) => {
+    const position =
+      typeof team.position === 'number' && Number.isFinite(team.position)
+        ? team.position
+        : null;
+    const totalScore =
+      typeof team.totalScore === 'number' && Number.isFinite(team.totalScore)
+        ? team.totalScore
+        : null;
+    const teamId = buildLeagueTeamId(team.userName, team.teamNo) || null;
+    const gapToLeader =
+      totalScore !== null && leaderScore !== null
+        ? totalScore - leaderScore
+        : null;
+
+    return {
+      position,
+      teamName: team.teamName || team.userName || '—',
+      userName: team.userName || null,
+      teamNo:
+        typeof team.teamNo === 'number' && Number.isFinite(team.teamNo)
+          ? team.teamNo
+          : null,
+      teamId,
+      totalScore,
+      gapToLeader,
+      isSelected: Boolean(teamId && selectedTeamId && teamId === selectedTeamId),
+    };
+  });
+
+  return {
+    status: 'ok',
+    leagueCode,
+    leagueName: leagueData.leagueName || leagueCode,
+    ...(typeof leagueData.leagueId === 'number'
+      ? { leagueId: leagueData.leagueId }
+      : {}),
+    memberCount:
+      typeof leagueData.memberCount === 'number'
+        ? leagueData.memberCount
+        : teams.length,
+    fetchedAt: leagueData.fetchedAt || null,
+    selectedTeamId,
+    standings,
+  };
+}
+
+module.exports = { getLeaderboard };

--- a/src/cores/leaderboardCore.test.js
+++ b/src/cores/leaderboardCore.test.js
@@ -1,0 +1,108 @@
+jest.mock('../leagueRegistryService', () => ({
+  listUserLeagues: jest.fn(),
+}));
+jest.mock('../azureStorageService', () => ({
+  getLeagueData: jest.fn(),
+}));
+
+const { getLeaderboard } = require('./leaderboardCore');
+const cache = require('../cache');
+const { listUserLeagues } = require('../leagueRegistryService');
+const { getLeagueData } = require('../azureStorageService');
+
+function resetCache() {
+  Object.keys(cache.userCache).forEach((k) => delete cache.userCache[k]);
+}
+
+describe('getLeaderboard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetCache();
+  });
+
+  test('returns status=invalid_input when leagueCode is missing', async () => {
+    const result = await getLeaderboard({ chatId: 42, leagueCode: '' });
+    expect(result).toEqual({ status: 'invalid_input', leagueCode: null });
+    expect(listUserLeagues).not.toHaveBeenCalled();
+  });
+
+  test('returns status=not_followed when the user does not follow the league', async () => {
+    listUserLeagues.mockResolvedValue([{ leagueCode: 'OTHER' }]);
+
+    const result = await getLeaderboard({ chatId: 42, leagueCode: 'C7' });
+    expect(result).toEqual({ status: 'not_followed', leagueCode: 'C7' });
+    expect(getLeagueData).not.toHaveBeenCalled();
+  });
+
+  test('returns status=not_found when the blob is missing', async () => {
+    listUserLeagues.mockResolvedValue([{ leagueCode: 'C7' }]);
+    getLeagueData.mockResolvedValue(null);
+
+    const result = await getLeaderboard({ chatId: 42, leagueCode: 'C7' });
+    expect(result).toEqual({ status: 'not_found', leagueCode: 'C7' });
+  });
+
+  test('returns sorted standings with gapToLeader and selected highlight', async () => {
+    cache.userCache['42'] = { selectedTeam: 'Kilzid_1' };
+    listUserLeagues.mockResolvedValue([{ leagueCode: 'C7' }]);
+    getLeagueData.mockResolvedValue({
+      leagueName: 'MSFT ILDC 2026 League',
+      leagueId: 2976007,
+      memberCount: 3,
+      fetchedAt: '2026-05-17T00:00:00Z',
+      teams: [
+        { position: 3, teamName: 'Other2', userName: 'Other2', teamNo: 1, totalScore: 900 },
+        { position: 1, teamName: 'Cooperon', userName: 'Cooperon', teamNo: 1, totalScore: 1223 },
+        { position: 2, teamName: 'Kilzid', userName: 'Kilzid', teamNo: 1, totalScore: 1100 },
+      ],
+    });
+
+    const result = await getLeaderboard({ chatId: 42, leagueCode: 'C7' });
+    expect(result.status).toBe('ok');
+    expect(result.leagueCode).toBe('C7');
+    expect(result.leagueName).toBe('MSFT ILDC 2026 League');
+    expect(result.memberCount).toBe(3);
+    expect(result.fetchedAt).toBe('2026-05-17T00:00:00Z');
+    expect(result.selectedTeamId).toBe('Kilzid_1');
+
+    const positions = result.standings.map((s) => s.position);
+    expect(positions).toEqual([1, 2, 3]);
+
+    const cooperon = result.standings[0];
+    expect(cooperon).toMatchObject({
+      teamName: 'Cooperon',
+      teamId: 'Cooperon_1',
+      totalScore: 1223,
+      gapToLeader: 0,
+      isSelected: false,
+    });
+
+    const kilzid = result.standings[1];
+    expect(kilzid).toMatchObject({
+      teamName: 'Kilzid',
+      teamId: 'Kilzid_1',
+      totalScore: 1100,
+      gapToLeader: -123,
+      isSelected: true,
+    });
+  });
+
+  test('handles missing position / score gracefully', async () => {
+    listUserLeagues.mockResolvedValue([{ leagueCode: 'C7' }]);
+    getLeagueData.mockResolvedValue({
+      leagueName: 'L',
+      teams: [
+        { teamName: 'Mystery', userName: 'M', teamNo: 1 },
+      ],
+    });
+
+    const result = await getLeaderboard({ chatId: 42, leagueCode: 'C7' });
+    expect(result.status).toBe('ok');
+    expect(result.standings[0]).toMatchObject({
+      position: null,
+      totalScore: null,
+      gapToLeader: null,
+      teamId: 'M_1',
+    });
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,7 +3,10 @@ import { CopilotChat } from '@copilotkit/react-ui';
 import '@copilotkit/react-ui/styles.css';
 import { useNextRacesAction } from './components/NextRacesTable';
 import { useBestTeamsAction } from './components/BestTeamsTable';
+import { useBestTeamScenariosAction } from './components/BestTeamScenariosMatrix';
 import { useUserTeamsAction } from './components/UserTeamsList';
+import { useFollowedTeamsAction } from './components/FollowedTeamsGrid';
+import { useLeaderboardAction } from './components/LeaderboardTable';
 
 const RUNTIME_URL =
   (import.meta.env.VITE_AGENT_API_URL as string | undefined) ??
@@ -12,7 +15,10 @@ const RUNTIME_URL =
 function AgentActions() {
   useNextRacesAction();
   useUserTeamsAction();
+  useFollowedTeamsAction();
+  useLeaderboardAction();
   useBestTeamsAction();
+  useBestTeamScenariosAction();
   return null;
 }
 

--- a/web/src/components/BestTeamScenariosMatrix.tsx
+++ b/web/src/components/BestTeamScenariosMatrix.tsx
@@ -1,0 +1,235 @@
+import { useCopilotAction } from '@copilotkit/react-core';
+
+type ScenarioResult = {
+  chipKey: string | null;
+  chipLabel: string;
+  projectedPoints: number | null;
+  expectedPriceChange: number | null;
+  recommendation: 'green' | 'yellow' | null;
+};
+
+type ScenarioRow = {
+  ppm: number;
+  ppmLabel: string;
+  results: ScenarioResult[];
+};
+
+type BestTeamScenariosResult = {
+  status?: 'ok' | 'no_teams' | 'unknown_team' | 'ambiguous_team' | 'missing_cache';
+  teamId?: string;
+  teamName?: string;
+  chip?: string | null;
+  scenarios?: ScenarioRow[];
+  teamIds?: string[];
+};
+
+function recommendationDot(level: ScenarioResult['recommendation']): string {
+  if (level === 'green') return ' 🟢';
+  if (level === 'yellow') return ' 🟡';
+  return '';
+}
+
+function formatDelta(value: number | null): string {
+  if (value === null) return '—';
+  if (value === 0) return '0';
+  return value > 0 ? `+${value.toFixed(2)}` : value.toFixed(2);
+}
+
+function BestTeamScenariosMatrix({
+  result,
+}: {
+  result?: BestTeamScenariosResult;
+}) {
+  if (!result || !result.status) return null;
+
+  if (result.status === 'no_teams') {
+    return (
+      <div style={{ padding: 12, color: '#7a4a00' }}>
+        You don't have any tracked teams yet.
+      </div>
+    );
+  }
+
+  if (result.status === 'missing_cache') {
+    return (
+      <div style={{ padding: 12, color: '#7a4a00' }}>
+        Missing cached data for this team. Upload current team data via the
+        Telegram bot first.
+      </div>
+    );
+  }
+
+  if (result.status === 'unknown_team') {
+    return (
+      <div style={{ padding: 12, color: '#a32020' }}>
+        Couldn't find a matching team.
+      </div>
+    );
+  }
+
+  if (result.status === 'ambiguous_team') {
+    return (
+      <div style={{ padding: 12, color: '#7a4a00' }}>
+        Multiple tracked teams — specify which one.
+      </div>
+    );
+  }
+
+  const scenarios = result.scenarios ?? [];
+  if (scenarios.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      style={{
+        margin: '8px 0',
+        border: '1px solid #e2e6ee',
+        borderRadius: 10,
+        background: '#fff',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          padding: '10px 14px',
+          background: '#f6f8fb',
+          borderBottom: '1px solid #e2e6ee',
+        }}
+      >
+        <div style={{ fontWeight: 700, fontSize: 14, color: '#1f2937' }}>
+          📊 Best Team Scenarios — {result.teamName}
+        </div>
+        <div style={{ color: '#7d8693', fontSize: 11, marginTop: 2 }}>
+          Top team per ppm preset × chip combination. 🟢/🟡 indicate chip lift
+          vs. no-chip baseline of the same row.
+        </div>
+      </div>
+
+      {scenarios.map((row) => (
+        <div
+          key={row.ppm}
+          style={{ borderTop: '1px solid #f0f2f6', padding: '10px 14px' }}
+        >
+          <div
+            style={{
+              fontWeight: 600,
+              fontSize: 13,
+              color: '#1f2937',
+              marginBottom: 6,
+            }}
+          >
+            {row.ppmLabel}{' '}
+            <span style={{ color: '#7d8693', fontWeight: 400 }}>
+              ({row.ppm} pts / $M)
+            </span>
+          </div>
+          <table
+            style={{
+              width: '100%',
+              borderCollapse: 'collapse',
+              fontSize: 12,
+            }}
+          >
+            <thead>
+              <tr style={{ color: '#7d8693', textAlign: 'left' }}>
+                <th style={{ padding: '4px 8px', fontWeight: 500 }}>Scenario</th>
+                <th
+                  style={{ padding: '4px 8px', textAlign: 'right', fontWeight: 500 }}
+                >
+                  Pts
+                </th>
+                <th
+                  style={{ padding: '4px 8px', textAlign: 'right', fontWeight: 500 }}
+                >
+                  Δ price
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {row.results.map((cell, idx) => {
+                const isBaseline = idx === 0;
+                const dot = recommendationDot(cell.recommendation);
+                return (
+                  <tr
+                    key={cell.chipLabel}
+                    style={{
+                      background: isBaseline ? 'transparent' : '#fafbfd',
+                      borderTop: idx === 0 ? 'none' : '1px solid #f5f7fa',
+                    }}
+                  >
+                    <td
+                      style={{
+                        padding: '4px 8px',
+                        fontWeight: isBaseline ? 600 : 400,
+                        color: '#1f2937',
+                      }}
+                    >
+                      {cell.chipLabel}
+                      {dot}
+                    </td>
+                    <td
+                      style={{
+                        padding: '4px 8px',
+                        textAlign: 'right',
+                        fontVariantNumeric: 'tabular-nums',
+                        fontWeight: isBaseline ? 700 : 500,
+                      }}
+                    >
+                      {cell.projectedPoints !== null
+                        ? cell.projectedPoints.toFixed(1)
+                        : '—'}
+                    </td>
+                    <td
+                      style={{
+                        padding: '4px 8px',
+                        textAlign: 'right',
+                        color: '#7d8693',
+                        fontVariantNumeric: 'tabular-nums',
+                      }}
+                    >
+                      {formatDelta(cell.expectedPriceChange)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function useBestTeamScenariosAction() {
+  useCopilotAction({
+    name: 'get_best_team_scenarios',
+    description:
+      'Compare best teams across the 4 budget-adjusted weight presets × 4 chip scenarios.',
+    parameters: [],
+    available: 'frontend',
+    render: ({ status, result }) => {
+      if (status === 'inProgress' || status === 'executing') {
+        return (
+          <div style={{ padding: 10, color: '#666' }}>
+            Computing scenarios…
+          </div>
+        );
+      }
+      const parsed = typeof result === 'string' ? safeParse(result) : result;
+      return (
+        <BestTeamScenariosMatrix
+          result={parsed as BestTeamScenariosResult | undefined}
+        />
+      );
+    },
+  });
+}
+
+function safeParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}

--- a/web/src/components/BestTeamsTable.tsx
+++ b/web/src/components/BestTeamsTable.tsx
@@ -12,7 +12,6 @@ type BestTeamRow = {
   projectedPoints: number;
   budgetAdjustedPoints: number | null;
   expectedPriceChange: number | null;
-  pointsPerMillion: number | null;
 };
 
 type GetBestTeamsOkResult = {
@@ -20,7 +19,7 @@ type GetBestTeamsOkResult = {
   teamId: string;
   teamName: string;
   chip: string | null;
-  rankBy: 'points' | 'budget_adjusted' | 'points_per_million' | null;
+  rankBy: 'points' | 'budget_adjusted' | null;
   budgetChangePointsPerMillion: number;
   filters: {
     mustIncludeDrivers: string[];
@@ -92,7 +91,6 @@ function rankByLabel(
 ): string {
   if (rankBy === 'points') return 'projected points';
   if (rankBy === 'budget_adjusted') return 'budget-adjusted points';
-  if (rankBy === 'points_per_million') return 'points per million';
   return budgetChangePointsPerMillion > 0
     ? 'budget-adjusted points'
     : 'projected points';
@@ -185,7 +183,6 @@ function BestTeamsTable({ result }: { result?: GetBestTeamsResult }) {
   const includeDrivers = new Set(result.filters.mustIncludeDrivers);
   const includeConstructors = new Set(result.filters.mustIncludeConstructors);
   const showBudgetAdjusted = result.budgetChangePointsPerMillion > 0;
-  const showPointsPerMillion = result.rankBy === 'points_per_million';
 
   return (
     <div
@@ -235,7 +232,6 @@ function BestTeamsTable({ result }: { result?: GetBestTeamsResult }) {
             <th style={cellHeader}>Price</th>
             <th style={cellHeader}>Pts</th>
             {showBudgetAdjusted ? <th style={cellHeader}>Budget-adj</th> : null}
-            {showPointsPerMillion ? <th style={cellHeader}>Pts/$M</th> : null}
             <th style={cellHeader}>Tr</th>
             <th style={cellHeader}>Δ price</th>
           </tr>
@@ -284,13 +280,6 @@ function BestTeamsTable({ result }: { result?: GetBestTeamsResult }) {
                 <td style={cellBody}>
                   {team.budgetAdjustedPoints != null
                     ? team.budgetAdjustedPoints.toFixed(1)
-                    : '—'}
-                </td>
-              ) : null}
-              {showPointsPerMillion ? (
-                <td style={cellBody}>
-                  {team.pointsPerMillion != null
-                    ? team.pointsPerMillion.toFixed(2)
                     : '—'}
                 </td>
               ) : null}

--- a/web/src/components/FollowedTeamsGrid.tsx
+++ b/web/src/components/FollowedTeamsGrid.tsx
@@ -1,0 +1,168 @@
+import { useCopilotAction } from '@copilotkit/react-core';
+
+type LeagueRow = {
+  leagueCode: string;
+  leagueName: string;
+  position: number | null;
+};
+
+type FollowedTeam = {
+  teamId: string;
+  teamName: string;
+  leagues: LeagueRow[];
+  isSelected: boolean;
+};
+
+type ListFollowedTeamsResult = {
+  status?: 'ok' | 'empty';
+  teams?: FollowedTeam[];
+};
+
+function positionStyle(position: number | null): {
+  background: string;
+  color: string;
+} {
+  if (position === 1) return { background: '#fff3c2', color: '#7a5a00' };
+  if (position && position <= 3)
+    return { background: '#e6f1ff', color: '#0b3e88' };
+  return { background: '#f1f3f7', color: '#37404f' };
+}
+
+function FollowedTeamsGrid({ result }: { result?: ListFollowedTeamsResult }) {
+  if (result?.status === 'empty' || !result?.teams || result.teams.length === 0) {
+    return (
+      <div style={{ padding: 12, color: '#555' }}>
+        No tracked league teams yet. Run <code>/follow_league</code> +{' '}
+        <code>/teams_tracker</code> in the Telegram bot first.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        margin: '8px 0',
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+        gap: 10,
+      }}
+    >
+      {result.teams.map((team) => (
+        <div
+          key={team.teamId}
+          style={{
+            border: team.isSelected ? '2px solid #2c6fd1' : '1px solid #e2e6ee',
+            borderRadius: 10,
+            padding: '12px 14px',
+            background: '#fff',
+            fontSize: 13,
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+              gap: 6,
+            }}
+          >
+            <strong style={{ fontSize: 15 }}>{team.teamName}</strong>
+            {team.isSelected ? (
+              <span
+                style={{
+                  fontSize: 11,
+                  color: '#1c4f99',
+                  fontWeight: 700,
+                  letterSpacing: 0.3,
+                }}
+              >
+                ACTIVE
+              </span>
+            ) : null}
+          </div>
+          <div style={{ color: '#7d8693', fontSize: 11, marginTop: 2 }}>
+            id: <code>{team.teamId}</code>
+          </div>
+          <div
+            style={{
+              marginTop: 10,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 4,
+            }}
+          >
+            {team.leagues.length === 0 ? (
+              <div style={{ color: '#888', fontSize: 12 }}>
+                (no leagues resolved for this team)
+              </div>
+            ) : (
+              team.leagues.map((row) => {
+                const pos = row.position;
+                const chip = positionStyle(pos);
+                return (
+                  <div
+                    key={`${team.teamId}:${row.leagueCode}`}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      gap: 8,
+                    }}
+                  >
+                    <span style={{ color: '#37404f' }}>{row.leagueName}</span>
+                    <span
+                      style={{
+                        padding: '2px 8px',
+                        borderRadius: 999,
+                        fontSize: 11,
+                        fontWeight: 700,
+                        background: chip.background,
+                        color: chip.color,
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {pos === null ? '—' : `P${pos}`}
+                    </span>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function useFollowedTeamsAction() {
+  useCopilotAction({
+    name: 'list_followed_teams',
+    description:
+      'List the user\'s followed F1 Fantasy teams enriched with each league they appear in and their current position.',
+    parameters: [],
+    available: 'frontend',
+    render: ({ status, result }) => {
+      if (status === 'inProgress' || status === 'executing') {
+        return (
+          <div style={{ padding: 10, color: '#666' }}>
+            Loading your tracked teams…
+          </div>
+        );
+      }
+      const parsed = typeof result === 'string' ? safeParse(result) : result;
+      return (
+        <FollowedTeamsGrid
+          result={parsed as ListFollowedTeamsResult | undefined}
+        />
+      );
+    },
+  });
+}
+
+function safeParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}

--- a/web/src/components/LeaderboardTable.tsx
+++ b/web/src/components/LeaderboardTable.tsx
@@ -1,0 +1,203 @@
+import { useCopilotAction } from '@copilotkit/react-core';
+
+type StandingsRow = {
+  position: number | null;
+  teamName: string;
+  userName: string | null;
+  teamNo: number | null;
+  teamId: string | null;
+  totalScore: number | null;
+  gapToLeader: number | null;
+  isSelected: boolean;
+};
+
+type LeaderboardResult = {
+  status?: 'ok' | 'not_followed' | 'not_found' | 'invalid_input';
+  leagueCode?: string;
+  leagueName?: string;
+  memberCount?: number | null;
+  fetchedAt?: string | null;
+  selectedTeamId?: string | null;
+  standings?: StandingsRow[];
+};
+
+function formatGap(gap: number | null, idx: number): string {
+  if (idx === 0) return '';
+  if (gap === null) return '';
+  if (gap === 0) return '0';
+  return String(gap);
+}
+
+function formatFetchedAt(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function LeaderboardTable({ result }: { result?: LeaderboardResult }) {
+  if (!result) {
+    return null;
+  }
+
+  if (result.status === 'not_followed') {
+    return (
+      <div style={{ padding: 12, color: '#7a4a00' }}>
+        You don't follow league <code>{result.leagueCode}</code>. Run{' '}
+        <code>/follow_league</code> in the Telegram bot first.
+      </div>
+    );
+  }
+
+  if (result.status === 'not_found') {
+    return (
+      <div style={{ padding: 12, color: '#7a4a00' }}>
+        No standings available yet for league <code>{result.leagueCode}</code>.
+        Try again after the next scrape.
+      </div>
+    );
+  }
+
+  if (result.status === 'invalid_input') {
+    return (
+      <div style={{ padding: 12, color: '#a32020' }}>
+        Invalid league code.
+      </div>
+    );
+  }
+
+  const rows = result.standings ?? [];
+  if (rows.length === 0) {
+    return (
+      <div style={{ padding: 12, color: '#555' }}>
+        No teams in <strong>{result.leagueName}</strong> yet.
+      </div>
+    );
+  }
+
+  const fetchedAt = formatFetchedAt(result.fetchedAt);
+
+  return (
+    <div
+      style={{
+        margin: '8px 0',
+        border: '1px solid #e2e6ee',
+        borderRadius: 10,
+        background: '#fff',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          padding: '10px 14px',
+          background: '#f6f8fb',
+          borderBottom: '1px solid #e2e6ee',
+        }}
+      >
+        <div style={{ fontWeight: 700, fontSize: 14, color: '#1f2937' }}>
+          🏆 {result.leagueName ?? result.leagueCode}
+        </div>
+        <div style={{ color: '#7d8693', fontSize: 11, marginTop: 2 }}>
+          {result.memberCount ?? rows.length} teams
+          {fetchedAt ? ` · updated ${fetchedAt}` : ''}
+        </div>
+      </div>
+      <table
+        style={{
+          width: '100%',
+          borderCollapse: 'collapse',
+          fontSize: 13,
+          color: '#1f2937',
+        }}
+      >
+        <thead>
+          <tr style={{ background: '#fafbfd', textAlign: 'left' }}>
+            <th style={{ padding: '6px 12px', width: 50 }}>#</th>
+            <th style={{ padding: '6px 12px' }}>Team</th>
+            <th style={{ padding: '6px 12px', textAlign: 'right', width: 90 }}>
+              Score
+            </th>
+            <th style={{ padding: '6px 12px', textAlign: 'right', width: 70 }}>
+              Gap
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, idx) => {
+            const highlight = row.isSelected;
+            return (
+              <tr
+                key={row.teamId ?? `${row.teamName}-${idx}`}
+                style={{
+                  background: highlight ? '#fff8d6' : 'transparent',
+                  fontWeight: highlight ? 700 : 400,
+                  borderTop: idx === 0 ? 'none' : '1px solid #f0f2f6',
+                }}
+              >
+                <td style={{ padding: '6px 12px', color: '#7d8693' }}>
+                  {row.position ?? '—'}
+                </td>
+                <td style={{ padding: '6px 12px' }}>{row.teamName}</td>
+                <td
+                  style={{
+                    padding: '6px 12px',
+                    textAlign: 'right',
+                    fontVariantNumeric: 'tabular-nums',
+                  }}
+                >
+                  {row.totalScore ?? '—'}
+                </td>
+                <td
+                  style={{
+                    padding: '6px 12px',
+                    textAlign: 'right',
+                    color: '#7d8693',
+                    fontVariantNumeric: 'tabular-nums',
+                  }}
+                >
+                  {formatGap(row.gapToLeader, idx)}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function useLeaderboardAction() {
+  useCopilotAction({
+    name: 'get_leaderboard',
+    description:
+      'Show the standings for one of the user\'s followed F1 Fantasy leagues.',
+    parameters: [],
+    available: 'frontend',
+    render: ({ status, result }) => {
+      if (status === 'inProgress' || status === 'executing') {
+        return (
+          <div style={{ padding: 10, color: '#666' }}>
+            Loading league standings…
+          </div>
+        );
+      }
+      const parsed = typeof result === 'string' ? safeParse(result) : result;
+      return (
+        <LeaderboardTable result={parsed as LeaderboardResult | undefined} />
+      );
+    },
+  });
+}
+
+function safeParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary

Adds **4 new agent tools** and **3 new React components** on top of Phase 2, plus a correctness fix to the points-per-million semantics that crept in during Phase 2. Telegram bot stays byte-identical — no handler was touched. All 770 existing tests pass unchanged; 16 new core tests bring the suite to **775/775**.

## New agent tools

| Tool | Core | Purpose |
|---|---|---|
| `list_followed_teams` | `src/cores/followedTeamsCore.js` | User's tracked teams, dedup'd by teamId across all followed leagues, each enriched with `leagues: [{leagueCode, leagueName, position}]`. Status-tagged (`ok` / `empty`). |
| `get_leaderboard` | `src/cores/leaderboardCore.js` | Standings for a followed league with `selectedTeamId` + per-row `gapToLeader` and `isSelected` for client-side highlighting. Status-tagged (`ok` / `not_followed` / `not_found` / `invalid_input`). |
| `list_user_leagues` | direct wrap of `leagueRegistryService.listUserLeagues` | The user's followed private leagues. |
| `get_best_team_scenarios` | `src/cores/bestTeamScenariosCore.js` | Pure 4×4 matrix (4 budget-adjusted weight presets × 4 chip choices) mirroring Telegram `/best_team_scenarios`. Each cell: `projectedPoints`, `expectedPriceChange`, `recommendation` (`null` / `'yellow'` / `'green'`) computed against the no-chip baseline of the SAME ppm row using the chip-specific thresholds from `getChipRecommendationDot`. |

## New rich UI components

- `<FollowedTeamsGrid />` — card-per-team with `leagueName: position` chips and active-team highlight
- `<LeaderboardTable />` — standings table; user's row highlighted; status fallbacks for not_followed / not_found
- `<BestTeamScenariosMatrix />` — 4 ppm sections × 4 chip rows with 🟢/🟡 recommendation dots

## Marquee: clarify-and-focus (no LLM fan-out)

For multi-team questions like _"best teams by points-per-million for every team I track"_, the agent does **not** fan out N tool calls (which would hit the `parallelToolCalls: false` constraint with N spinners + N sequential table renders). Instead:

1. Agent calls `list_followed_teams`
2. Surfaces the team names back to the user
3. Asks _"which team would you like to focus on?"_
4. Runs `get_best_teams` ONCE with the chosen team

Single rich render per question, no jank.

## PPM semantics fix

Phase 2 introduced `rankBy: 'points_per_million'` computing `projected_points / total_price` (value-for-money). **That is not what 'points per million' means in this bot.** The actual concept is `budgetChangePointsPerMillion` — the **weight** (points per $1M of expected price change per race left) controlled via `/set_best_team_ranking` (presets: Pure Points 0, Points Lean 1.3, Points Plus Budget 1.65, Balanced Budget Value 2.0).

Removed across the calculator, agent tools, core tests, system prompt, and `<BestTeamsTable />`. **The `Pts/$M` column is gone.** The system prompt now teaches the LLM that "points per million" sorting → `rankBy='budget_adjusted'` (the backend uses the user's saved weight). Plus a new `get_best_team_scenarios` tool for when the user actually wants to compare across weights.

## Scenarios-precedence rule

Browser testing revealed the LLM was routing _"best team scenarios for Kilzid"_ to `get_best_teams` (wrong). Root cause: the first workflow rule was "team-name + best-teams → get_best_teams DIRECTLY", which matched any "best team" phrasing including scenarios.

Moved a scenarios-precedence rule to the **top** of the workflow rules block: any mention of "scenarios", "compare", "what if I change my ranking", "should I play a chip", etc. now routes to `get_best_team_scenarios` even when a team is named.

## Telegram bot byte-identical

`leaderboardHandler.js` is already a thin `getLeagueData → formatLeaderboard → bot.sendMessage` pipeline. `formatLeaderboard` is tested directly with the raw blob shape (the byte-identical rule). The new `leaderboardCore` is an **additive abstraction for the agent** — Telegram path is untouched.

## Files

| File | Change |
|---|---|
| `src/cores/followedTeamsCore.js` + test | **NEW** |
| `src/cores/leaderboardCore.js` + test | **NEW** |
| `src/cores/bestTeamScenariosCore.js` + test | **NEW** |
| `src/cores/bestTeamsCore.test.js` | Replace `points_per_million` test refs with `budget_adjusted` |
| `src/bestTeamsCalculator.js` | Drop value-for-money rankBy branch + docstring |
| `src/bestTeamsCalculator.options.test.js` | Drop value-for-money test |
| `src/agent/tools.js` | +4 tools; drop `pointsPerMillion` from summariseBestTeam; rankBy enum trimmed |
| `src/agent/systemPrompt.js` | Scenarios-precedence rule, clarify-and-focus, leaderboard workflow, ppm semantics |
| `web/src/components/{FollowedTeamsGrid,LeaderboardTable,BestTeamScenariosMatrix}.tsx` | **NEW** |
| `web/src/components/BestTeamsTable.tsx` | Remove Pts/$M column + type field |
| `web/src/App.tsx` | Register 3 new actions |
| `AGENTS.md` + `docs/agent-rollout-plan.md` | Document Phase 3 |

## Test results

- **Jest:** 775/775 passing (770 → 775; +16 new core tests, −1 dropped value-for-money test)
- **Lint:** clean (4 pre-existing warnings, none mine)
- **Browser-verified:** all 4 acceptance flows (followed teams, leaderboard, scenarios after the precedence fix, clarify-and-focus for multi-team) + Phase 1+2 regression flows (next races, best teams with filters)

🤖 Co-authored with [Copilot](https://github.com/copilot)