### PR TITLE
feat: web-agent Phase 4 — race info, weather, deadline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Both surfaces share the same business logic via **pure cores** in `src/cores/`. 
   - `src/azureStorageService.js` and `src/azureBillingService.js` wrap Azure integrations.
 - **Internationalization:** `src/i18n.js` and `src/translations.js` provide language support (English/Hebrew) used throughout handlers.
 - **AI Assist:** `src/prompts.js` defines system prompts. `/ask`-style natural language queries are handled by `src/commandsHandler/askHandler.js`, which leverages Azure OpenAI to map free-text requests into command sequences.
-- **Logic Cores:** `src/cores/` holds **pure** business-logic functions that take inputs and return structured JSON. They do not depend on `bot`, `t()`, or `sendMessage`. Each Telegram handler is being progressively refactored into `(pure core in src/cores/) + (thin Telegram adapter)`. The same core is consumed by the web-chat agent's tools — so a question like "best teams with VER but no ALO" runs through the same calculator as the `/best_teams` command. **Refactor rule:** existing handler tests must keep passing unchanged after the extraction; if they don't, fix the refactor, not the test. Phases 1–2 have extracted `nextRacesCore.js`, `bestTeamsCore.js`, and `userTeamsCore.js`; more will land as future phases ship.
+- **Logic Cores:** `src/cores/` holds **pure** business-logic functions that take inputs and return structured JSON. They do not depend on `bot`, `t()`, or `sendMessage`. Each Telegram handler is being progressively refactored into `(pure core in src/cores/) + (thin Telegram adapter)`. The same core is consumed by the web-chat agent's tools — so a question like "best teams with VER but no ALO" runs through the same calculator as the `/best_teams` command. **Refactor rule:** existing handler tests must keep passing unchanged after the extraction; if they don't, fix the refactor, not the test. Cores extracted so far: `nextRacesCore`, `bestTeamsCore`, `userTeamsCore`, `followedTeamsCore`, `leaderboardCore`, `bestTeamScenariosCore`, `nextRaceInfoCore`, `raceWeatherCore`, `deadlineCore`. Cores that need side effects (e.g. weather fetch logging) accept optional `onFetch`/`onError` callbacks — the Telegram adapter wires them to bot-side helpers; the agent path omits them.
 - **Agent (Web Chat):** `src/agent/`, `agentWebhook/`, and `web/` together implement a second user-facing surface. Identity is resolved from the `AGENT_HARDCODED_CHAT_ID` env var (v1) so all tool calls operate as that user against the same caches/blobs as the Telegram bot. See the [Agent (Web Chat)](#agent-web-chat) section for the full architecture, the cores↔tools pattern, and how to add a new tool with a matching React component.
 
 ---
@@ -543,7 +543,7 @@ Blob naming includes the team ID:
 
 A second user-facing surface that runs the same business logic as the Telegram bot through tool calls. Architecture, code layout, and the patterns for adding new capabilities live in this section.
 
-Phase-3 capabilities (shipped):
+Phase-4 capabilities (shipped):
 
 - `get_next_races` — upcoming races for the season (Phase 1).
 - `list_user_teams` — the user's tracked teams (teamId + friendly teamName) (Phase 2).
@@ -552,6 +552,9 @@ Phase-3 capabilities (shipped):
 - `list_followed_teams` — the user's followed league teams enriched with the leagues each team appears in + position in each (Phase 3).
 - `list_user_leagues` — the private leagues the user has followed via `/follow_league` (Phase 3).
 - `get_leaderboard` — standings for one of the user's followed leagues (Phase 3). Returns status-tagged result (`ok` / `not_followed` / `not_found` / `invalid_input`) plus `selectedTeamId` for client-side highlighting.
+- `get_next_race_info` — full info on the next race: circuit, location, weekend format (regular/sprint), session timestamps, historical stats, multi-language track history, and opportunistic weather snapshot. Reads `nextRaceInfoCache[sharedKey]` + `weatherForecastCache`; on cache miss the core calls `getWeatherForecast` directly (Phase 4).
+- `get_race_weather` — per-session hourly weather forecast (up to 3 hours per session, filtered to drop hours already in the past) for the next race weekend (Phase 4).
+- `get_deadline` — next team-lock deadline (start of the first locking session: sprint on sprint weekends, qualifying otherwise). Returns absolute timestamps (`sessionStartsAt`, `nowIso`) — the web UI's `<DeadlineCountdown />` ticks client-side with skew compensation so the server's clock stays the source of truth (Phase 4).
 
 **Multi-team "every team I track" pattern.** When the user asks a multi-team
 question like _"best teams by points-per-million for every team I track"_,
@@ -631,7 +634,13 @@ f1-fantazy-bot/
 │   ├── cores/
 │   │   ├── nextRacesCore.js          # pure: getNextRaces() → {season, races, counts}
 │   │   ├── bestTeamsCore.js          # pure: computeBestTeams({chatId, teamId?, teamName?, rankBy?, mustInclude*, mustExclude*})
-│   │   └── userTeamsCore.js          # pure: listUserTeams({chatId}) → [{teamId, teamName, ...}]
+│   │   ├── userTeamsCore.js          # pure: listUserTeams({chatId}) → [{teamId, teamName, ...}]
+│   │   ├── followedTeamsCore.js      # pure: listFollowedTeams({chatId}) — status-tagged
+│   │   ├── leaderboardCore.js        # pure: getLeaderboard({chatId, leagueCode}) — status-tagged
+│   │   ├── bestTeamScenariosCore.js  # pure: computeBestTeamScenarios({chatId, teamId?, teamName?}) — 4×4 matrix
+│   │   ├── nextRaceInfoCore.js       # pure: getNextRaceInfo({onFetch?, onError?}) — cache + opportunistic weather
+│   │   ├── raceWeatherCore.js        # pure: getRaceWeather({now?, onFetch?, onError?}) — hourly forecasts
+│   │   └── deadlineCore.js           # pure: getDeadlineSnapshot({now?}) — absolute timestamps for client-side countdown
 │   ├── agent/
 │   │   ├── identity.js               # AGENT_HARDCODED_CHAT_ID (LLM never sees it)
 │   │   ├── systemPrompt.js           # English-only v1; built once at startup
@@ -641,6 +650,9 @@ f1-fantazy-bot/
 │   ├── bestTeamsCalculator.js        # exports an optional `options` arg: filters + rankBy + resultCount
 │   └── commandsHandler/
 │       ├── nextRacesHandler.js       # refactored: thin Telegram adapter over the core
+│       ├── nextRaceInfoHandler.js    # refactored: thin Telegram adapter over nextRaceInfoCore
+│       ├── nextRaceWeatherHandler.js # refactored: thin Telegram adapter over raceWeatherCore
+│       ├── deadlineHandler.js        # untouched — deadlineCore is additive (agent-only entry point)
 │       └── bestTeamsHandler.js       # refactored: thin Telegram adapter over the core
 ├── agentWebhook/
 │   ├── function.json                 # httpTrigger, route `agent/{*restOfPath}`
@@ -654,7 +666,10 @@ f1-fantazy-bot/
 │   │       ├── UserTeamsList.tsx     # useCopilotAction({ name: 'list_user_teams', available: 'frontend', render })
 │   │       ├── FollowedTeamsGrid.tsx # useCopilotAction({ name: 'list_followed_teams', available: 'frontend', render })
 │   │       ├── LeaderboardTable.tsx  # useCopilotAction({ name: 'get_leaderboard', available: 'frontend', render })
-│   │       └── BestTeamScenariosMatrix.tsx # useCopilotAction({ name: 'get_best_team_scenarios', available: 'frontend', render })
+│   │       ├── BestTeamScenariosMatrix.tsx # useCopilotAction({ name: 'get_best_team_scenarios', available: 'frontend', render })
+│   │       ├── RaceInfoCard.tsx      # useCopilotAction({ name: 'get_next_race_info', available: 'frontend', render })
+│   │       ├── WeatherForecast.tsx   # useCopilotAction({ name: 'get_race_weather', available: 'frontend', render })
+│   │       └── DeadlineCountdown.tsx # useCopilotAction({ name: 'get_deadline', available: 'frontend', render })
 │   ├── package.json
 │   └── …                             # own package.json — frontend deps don't pollute the backend
 └── scripts/
@@ -801,6 +816,12 @@ npm run dev:web      # only Vite frontend on :5173/:5174
 | `web/src/components/FollowedTeamsGrid.tsx` | `list_followed_teams` rich render — card per team with `leagueName: position` chips, active-team highlight. |
 | `web/src/components/LeaderboardTable.tsx` | `get_leaderboard` rich render — sortable standings table with the user's row highlighted; status fallbacks for `not_followed` / `not_found`. |
 | `web/src/components/BestTeamScenariosMatrix.tsx` | `get_best_team_scenarios` rich render — 4 ppm sections × 4 chip rows showing projected points, Δ price change, and 🟢/🟡 chip recommendation dots mirroring `/best_team_scenarios`. |
+| `src/cores/nextRaceInfoCore.js` | `getNextRaceInfo({onFetch?, onError?})` — reads `nextRaceInfoCache[sharedKey]` + opportunistic `weatherForecastCache`; on cache miss fetches live weather via `getWeatherForecast` and populates the cache. Callbacks let the Telegram adapter wire `sendLogMessage`/`sendErrorMessage`; the agent omits them. |
+| `src/cores/raceWeatherCore.js` | `getRaceWeather({now?, onFetch?, onError?})` — hourly forecasts per session (3 hours starting at each session start, filtered by `nowRounded`). `now` injection keeps tests deterministic. |
+| `src/cores/deadlineCore.js` | `getDeadlineSnapshot({now?})` — `{status, raceName, sessionType, sessionLabel, sessionStartsAt, nowIso, alreadyStarted}`. Server returns absolute timestamps; the React `<DeadlineCountdown />` ticks client-side with skew compensation. Additive — `deadlineHandler.js` (with its existing pure helpers) is untouched. |
+| `web/src/components/RaceInfoCard.tsx` | `get_next_race_info` rich render — header + circuit image + schedule (quali/race/+sprint pair) + weather chips + historical results table + track history. |
+| `web/src/components/WeatherForecast.tsx` | `get_race_weather` rich render — per-session card with hourly chips: temp, rain %/mm, wind, humidity, cloud cover. |
+| `web/src/components/DeadlineCountdown.tsx` | `get_deadline` rich render — live ticking countdown (days/hours/min/sec) anchored to server clock via `nowIso` skew; stops ticking once deadline passes; collapses to "already started" state when applicable. |
 | `scripts/dev-agent-server.js` | Local dev wrapper around `agentWebhook/index.js`. Not deployed. |
 
 ---

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@ import unusedImports from 'eslint-plugin-unused-imports';
 import globals from 'globals';
 
 export default [
+  { ignores: ['web/dist/**', 'web/node_modules/**', 'node_modules/**', 'coverage/**'] },
   { files: ['**/*.{js,mjs,cjs}'] },
   { files: ['**/*.js'], languageOptions: { sourceType: 'commonjs' } },
   {

--- a/src/agent/systemPrompt.js
+++ b/src/agent/systemPrompt.js
@@ -31,6 +31,14 @@ Available tools:
   Limitless, Extra Boost, Wildcard). Use for "compare best teams at
   different weights", "best team scenarios", "what if I change my
   ranking preference", "should I play a chip".
+- get_next_race_info — full info on the next race: circuit, location,
+  weekend format (regular/sprint), session timestamps, historical stats,
+  track history, circuit image.
+- get_race_weather — per-session hourly weather forecast for the next
+  race weekend (qualifying, race, +sprint sessions if applicable).
+- get_deadline — next team-lock deadline (start of the first locking
+  session: sprint on sprint weekends, qualifying otherwise). Returns
+  absolute timestamps; the web UI handles the live countdown.
 
 Workflow rules:
 - **Scenarios questions take precedence.** When the user mentions
@@ -96,6 +104,26 @@ Workflow rules:
   don't follow that league and suggest /follow_league.
 - If get_leaderboard returns status="not_found", tell the user the
   standings haven't been generated yet for this league.
+- **Race-info / weather / deadline routing.**
+  - "Next race", "race info", "track history", "circuit", "schedule",
+    "historical stats", "what's the next race" → call **get_next_race_info**.
+  - "Weather", "forecast", "rain", "temperature", "wind", "humidity" for
+    the next race → call **get_race_weather**.
+  - "Deadline", "lock", "when does the team lock", "countdown", "how
+    long until the deadline" → call **get_deadline**.
+  - All three are no-arg tools. Don't combine them with other tools in
+    the same turn.
+  - **Exclusion:** use these ONLY when the question is about the race or
+    event itself (circuit, schedule, forecast, history, lock time). If
+    the question is about the user's fantasy team, best teams, chips,
+    drivers/constructors, or lineups — keep using the fantasy-team
+    tools (get_best_teams, get_best_team_scenarios, etc.), even when
+    the phrase "next race" appears in the prompt (e.g. "best team for
+    the next race" → get_best_teams, NOT get_next_race_info).
+- For get_deadline results, do not compute a human-readable countdown
+  in text — the web UI renders a live ticking countdown component.
+  Briefly mention the race name and session type ("Sprint" or
+  "Qualifying") in your reply, but don't restate "X days Y hours...".
 
 Style rules:
 - Answer in English.

--- a/src/agent/tools.js
+++ b/src/agent/tools.js
@@ -20,6 +20,9 @@ const {
 const { listUserTeams } = require('../cores/userTeamsCore');
 const { listFollowedTeams } = require('../cores/followedTeamsCore');
 const { getLeaderboard } = require('../cores/leaderboardCore');
+const { getNextRaceInfo } = require('../cores/nextRaceInfoCore');
+const { getRaceWeather } = require('../cores/raceWeatherCore');
+const { getDeadlineSnapshot } = require('../cores/deadlineCore');
 const { listUserLeagues } = require('../leagueRegistryService');
 const { getAgentChatId } = require('./identity');
 const { ensureCacheReady } = require('./cacheBootstrap');
@@ -242,6 +245,41 @@ const tools = [
       const chatId = getAgentChatId();
 
       return await getLeaderboard({ chatId, leagueCode: args.leagueCode });
+    },
+  }),
+
+  defineTool({
+    name: 'get_next_race_info',
+    description:
+      'Get detailed information about the next upcoming F1 race: race name, circuit, location, weekend format (regular or sprint), session timestamps (qualifying / race, plus sprintQualifying / sprint on sprint weekends), historical race stats for that track, multi-language track history, circuit image URL, and an optional pre-fetched weather snapshot. Use for questions like "tell me about the next race", "what circuit is next", "give me race info", "what is the schedule for the next race", "track history", or "historical stats for this race". Returns { status, raceName, circuitName, circuitImageUrl, location, weekendFormat, isSprintWeekend, sessions, historicalRaceStats, trackHistory, weather }. status="unavailable" means the race-info cache has not been populated yet.',
+    parameters: z.object({}),
+    execute: async () => {
+      await ensureCacheReady();
+
+      return await getNextRaceInfo();
+    },
+  }),
+
+  defineTool({
+    name: 'get_race_weather',
+    description:
+      'Get the per-session hourly weather forecast (up to 3 hours per session, starting from each session start time, filtered to drop hours already in the past) for the next F1 race. Use for questions about weather, rain, temperature, wind, humidity, or cloud cover for the upcoming race weekend. Returns { status, raceName, circuitName, location, isSprintWeekend, sessions: [{ key, label, startsAt, hours: [iso], forecasts: [{ temperature, humidity, cloudCover, precipitation, precipitation_mm, wind }] }] }. status="unavailable" means either the race-info cache is empty or the weather API call failed.',
+    parameters: z.object({}),
+    execute: async () => {
+      await ensureCacheReady();
+
+      return await getRaceWeather();
+    },
+  }),
+
+  defineTool({
+    name: 'get_deadline',
+    description:
+      'Get the next F1 Fantasy team-lock deadline. The deadline is the start time of the first locking session of the weekend: sprint (on sprint weekends) or qualifying (on regular weekends). Use for questions like "when does the team lock", "how long until the deadline", "next deadline", or "countdown to lock". Returns { status, raceName, sessionType, sessionLabel, sessionStartsAt: ISO, nowIso: ISO, alreadyStarted }. The web UI uses `sessionStartsAt` to render a live ticking countdown — return the result as-is and let the rich component handle the display.',
+    parameters: z.object({}),
+    execute: async () => {
+      // No cache needed — fetchNextRace pulls fresh from the schedule service.
+      return await getDeadlineSnapshot();
     },
   }),
 ];

--- a/src/commandsHandler/nextRaceInfoHandler.js
+++ b/src/commandsHandler/nextRaceInfoHandler.js
@@ -1,18 +1,23 @@
 const { sendLogMessage, sendErrorMessage, sendPhotoToUser } = require('../utils');
 const { formatDateTime } = require('../utils/utils');
-const { getWeatherForecast } = require('../utils/weatherApi');
 const { MAX_TELEGRAM_MESSAGE_LENGTH } = require('../constants');
-const {
-  nextRaceInfoCache,
-  sharedKey,
-  weatherForecastCache,
-} = require('../cache');
+const { getNextRaceInfo } = require('../cores/nextRaceInfoCore');
 const { t, getLanguage } = require('../i18n');
 
 async function handleNextRaceInfoCommand(bot, chatId) {
-  const nextRaceInfo = nextRaceInfoCache[sharedKey];
+  const result = await getNextRaceInfo({
+    onFetch: async ({ locality, country }) => {
+      await sendLogMessage(
+        bot,
+        `Weather forecast fetched for location: ${locality}, ${country}`
+      );
+    },
+    onError: async (err) => {
+      await sendErrorMessage(bot, `Weather API error: ${err.message}`);
+    },
+  });
 
-  if (!nextRaceInfo) {
+  if (result.status === 'unavailable') {
     await bot
       .sendMessage(
         chatId,
@@ -25,86 +30,55 @@ async function handleNextRaceInfoCommand(bot, chatId) {
     return;
   }
 
-  const circuitImageUrl = nextRaceInfo.circuitImageUrl;
-  // Prepare session dates
-  const raceDate = new Date(nextRaceInfo.sessions.race);
-  const qualifyingDate = new Date(nextRaceInfo.sessions.qualifying);
-  const isSprintWeekend = nextRaceInfo.weekendFormat === 'sprint';
+  const {
+    raceName,
+    circuitName,
+    circuitImageUrl,
+    location,
+    weekendFormat,
+    isSprintWeekend,
+    sessions,
+    historicalRaceStats,
+    trackHistory,
+    weather,
+  } = result;
 
-  // If sprint weekend, get sprint session dates
-  let sprintQualifyingDate = null;
-  let sprintDate = null;
-  if (isSprintWeekend) {
-    sprintQualifyingDate = new Date(nextRaceInfo.sessions.sprintQualifying);
-    sprintDate = new Date(nextRaceInfo.sessions.sprint);
-  }
+  const qualifyingDate = new Date(sessions.qualifying);
+  const raceDate = new Date(sessions.race);
+  const sprintQualifyingDate = isSprintWeekend
+    ? new Date(sessions.sprintQualifying)
+    : null;
+  const sprintDate = isSprintWeekend ? new Date(sessions.sprint) : null;
 
-  // Format session dates and times
   const { dateStr: qualifyingDateStr, timeStr: qualifyingTimeStr } =
     formatDateTime(qualifyingDate, chatId);
-  const { dateStr: raceDateStr, timeStr: raceTimeStr } =
-    formatDateTime(raceDate, chatId);
+  const { dateStr: raceDateStr, timeStr: raceTimeStr } = formatDateTime(
+    raceDate,
+    chatId
+  );
 
-  let sprintQualifyingDateStr = '',
-    sprintQualifyingTimeStr = '';
-  let sprintDateStr = '',
-    sprintTimeStr = '';
+  let sprintQualifyingDateStr = '';
+  let sprintQualifyingTimeStr = '';
+  let sprintDateStr = '';
+  let sprintTimeStr = '';
   if (isSprintWeekend) {
     ({ dateStr: sprintQualifyingDateStr, timeStr: sprintQualifyingTimeStr } =
       formatDateTime(sprintQualifyingDate, chatId));
 
-    ({ dateStr: sprintDateStr, timeStr: sprintTimeStr } =
-      formatDateTime(sprintDate, chatId));
+    ({ dateStr: sprintDateStr, timeStr: sprintTimeStr } = formatDateTime(
+      sprintDate,
+      chatId
+    ));
   }
 
-  // Prepare array of dates for weather API
-  const datesForWeatherApi = [];
-  datesForWeatherApi.push(qualifyingDate, raceDate);
-  if (isSprintWeekend) {
-    datesForWeatherApi.push(sprintQualifyingDate, sprintDate);
-  }
+  const {
+    qualifyingWeather,
+    raceWeather,
+    sprintQualifyingWeather,
+    sprintWeather,
+  } = weather;
 
-  // Weather forecast section
   let weatherSection = '';
-  let sprintQualifyingWeather, sprintWeather, qualifyingWeather, raceWeather;
-  const cachedWeatherData = weatherForecastCache;
-  if (cachedWeatherData && Object.keys(cachedWeatherData).length > 0) {
-    qualifyingWeather = cachedWeatherData.qualifyingWeather;
-    raceWeather = cachedWeatherData.raceWeather;
-    if (isSprintWeekend) {
-      sprintQualifyingWeather = cachedWeatherData.sprintQualifyingWeather;
-      sprintWeather = cachedWeatherData.sprintWeather;
-    }
-  } else {
-    try {
-      const weatherForecastsMap = await getWeatherForecast(
-        nextRaceInfo.location.lat,
-        nextRaceInfo.location.long,
-        ...datesForWeatherApi
-      );
-      qualifyingWeather = weatherForecastsMap[qualifyingDate.toISOString()];
-      raceWeather = weatherForecastsMap[raceDate.toISOString()];
-      weatherForecastCache.qualifyingWeather = qualifyingWeather;
-      weatherForecastCache.raceWeather = raceWeather;
-
-      if (isSprintWeekend) {
-        sprintQualifyingWeather =
-          weatherForecastsMap[sprintQualifyingDate.toISOString()];
-        sprintWeather = weatherForecastsMap[sprintDate.toISOString()];
-        weatherForecastCache.sprintQualifyingWeather = sprintQualifyingWeather;
-        weatherForecastCache.sprintWeather = sprintWeather;
-      }
-
-      await sendLogMessage(
-        bot,
-        `Weather forecast fetched for location: ${nextRaceInfo.location.locality}, ${nextRaceInfo.location.country}`
-      );
-    } catch (err) {
-      await sendErrorMessage(bot, `Weather API error: ${err.message}`);
-    }
-  }
-
-  // Build weather section
   if (qualifyingWeather && raceWeather) {
     weatherSection += `*${t('Weather Forecast', chatId)}:*\n`;
     if (isSprintWeekend) {
@@ -131,13 +105,10 @@ async function handleNextRaceInfoCommand(bot, chatId) {
     } ${t('km/h', chatId)}\n\n`;
   }
 
-  // Create message with next race information
   let message = `*${t('Next Race Information', chatId)}*\n\n`;
-  message += `🏎️ *${t('Race Name', chatId)}:* ${nextRaceInfo.raceName}\n`;
-  message += `🏁 *${t('Track', chatId)}:* ${nextRaceInfo.circuitName}\n`;
-  message += `📍 *${t('Location', chatId)}:* ${
-    nextRaceInfo.location.locality
-  }, ${nextRaceInfo.location.country}\n`;
+  message += `🏎️ *${t('Race Name', chatId)}:* ${raceName}\n`;
+  message += `🏁 *${t('Track', chatId)}:* ${circuitName}\n`;
+  message += `📍 *${t('Location', chatId)}:* ${location.locality}, ${location.country}\n`;
   if (isSprintWeekend) {
     message += `📅 *${t(
       'Sprint Qualifying Date',
@@ -155,20 +126,15 @@ async function handleNextRaceInfoCommand(bot, chatId) {
   message += `📅 *${t('Race Date', chatId)}:* ${raceDateStr}\n`;
   message += `⏰ *${t('Race Time', chatId)}:* ${raceTimeStr}\n`;
   const weekendFormatValue = t(
-    nextRaceInfo.weekendFormat.charAt(0).toUpperCase() +
-      nextRaceInfo.weekendFormat.slice(1),
+    weekendFormat.charAt(0).toUpperCase() + weekendFormat.slice(1),
     chatId
   );
   message += `📝 *${t('Weekend Format', chatId)}:* ${weekendFormatValue}\n\n`;
   message += weatherSection;
 
-  // Add historical data section
   message += `*${t('Historical Race Stats (Last Decade)', chatId)}:*\n`;
-  if (
-    nextRaceInfo.historicalRaceStats &&
-    nextRaceInfo.historicalRaceStats.length > 0
-  ) {
-    nextRaceInfo.historicalRaceStats
+  if (historicalRaceStats && historicalRaceStats.length > 0) {
+    historicalRaceStats
       .sort((a, b) => b.season - a.season)
       .forEach((data) => {
         message += `*${data.season}:*\n`;
@@ -204,14 +170,12 @@ async function handleNextRaceInfoCommand(bot, chatId) {
   }
 
   let trackHistoryMessage = '';
-  if (Array.isArray(nextRaceInfo.trackHistory)) {
+  if (Array.isArray(trackHistory) && trackHistory.length > 0) {
     const lang = getLanguage(chatId);
     const trackHistoryObj =
-      nextRaceInfo.trackHistory.find((h) => h.lang === lang) ||
-      nextRaceInfo.trackHistory[0];
+      trackHistory.find((h) => h.lang === lang) || trackHistory[0];
 
     if (trackHistoryObj && trackHistoryObj.text) {
-      // Add track History section
       trackHistoryMessage += `*${t('Track History', chatId)}:*\n`;
       trackHistoryMessage += trackHistoryObj.text;
       trackHistoryMessage += `\n`;

--- a/src/commandsHandler/nextRaceWeatherHandler.js
+++ b/src/commandsHandler/nextRaceWeatherHandler.js
@@ -1,17 +1,22 @@
 const { sendLogMessage, sendErrorMessage } = require('../utils');
 const { formatDateTime } = require('../utils/utils');
-const { getWeatherForecast } = require('../utils/weatherApi');
-const {
-  nextRaceInfoCache,
-  sharedKey,
-  weatherForecastCache,
-} = require('../cache');
+const { getRaceWeather } = require('../cores/raceWeatherCore');
 const { t } = require('../i18n');
 
 async function handleNextRaceWeatherCommand(bot, chatId) {
-  const nextRaceInfo = nextRaceInfoCache[sharedKey];
+  const result = await getRaceWeather({
+    onFetch: async ({ locality, country }) => {
+      await sendLogMessage(
+        bot,
+        `Weather forecast fetched for location: ${locality}, ${country}`
+      );
+    },
+    onError: async (err) => {
+      await sendErrorMessage(bot, `Weather API error: ${err.message}`);
+    },
+  });
 
-  if (!nextRaceInfo) {
+  if (result.status === 'unavailable') {
     await bot
       .sendMessage(
         chatId,
@@ -24,94 +29,22 @@ async function handleNextRaceWeatherCommand(bot, chatId) {
     return;
   }
 
-  const qualifyingDate = new Date(nextRaceInfo.sessions.qualifying);
-  const raceDate = new Date(nextRaceInfo.sessions.race);
-  const isSprintWeekend = nextRaceInfo.weekendFormat === 'sprint';
-
-  const sessions = [
-    { key: 'qualifyingHourlyWeather', label: t('Qualifying', chatId), start: qualifyingDate },
-    { key: 'raceHourlyWeather', label: t('Race', chatId), start: raceDate },
-  ];
-
-  if (isSprintWeekend) {
-    const sprintQualiDate = new Date(nextRaceInfo.sessions.sprintQualifying);
-    const sprintDate = new Date(nextRaceInfo.sessions.sprint);
-    sessions.push({
-      key: 'sprintQualifyingHourlyWeather',
-      label: t('Sprint Qualifying', chatId),
-      start: sprintQualiDate,
-    });
-    sessions.push({
-      key: 'sprintHourlyWeather',
-      label: t('Sprint', chatId),
-      start: sprintDate,
-    });
-  }
-
-  sessions.sort((a, b) => a.start - b.start);
-
-  const nowRounded = new Date(Math.floor(Date.now() / (60 * 60 * 1000)) * 60 * 60 * 1000);
-
-  const timesToFetch = [];
-  sessions.forEach((s) => {
-    s.hours = [
-      s.start,
-      new Date(s.start.getTime() + 60 * 60 * 1000),
-      new Date(s.start.getTime() + 2 * 60 * 60 * 1000),
-    ].filter((h) => h >= nowRounded);
-    s.forecast = weatherForecastCache[s.key];
-    timesToFetch.push(...s.hours);
-  });
-
-  const needFetch = sessions.some((s) => !s.forecast);
-  if (needFetch) {
-    try {
-      const weatherForecastsMap = await getWeatherForecast(
-        nextRaceInfo.location.lat,
-        nextRaceInfo.location.long,
-        ...timesToFetch
-      );
-      sessions.forEach((s) => {
-        if (!s.forecast) {
-          s.forecast = s.hours.map((h) => weatherForecastsMap[h.toISOString()]);
-          weatherForecastCache[s.key] = s.forecast;
-        }
-      });
-      await sendLogMessage(
-        bot,
-        `Weather forecast fetched for location: ${nextRaceInfo.location.locality}, ${nextRaceInfo.location.country}`
-      );
-    } catch (err) {
-      await sendErrorMessage(bot, `Weather API error: ${err.message}`);
-    }
-  }
-
-  if (sessions.some((s) => !s.forecast)) {
-    await bot
-      .sendMessage(
-        chatId,
-        t('Next race information is currently unavailable.', chatId)
-      )
-      .catch((err) =>
-        console.error('Error sending next race weather message:', err)
-      );
-
-    return;
-  }
+  const { raceName, circuitName, location, sessions } = result;
 
   let message = `*${t('Next Race Weather Forecast', chatId)}*\n\n`;
-  message += `🏎️ *${t('Race Name', chatId)}:* ${nextRaceInfo.raceName}\n`;
-  message += `🏁 *${t('Track', chatId)}:* ${nextRaceInfo.circuitName}\n`;
-  message += `📍 *${t('Location', chatId)}:* ${nextRaceInfo.location.locality}, ${nextRaceInfo.location.country}\n\n`;
+  message += `🏎️ *${t('Race Name', chatId)}:* ${raceName}\n`;
+  message += `🏁 *${t('Track', chatId)}:* ${circuitName}\n`;
+  message += `📍 *${t('Location', chatId)}:* ${location.locality}, ${location.country}\n\n`;
   sessions.forEach((session) => {
     if (session.hours.length === 0) {
       return;
     }
-    const { dateStr, timeStr } = formatDateTime(session.start, chatId);
-    message += `*${session.label}* (${dateStr} ${timeStr})\n`;
-    session.hours.forEach((hourTime, idx) => {
-      const forecast = session.forecast[idx];
-      const { timeStr: hTime } = formatDateTime(hourTime, chatId);
+    const startsAt = new Date(session.startsAt);
+    const { dateStr, timeStr } = formatDateTime(startsAt, chatId);
+    message += `*${t(session.label, chatId)}* (${dateStr} ${timeStr})\n`;
+    session.hours.forEach((hourIso, idx) => {
+      const forecast = session.forecasts[idx];
+      const { timeStr: hTime } = formatDateTime(new Date(hourIso), chatId);
       message += `*${t('Hour', chatId)} ${hTime}*:\n`;
       message += `🌡️ ${t('Temp', chatId)}: ${forecast.temperature}°C\n`;
       message += `💧 ${t('Humidity', chatId)}: ${forecast.humidity}%\n`;

--- a/src/cores/deadlineCore.js
+++ b/src/cores/deadlineCore.js
@@ -1,0 +1,43 @@
+const { fetchNextRace } = require('../raceScheduleService');
+const { getDeadlineSession } = require('../commandsHandler/deadlineHandler');
+
+// Returns the deadline snapshot for the agent. The live countdown is
+// computed on the client; the server provides absolute timestamps
+// (`sessionStartsAt`, `nowIso`) plus an `alreadyStarted` flag. The
+// Telegram surface keeps its existing message-building helpers
+// (`buildDeadlineMessage`, `getDeadlinePayload`) in `deadlineHandler.js`
+// — this core is additive.
+async function getDeadlineSnapshot({ now = new Date() } = {}) {
+  const race = await fetchNextRace();
+
+  if (!race) {
+    return {
+      status: 'unavailable',
+      nowIso: now.toISOString(),
+    };
+  }
+
+  const session = getDeadlineSession(race);
+
+  if (!session?.startsAt) {
+    return {
+      status: 'unavailable',
+      raceName: race.raceName,
+      nowIso: now.toISOString(),
+    };
+  }
+
+  const alreadyStarted = session.startsAt.getTime() - now.getTime() <= 0;
+
+  return {
+    status: 'ok',
+    raceName: race.raceName,
+    sessionType: session.type,
+    sessionLabel: session.label,
+    sessionStartsAt: session.startsAt.toISOString(),
+    nowIso: now.toISOString(),
+    alreadyStarted,
+  };
+}
+
+module.exports = { getDeadlineSnapshot };

--- a/src/cores/deadlineCore.test.js
+++ b/src/cores/deadlineCore.test.js
@@ -1,0 +1,91 @@
+jest.mock('../raceScheduleService', () => {
+  const actual = jest.requireActual('../raceScheduleService');
+
+  return {
+    ...actual,
+    fetchNextRace: jest.fn(),
+  };
+});
+
+const { fetchNextRace } = require('../raceScheduleService');
+const { getDeadlineSnapshot } = require('./deadlineCore');
+
+describe('getDeadlineSnapshot', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns status="unavailable" when fetchNextRace returns nothing', async () => {
+    fetchNextRace.mockResolvedValue(null);
+    const now = new Date('2026-05-01T10:00:00Z');
+
+    const result = await getDeadlineSnapshot({ now });
+
+    expect(result).toEqual({
+      status: 'unavailable',
+      nowIso: '2026-05-01T10:00:00.000Z',
+    });
+  });
+
+  it('returns status="ok" with qualifying deadline for a regular weekend', async () => {
+    fetchNextRace.mockResolvedValue({
+      raceName: 'Spanish GP',
+      Qualifying: { date: '2026-05-09', time: '14:00:00Z' },
+    });
+    const now = new Date('2026-05-01T10:00:00Z');
+
+    const result = await getDeadlineSnapshot({ now });
+
+    expect(result).toEqual({
+      status: 'ok',
+      raceName: 'Spanish GP',
+      sessionType: 'qualifying',
+      sessionLabel: 'quali',
+      sessionStartsAt: '2026-05-09T14:00:00.000Z',
+      nowIso: '2026-05-01T10:00:00.000Z',
+      alreadyStarted: false,
+    });
+  });
+
+  it('returns sprint as deadline session for sprint weekends', async () => {
+    fetchNextRace.mockResolvedValue({
+      raceName: 'Miami GP',
+      Sprint: { date: '2026-05-02', time: '15:30:00Z' },
+      Qualifying: { date: '2026-05-03', time: '15:30:00Z' },
+    });
+    const now = new Date('2026-05-01T10:00:00Z');
+
+    const result = await getDeadlineSnapshot({ now });
+
+    expect(result.sessionType).toBe('sprint');
+    expect(result.sessionLabel).toBe('sprint');
+    expect(result.sessionStartsAt).toBe('2026-05-02T15:30:00.000Z');
+    expect(result.alreadyStarted).toBe(false);
+  });
+
+  it('marks alreadyStarted=true when the session is in the past', async () => {
+    fetchNextRace.mockResolvedValue({
+      raceName: 'Past GP',
+      Qualifying: { date: '2026-05-01', time: '09:00:00Z' },
+    });
+    const now = new Date('2026-05-01T10:00:00Z');
+
+    const result = await getDeadlineSnapshot({ now });
+
+    expect(result.alreadyStarted).toBe(true);
+    expect(result.sessionStartsAt).toBe('2026-05-01T09:00:00.000Z');
+  });
+
+  it('returns status="unavailable" + raceName when session has no startsAt', async () => {
+    fetchNextRace.mockResolvedValue({ raceName: 'No-quali GP' });
+    const now = new Date('2026-05-01T10:00:00Z');
+
+    const result = await getDeadlineSnapshot({ now });
+
+    expect(result).toEqual({
+      status: 'unavailable',
+      raceName: 'No-quali GP',
+      nowIso: '2026-05-01T10:00:00.000Z',
+    });
+  });
+});

--- a/src/cores/nextRaceInfoCore.js
+++ b/src/cores/nextRaceInfoCore.js
@@ -1,0 +1,122 @@
+const {
+  nextRaceInfoCache,
+  sharedKey,
+  weatherForecastCache,
+} = require('../cache');
+const { getWeatherForecast } = require('../utils/weatherApi');
+
+// Reads cached next-race info + opportunistically populates the
+// race/qualifying (and sprint, when applicable) weather snapshot. Both
+// surfaces (Telegram adapter, agent tool) consume this. The Telegram
+// adapter wires `onFetch` / `onError` to bot-side logging helpers; the
+// agent path omits them.
+//
+// Cache-population logic mirrors the original handler byte-for-byte so
+// the existing handler test stays green: the "is cached" check uses
+// `Object.keys(weatherForecastCache).length > 0` (loose, matches prior
+// behavior), and on fetch we populate the same `qualifyingWeather` /
+// `raceWeather` (+ sprint variants) keys.
+async function getNextRaceInfo({ onFetch, onError } = {}) {
+  const nextRaceInfo = nextRaceInfoCache[sharedKey];
+
+  if (!nextRaceInfo) {
+    return { status: 'unavailable' };
+  }
+
+  const isSprintWeekend = nextRaceInfo.weekendFormat === 'sprint';
+  const qualifyingDate = new Date(nextRaceInfo.sessions.qualifying);
+  const raceDate = new Date(nextRaceInfo.sessions.race);
+
+  let sprintQualifyingDate = null;
+  let sprintDate = null;
+  if (isSprintWeekend) {
+    sprintQualifyingDate = new Date(nextRaceInfo.sessions.sprintQualifying);
+    sprintDate = new Date(nextRaceInfo.sessions.sprint);
+  }
+
+  const datesForWeatherApi = [qualifyingDate, raceDate];
+  if (isSprintWeekend) {
+    datesForWeatherApi.push(sprintQualifyingDate, sprintDate);
+  }
+
+  let qualifyingWeather;
+  let raceWeather;
+  let sprintQualifyingWeather;
+  let sprintWeather;
+  let weatherFetchFailed = false;
+
+  const cachedWeatherData = weatherForecastCache;
+  if (cachedWeatherData && Object.keys(cachedWeatherData).length > 0) {
+    qualifyingWeather = cachedWeatherData.qualifyingWeather;
+    raceWeather = cachedWeatherData.raceWeather;
+    if (isSprintWeekend) {
+      sprintQualifyingWeather = cachedWeatherData.sprintQualifyingWeather;
+      sprintWeather = cachedWeatherData.sprintWeather;
+    }
+  } else {
+    try {
+      const weatherForecastsMap = await getWeatherForecast(
+        nextRaceInfo.location.lat,
+        nextRaceInfo.location.long,
+        ...datesForWeatherApi
+      );
+      qualifyingWeather = weatherForecastsMap[qualifyingDate.toISOString()];
+      raceWeather = weatherForecastsMap[raceDate.toISOString()];
+      weatherForecastCache.qualifyingWeather = qualifyingWeather;
+      weatherForecastCache.raceWeather = raceWeather;
+
+      if (isSprintWeekend) {
+        sprintQualifyingWeather =
+          weatherForecastsMap[sprintQualifyingDate.toISOString()];
+        sprintWeather = weatherForecastsMap[sprintDate.toISOString()];
+        weatherForecastCache.sprintQualifyingWeather = sprintQualifyingWeather;
+        weatherForecastCache.sprintWeather = sprintWeather;
+      }
+
+      if (typeof onFetch === 'function') {
+        await onFetch({
+          locality: nextRaceInfo.location.locality,
+          country: nextRaceInfo.location.country,
+        });
+      }
+    } catch (err) {
+      weatherFetchFailed = true;
+      if (typeof onError === 'function') {
+        await onError(err);
+      }
+    }
+  }
+
+  return {
+    status: 'ok',
+    raceName: nextRaceInfo.raceName,
+    circuitName: nextRaceInfo.circuitName,
+    circuitImageUrl: nextRaceInfo.circuitImageUrl,
+    location: nextRaceInfo.location,
+    weekendFormat: nextRaceInfo.weekendFormat,
+    isSprintWeekend,
+    sessions: {
+      qualifying: nextRaceInfo.sessions.qualifying,
+      race: nextRaceInfo.sessions.race,
+      ...(isSprintWeekend
+        ? {
+            sprintQualifying: nextRaceInfo.sessions.sprintQualifying,
+            sprint: nextRaceInfo.sessions.sprint,
+          }
+        : {}),
+    },
+    historicalRaceStats: nextRaceInfo.historicalRaceStats || [],
+    trackHistory: Array.isArray(nextRaceInfo.trackHistory)
+      ? nextRaceInfo.trackHistory
+      : [],
+    weather: {
+      qualifyingWeather,
+      raceWeather,
+      sprintQualifyingWeather,
+      sprintWeather,
+      fetchFailed: weatherFetchFailed,
+    },
+  };
+}
+
+module.exports = { getNextRaceInfo };

--- a/src/cores/nextRaceInfoCore.test.js
+++ b/src/cores/nextRaceInfoCore.test.js
@@ -1,0 +1,155 @@
+jest.mock('../utils/weatherApi', () => ({
+  getWeatherForecast: jest.fn(),
+}));
+
+const { getWeatherForecast } = require('../utils/weatherApi');
+const {
+  nextRaceInfoCache,
+  weatherForecastCache,
+  sharedKey,
+} = require('../cache');
+const { getNextRaceInfo } = require('./nextRaceInfoCore');
+
+const fixture = {
+  raceName: 'Monaco Grand Prix',
+  circuitName: 'Circuit de Monaco',
+  circuitImageUrl: 'http://example.com/circuit.jpg',
+  location: { lat: '43.7', long: '7.4', locality: 'Monte-Carlo', country: 'Monaco' },
+  weekendFormat: 'regular',
+  sessions: {
+    qualifying: '2099-05-24T14:00:00Z',
+    race: '2099-05-25T13:00:00Z',
+  },
+  historicalRaceStats: [{ season: 2024, winner: 'Leclerc' }],
+  trackHistory: [{ lang: 'en', text: 'storied venue' }],
+};
+
+const sprintFixture = {
+  ...fixture,
+  weekendFormat: 'sprint',
+  sessions: {
+    qualifying: '2099-05-24T14:00:00Z',
+    race: '2099-05-25T13:00:00Z',
+    sprintQualifying: '2099-05-24T10:00:00Z',
+    sprint: '2099-05-24T17:00:00Z',
+  },
+};
+
+describe('getNextRaceInfo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete nextRaceInfoCache[sharedKey];
+    Object.keys(weatherForecastCache).forEach(
+      (key) => delete weatherForecastCache[key]
+    );
+  });
+
+  it('returns status="unavailable" when cache empty', async () => {
+    const result = await getNextRaceInfo();
+
+    expect(result).toEqual({ status: 'unavailable' });
+    expect(getWeatherForecast).not.toHaveBeenCalled();
+  });
+
+  it('returns status="ok" with passthrough fields + fresh-fetched weather', async () => {
+    nextRaceInfoCache[sharedKey] = fixture;
+    getWeatherForecast.mockResolvedValue({
+      '2099-05-24T14:00:00.000Z': { temperature: 18, precipitation: 10, wind: 5 },
+      '2099-05-25T13:00:00.000Z': { temperature: 22, precipitation: 0, wind: 3 },
+    });
+
+    const onFetch = jest.fn();
+    const result = await getNextRaceInfo({ onFetch });
+
+    expect(result.status).toBe('ok');
+    expect(result.raceName).toBe('Monaco Grand Prix');
+    expect(result.isSprintWeekend).toBe(false);
+    expect(result.sessions).toEqual({
+      qualifying: '2099-05-24T14:00:00Z',
+      race: '2099-05-25T13:00:00Z',
+    });
+    expect(result.weather.qualifyingWeather).toEqual({
+      temperature: 18,
+      precipitation: 10,
+      wind: 5,
+    });
+    expect(result.weather.raceWeather).toEqual({
+      temperature: 22,
+      precipitation: 0,
+      wind: 3,
+    });
+    expect(result.weather.fetchFailed).toBe(false);
+    expect(onFetch).toHaveBeenCalledWith({
+      locality: 'Monte-Carlo',
+      country: 'Monaco',
+    });
+    expect(weatherForecastCache.qualifyingWeather).toBeDefined();
+    expect(weatherForecastCache.raceWeather).toBeDefined();
+  });
+
+  it('uses cached weather and does not fetch when cache populated', async () => {
+    nextRaceInfoCache[sharedKey] = fixture;
+    weatherForecastCache.qualifyingWeather = { temperature: 19 };
+    weatherForecastCache.raceWeather = { temperature: 24 };
+
+    const onFetch = jest.fn();
+    const result = await getNextRaceInfo({ onFetch });
+
+    expect(getWeatherForecast).not.toHaveBeenCalled();
+    expect(onFetch).not.toHaveBeenCalled();
+    expect(result.weather.qualifyingWeather).toEqual({ temperature: 19 });
+    expect(result.weather.raceWeather).toEqual({ temperature: 24 });
+  });
+
+  it('invokes onError on weather fetch failure and sets fetchFailed=true', async () => {
+    nextRaceInfoCache[sharedKey] = fixture;
+    getWeatherForecast.mockRejectedValue(new Error('boom'));
+
+    const onError = jest.fn();
+    const result = await getNextRaceInfo({ onError });
+
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    expect(result.status).toBe('ok');
+    expect(result.weather.fetchFailed).toBe(true);
+    expect(result.weather.qualifyingWeather).toBeUndefined();
+  });
+
+  it('handles sprint weekend: includes sprint sessions + weather', async () => {
+    nextRaceInfoCache[sharedKey] = sprintFixture;
+    getWeatherForecast.mockResolvedValue({
+      '2099-05-24T14:00:00.000Z': { temperature: 18 },
+      '2099-05-25T13:00:00.000Z': { temperature: 22 },
+      '2099-05-24T10:00:00.000Z': { temperature: 16 },
+      '2099-05-24T17:00:00.000Z': { temperature: 20 },
+    });
+
+    const result = await getNextRaceInfo();
+
+    expect(result.isSprintWeekend).toBe(true);
+    expect(result.sessions).toEqual({
+      qualifying: '2099-05-24T14:00:00Z',
+      race: '2099-05-25T13:00:00Z',
+      sprintQualifying: '2099-05-24T10:00:00Z',
+      sprint: '2099-05-24T17:00:00Z',
+    });
+    expect(result.weather.sprintQualifyingWeather).toEqual({ temperature: 16 });
+    expect(result.weather.sprintWeather).toEqual({ temperature: 20 });
+  });
+
+  it('returns empty arrays for missing historicalRaceStats and trackHistory', async () => {
+    nextRaceInfoCache[sharedKey] = {
+      ...fixture,
+      historicalRaceStats: undefined,
+      trackHistory: undefined,
+    };
+    getWeatherForecast.mockResolvedValue({
+      '2099-05-24T14:00:00.000Z': { temperature: 18 },
+      '2099-05-25T13:00:00.000Z': { temperature: 22 },
+    });
+
+    const result = await getNextRaceInfo();
+
+    expect(result.historicalRaceStats).toEqual([]);
+    expect(result.trackHistory).toEqual([]);
+  });
+});

--- a/src/cores/raceWeatherCore.js
+++ b/src/cores/raceWeatherCore.js
@@ -1,0 +1,114 @@
+const {
+  nextRaceInfoCache,
+  sharedKey,
+  weatherForecastCache,
+} = require('../cache');
+const { getWeatherForecast } = require('../utils/weatherApi');
+
+// Returns the per-session hourly weather snapshot for the next race.
+// Both the Telegram adapter and the agent tool consume this. The
+// `now` argument makes the 3-hour-from-now filter testable. The
+// Telegram adapter wires `onFetch` / `onError` to bot-side logging
+// helpers; the agent path omits them.
+async function getRaceWeather({ now = new Date(), onFetch, onError } = {}) {
+  const nextRaceInfo = nextRaceInfoCache[sharedKey];
+
+  if (!nextRaceInfo) {
+    return { status: 'unavailable' };
+  }
+
+  const qualifyingDate = new Date(nextRaceInfo.sessions.qualifying);
+  const raceDate = new Date(nextRaceInfo.sessions.race);
+  const isSprintWeekend = nextRaceInfo.weekendFormat === 'sprint';
+
+  const sessions = [
+    {
+      key: 'qualifyingHourlyWeather',
+      label: 'Qualifying',
+      start: qualifyingDate,
+    },
+    { key: 'raceHourlyWeather', label: 'Race', start: raceDate },
+  ];
+
+  if (isSprintWeekend) {
+    const sprintQualiDate = new Date(nextRaceInfo.sessions.sprintQualifying);
+    const sprintDate = new Date(nextRaceInfo.sessions.sprint);
+    sessions.push({
+      key: 'sprintQualifyingHourlyWeather',
+      label: 'Sprint Qualifying',
+      start: sprintQualiDate,
+    });
+    sessions.push({
+      key: 'sprintHourlyWeather',
+      label: 'Sprint',
+      start: sprintDate,
+    });
+  }
+
+  sessions.sort((a, b) => a.start - b.start);
+
+  const nowRounded = new Date(
+    Math.floor(now.getTime() / (60 * 60 * 1000)) * 60 * 60 * 1000
+  );
+
+  const timesToFetch = [];
+  sessions.forEach((s) => {
+    s.hours = [
+      s.start,
+      new Date(s.start.getTime() + 60 * 60 * 1000),
+      new Date(s.start.getTime() + 2 * 60 * 60 * 1000),
+    ].filter((h) => h >= nowRounded);
+    s.forecast = weatherForecastCache[s.key];
+    timesToFetch.push(...s.hours);
+  });
+
+  const needFetch = sessions.some((s) => !s.forecast);
+  let fetchFailed = false;
+  if (needFetch) {
+    try {
+      const weatherForecastsMap = await getWeatherForecast(
+        nextRaceInfo.location.lat,
+        nextRaceInfo.location.long,
+        ...timesToFetch
+      );
+      sessions.forEach((s) => {
+        if (!s.forecast) {
+          s.forecast = s.hours.map((h) => weatherForecastsMap[h.toISOString()]);
+          weatherForecastCache[s.key] = s.forecast;
+        }
+      });
+      if (typeof onFetch === 'function') {
+        await onFetch({
+          locality: nextRaceInfo.location.locality,
+          country: nextRaceInfo.location.country,
+        });
+      }
+    } catch (err) {
+      fetchFailed = true;
+      if (typeof onError === 'function') {
+        await onError(err);
+      }
+    }
+  }
+
+  if (sessions.some((s) => !s.forecast)) {
+    return { status: 'unavailable', fetchFailed };
+  }
+
+  return {
+    status: 'ok',
+    raceName: nextRaceInfo.raceName,
+    circuitName: nextRaceInfo.circuitName,
+    location: nextRaceInfo.location,
+    isSprintWeekend,
+    sessions: sessions.map((s) => ({
+      key: s.key,
+      label: s.label,
+      startsAt: s.start.toISOString(),
+      hours: s.hours.map((h) => h.toISOString()),
+      forecasts: s.forecast,
+    })),
+  };
+}
+
+module.exports = { getRaceWeather };

--- a/src/cores/raceWeatherCore.test.js
+++ b/src/cores/raceWeatherCore.test.js
@@ -1,0 +1,183 @@
+jest.mock('../utils/weatherApi', () => ({
+  getWeatherForecast: jest.fn(),
+}));
+
+const { getWeatherForecast } = require('../utils/weatherApi');
+const {
+  nextRaceInfoCache,
+  weatherForecastCache,
+  sharedKey,
+} = require('../cache');
+const { getRaceWeather } = require('./raceWeatherCore');
+
+const baseFixture = {
+  raceName: 'Monaco GP',
+  circuitName: 'Circuit de Monaco',
+  weekendFormat: 'regular',
+  location: { lat: '1', long: '2', locality: 'Town', country: 'Land' },
+  sessions: {
+    qualifying: '2099-05-24T14:00:00Z',
+    race: '2099-05-25T13:00:00Z',
+  },
+};
+
+const sprintFixture = {
+  ...baseFixture,
+  weekendFormat: 'sprint',
+  sessions: {
+    qualifying: '2099-05-24T14:00:00Z',
+    race: '2099-05-25T13:00:00Z',
+    sprintQualifying: '2099-05-24T10:00:00Z',
+    sprint: '2099-05-24T18:00:00Z',
+  },
+};
+
+function buildForecastMap(dates) {
+  const map = {};
+  dates.forEach((d, i) => {
+    map[d.toISOString()] = {
+      temperature: 20 + i,
+      precipitation: 10 + i,
+      precipitation_mm: 0.1 * i,
+      wind: 5 + i,
+      humidity: 50 + i,
+      cloudCover: 30 + i,
+    };
+  });
+
+  return map;
+}
+
+describe('getRaceWeather', () => {
+  const NOW = new Date('2099-01-01T00:00:00Z');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete nextRaceInfoCache[sharedKey];
+    Object.keys(weatherForecastCache).forEach(
+      (key) => delete weatherForecastCache[key]
+    );
+  });
+
+  it('returns status="unavailable" when cache empty', async () => {
+    const result = await getRaceWeather({ now: NOW });
+
+    expect(result).toEqual({ status: 'unavailable' });
+    expect(getWeatherForecast).not.toHaveBeenCalled();
+  });
+
+  it('fetches and returns 3 hours per session for a future regular weekend', async () => {
+    nextRaceInfoCache[sharedKey] = baseFixture;
+    const qualiDate = new Date(baseFixture.sessions.qualifying);
+    const raceDate = new Date(baseFixture.sessions.race);
+    const allDates = [
+      qualiDate,
+      new Date(qualiDate.getTime() + 3600 * 1000),
+      new Date(qualiDate.getTime() + 7200 * 1000),
+      raceDate,
+      new Date(raceDate.getTime() + 3600 * 1000),
+      new Date(raceDate.getTime() + 7200 * 1000),
+    ];
+    getWeatherForecast.mockResolvedValue(buildForecastMap(allDates));
+
+    const onFetch = jest.fn();
+    const result = await getRaceWeather({ now: NOW, onFetch });
+
+    expect(result.status).toBe('ok');
+    expect(result.sessions).toHaveLength(2);
+    expect(result.sessions[0].label).toBe('Qualifying');
+    expect(result.sessions[1].label).toBe('Race');
+    expect(result.sessions[0].hours).toHaveLength(3);
+    expect(result.sessions[0].forecasts).toHaveLength(3);
+    expect(result.sessions[0].startsAt).toBe(qualiDate.toISOString());
+    expect(onFetch).toHaveBeenCalledWith({ locality: 'Town', country: 'Land' });
+    expect(weatherForecastCache.qualifyingHourlyWeather).toHaveLength(3);
+    expect(weatherForecastCache.raceHourlyWeather).toHaveLength(3);
+  });
+
+  it('uses cached hourly forecasts and skips fetch', async () => {
+    nextRaceInfoCache[sharedKey] = baseFixture;
+    const cachedHours = Array(3).fill({
+      temperature: 20,
+      precipitation: 0,
+      precipitation_mm: 0,
+      wind: 1,
+      humidity: 10,
+      cloudCover: 5,
+    });
+    weatherForecastCache.qualifyingHourlyWeather = cachedHours;
+    weatherForecastCache.raceHourlyWeather = cachedHours;
+
+    const onFetch = jest.fn();
+    const result = await getRaceWeather({ now: NOW, onFetch });
+
+    expect(result.status).toBe('ok');
+    expect(getWeatherForecast).not.toHaveBeenCalled();
+    expect(onFetch).not.toHaveBeenCalled();
+    expect(result.sessions[0].forecasts).toBe(cachedHours);
+  });
+
+  it('returns status="unavailable" + fetchFailed=true on fetch failure', async () => {
+    nextRaceInfoCache[sharedKey] = baseFixture;
+    getWeatherForecast.mockRejectedValue(new Error('boom'));
+
+    const onError = jest.fn();
+    const result = await getRaceWeather({ now: NOW, onError });
+
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    expect(result.status).toBe('unavailable');
+    expect(result.fetchFailed).toBe(true);
+  });
+
+  it('filters out hours before nowRounded', async () => {
+    nextRaceInfoCache[sharedKey] = baseFixture;
+    // nowRounded floors to 15:00. Quali starts 14:00 → drops; +1h (15:00) stays;
+    // +2h (16:00) stays. Race is the next day → all 3 hours stay.
+    const nowAfterQualiStart = new Date('2099-05-24T15:30:00Z');
+    const qualiDate = new Date(baseFixture.sessions.qualifying);
+    const raceDate = new Date(baseFixture.sessions.race);
+    const remainingQualiHours = [
+      new Date(qualiDate.getTime() + 3600 * 1000),
+      new Date(qualiDate.getTime() + 2 * 3600 * 1000),
+    ];
+    const remainingRaceHours = [
+      raceDate,
+      new Date(raceDate.getTime() + 3600 * 1000),
+      new Date(raceDate.getTime() + 7200 * 1000),
+    ];
+    getWeatherForecast.mockResolvedValue(
+      buildForecastMap([...remainingQualiHours, ...remainingRaceHours])
+    );
+
+    const result = await getRaceWeather({ now: nowAfterQualiStart });
+
+    expect(result.status).toBe('ok');
+    expect(result.sessions[0].hours).toHaveLength(2);
+    expect(result.sessions[1].hours).toHaveLength(3);
+  });
+
+  it('includes sprint sessions for sprint weekends and sorts chronologically', async () => {
+    nextRaceInfoCache[sharedKey] = sprintFixture;
+    const sprintQualiDate = new Date(sprintFixture.sessions.sprintQualifying);
+    const qualiDate = new Date(sprintFixture.sessions.qualifying);
+    const sprintDate = new Date(sprintFixture.sessions.sprint);
+    const raceDate = new Date(sprintFixture.sessions.race);
+    const allDates = [];
+    [sprintQualiDate, qualiDate, sprintDate, raceDate].forEach((start) => {
+      for (let i = 0; i < 3; i++) {
+        allDates.push(new Date(start.getTime() + i * 3600 * 1000));
+      }
+    });
+    getWeatherForecast.mockResolvedValue(buildForecastMap(allDates));
+
+    const result = await getRaceWeather({ now: NOW });
+
+    expect(result.isSprintWeekend).toBe(true);
+    expect(result.sessions.map((s) => s.label)).toEqual([
+      'Sprint Qualifying',
+      'Qualifying',
+      'Sprint',
+      'Race',
+    ]);
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,9 @@ import { useBestTeamScenariosAction } from './components/BestTeamScenariosMatrix
 import { useUserTeamsAction } from './components/UserTeamsList';
 import { useFollowedTeamsAction } from './components/FollowedTeamsGrid';
 import { useLeaderboardAction } from './components/LeaderboardTable';
+import { useRaceInfoAction } from './components/RaceInfoCard';
+import { useWeatherForecastAction } from './components/WeatherForecast';
+import { useDeadlineCountdownAction } from './components/DeadlineCountdown';
 
 const RUNTIME_URL =
   (import.meta.env.VITE_AGENT_API_URL as string | undefined) ??
@@ -19,6 +22,9 @@ function AgentActions() {
   useLeaderboardAction();
   useBestTeamsAction();
   useBestTeamScenariosAction();
+  useRaceInfoAction();
+  useWeatherForecastAction();
+  useDeadlineCountdownAction();
   return null;
 }
 

--- a/web/src/components/DeadlineCountdown.tsx
+++ b/web/src/components/DeadlineCountdown.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useCopilotAction } from '@copilotkit/react-core';
+
+type DeadlineResult = {
+  status?: 'ok' | 'unavailable';
+  raceName?: string;
+  sessionType?: 'sprint' | 'qualifying';
+  sessionLabel?: string;
+  sessionStartsAt?: string;
+  nowIso?: string;
+  alreadyStarted?: boolean;
+};
+
+type Parts = { days: number; hours: number; minutes: number; seconds: number };
+
+function getParts(ms: number): Parts {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  return {
+    days: Math.floor(totalSeconds / 86400),
+    hours: Math.floor((totalSeconds % 86400) / 3600),
+    minutes: Math.floor((totalSeconds % 3600) / 60),
+    seconds: totalSeconds % 60,
+  };
+}
+
+function pad(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+function formatSessionStart(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  });
+}
+
+function DeadlineCountdown({ result }: { result?: DeadlineResult }) {
+  const sessionStartsAt = result?.sessionStartsAt;
+  const serverNowIso = result?.nowIso;
+
+  // Capture server↔client clock skew at mount so the ticking countdown is
+  // anchored to the server's notion of "now" (which is the source of truth).
+  const clockSkewMs = useMemo(() => {
+    if (!serverNowIso) return 0;
+    const serverNow = new Date(serverNowIso).getTime();
+    const clientNowAtMount = Date.now();
+    if (Number.isNaN(serverNow)) return 0;
+    return serverNow - clientNowAtMount;
+  }, [serverNowIso]);
+
+  const [now, setNow] = useState(() => Date.now() + clockSkewMs);
+
+  useEffect(() => {
+    if (!sessionStartsAt) return;
+    const deadlineMs = new Date(sessionStartsAt).getTime();
+    if (Number.isNaN(deadlineMs)) return;
+    if (deadlineMs <= Date.now() + clockSkewMs) return;
+    const id = window.setInterval(() => {
+      const estimated = Date.now() + clockSkewMs;
+      setNow(estimated);
+      if (estimated >= deadlineMs) {
+        window.clearInterval(id);
+      }
+    }, 1000);
+    return () => window.clearInterval(id);
+  }, [sessionStartsAt, clockSkewMs]);
+
+  if (!result || result.status === 'unavailable') {
+    return (
+      <div style={{ padding: 12, color: '#555' }}>
+        Next deadline isn't available right now.
+      </div>
+    );
+  }
+
+  const sessionType = result.sessionType;
+  const sessionLabel =
+    sessionType === 'sprint'
+      ? 'Sprint'
+      : sessionType === 'qualifying'
+        ? 'Qualifying'
+        : (result.sessionLabel ?? 'session');
+
+  const deadlineMs = sessionStartsAt
+    ? new Date(sessionStartsAt).getTime()
+    : Number.NaN;
+  const remainingMs = Number.isNaN(deadlineMs) ? 0 : deadlineMs - now;
+  const hasStarted = result.alreadyStarted || remainingMs <= 0;
+  const parts = getParts(remainingMs);
+
+  return (
+    <div
+      style={{
+        margin: '8px 0',
+        border: '1px solid #e2e6ee',
+        borderRadius: 12,
+        background:
+          'linear-gradient(135deg, #fff 0%, #f3f7ff 60%, #e8efff 100%)',
+        padding: '16px 18px',
+        fontSize: 13,
+      }}
+    >
+      <div style={{ fontWeight: 700, fontSize: 14, color: '#1c3d70' }}>
+        Teams lock deadline
+      </div>
+      <div style={{ marginTop: 4, color: '#37404f' }}>
+        Race: <strong>{result.raceName ?? '—'}</strong>
+      </div>
+      <div style={{ color: '#37404f', marginBottom: 12 }}>
+        Locks at start of <strong>{sessionLabel}</strong>
+        {sessionStartsAt
+          ? ` · ${formatSessionStart(sessionStartsAt)}`
+          : ''}
+      </div>
+
+      {hasStarted ? (
+        <div
+          style={{
+            padding: '12px 14px',
+            background: '#fff5f5',
+            border: '1px solid #f3c4c4',
+            borderRadius: 8,
+            color: '#7a1f1f',
+            fontWeight: 600,
+          }}
+        >
+          This session has already started.
+        </div>
+      ) : (
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(4, 1fr)',
+            gap: 8,
+          }}
+        >
+          <CountdownCell label="days" value={parts.days} />
+          <CountdownCell label="hours" value={pad(parts.hours)} />
+          <CountdownCell label="min" value={pad(parts.minutes)} />
+          <CountdownCell label="sec" value={pad(parts.seconds)} />
+        </div>
+      )}
+
+      <div style={{ marginTop: 10, color: '#5a6471', fontSize: 12 }}>
+        Don't forget to lock your team before then.
+      </div>
+    </div>
+  );
+}
+
+function CountdownCell({
+  label,
+  value,
+}: {
+  label: string;
+  value: number | string;
+}) {
+  return (
+    <div
+      style={{
+        background: '#fff',
+        border: '1px solid #d6e0f0',
+        borderRadius: 8,
+        textAlign: 'center',
+        padding: '10px 6px',
+      }}
+    >
+      <div style={{ fontSize: 24, fontWeight: 800, color: '#1c3d70' }}>
+        {value}
+      </div>
+      <div
+        style={{
+          fontSize: 11,
+          color: '#5a6471',
+          textTransform: 'uppercase',
+          letterSpacing: 0.6,
+          marginTop: 2,
+        }}
+      >
+        {label}
+      </div>
+    </div>
+  );
+}
+
+export function useDeadlineCountdownAction() {
+  useCopilotAction({
+    name: 'get_deadline',
+    description:
+      'Next F1 Fantasy team-lock deadline with a live ticking countdown.',
+    parameters: [],
+    available: 'frontend',
+    render: ({ status, result }) => {
+      if (status === 'inProgress' || status === 'executing') {
+        return (
+          <div style={{ padding: 10, color: '#666' }}>Loading deadline…</div>
+        );
+      }
+      const parsed = typeof result === 'string' ? safeParse(result) : result;
+      return (
+        <DeadlineCountdown result={parsed as DeadlineResult | undefined} />
+      );
+    },
+  });
+}
+
+function safeParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}

--- a/web/src/components/RaceInfoCard.tsx
+++ b/web/src/components/RaceInfoCard.tsx
@@ -1,0 +1,345 @@
+import { useCopilotAction } from '@copilotkit/react-core';
+
+type Sessions = {
+  qualifying?: string;
+  race?: string;
+  sprintQualifying?: string;
+  sprint?: string;
+};
+
+type WeatherEntry = {
+  temperature?: number;
+  precipitation?: number;
+  wind?: number;
+};
+
+type HistoricalRow = {
+  season?: number | string;
+  winner?: string;
+  constructor?: string;
+  polePosition?: string;
+  poleConstructor?: string;
+  secondPlaceDriver?: string;
+  secondPlaceConstructor?: string;
+  thirdPlaceDriver?: string;
+  thirdPlaceConstructor?: string;
+  carsFinished?: number;
+  overtakes?: number;
+  safetyCars?: number;
+  redFlags?: number;
+};
+
+type TrackHistory = { lang?: string; text?: string };
+
+type RaceInfoResult = {
+  status?: 'ok' | 'unavailable';
+  raceName?: string;
+  circuitName?: string;
+  circuitImageUrl?: string;
+  location?: { locality?: string; country?: string };
+  weekendFormat?: string;
+  isSprintWeekend?: boolean;
+  sessions?: Sessions;
+  historicalRaceStats?: HistoricalRow[];
+  trackHistory?: TrackHistory[];
+  weather?: {
+    qualifyingWeather?: WeatherEntry;
+    raceWeather?: WeatherEntry;
+    sprintQualifyingWeather?: WeatherEntry;
+    sprintWeather?: WeatherEntry;
+    fetchFailed?: boolean;
+  };
+};
+
+function formatIso(iso?: string): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function pickTrackHistory(entries?: TrackHistory[]): string | null {
+  if (!entries || entries.length === 0) return null;
+  const en = entries.find((h) => h.lang === 'en');
+  return (en ?? entries[0]).text ?? null;
+}
+
+function WeatherChip({
+  label,
+  entry,
+}: {
+  label: string;
+  entry?: WeatherEntry;
+}) {
+  if (!entry || entry.temperature === undefined) return null;
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 4,
+        padding: '4px 8px',
+        borderRadius: 999,
+        background: '#eef4ff',
+        color: '#1c3d70',
+        fontSize: 12,
+        fontWeight: 600,
+      }}
+    >
+      <span>{label}</span>
+      <span style={{ color: '#3b5d8e' }}>·</span>
+      <span>🌡 {entry.temperature}°C</span>
+      <span>🌧 {entry.precipitation ?? 0}%</span>
+      <span>💨 {entry.wind ?? 0} km/h</span>
+    </span>
+  );
+}
+
+function RaceInfoCard({ result }: { result?: RaceInfoResult }) {
+  if (!result || result.status === 'unavailable') {
+    return (
+      <div style={{ padding: 12, color: '#555' }}>
+        Race information isn't available right now. Try again in a moment.
+      </div>
+    );
+  }
+
+  const trackText = pickTrackHistory(result.trackHistory);
+  const stats = (result.historicalRaceStats || [])
+    .slice()
+    .sort((a, b) => Number(b.season ?? 0) - Number(a.season ?? 0));
+  const isSprint = result.isSprintWeekend;
+  const sessions = result.sessions || {};
+  const weather = result.weather || {};
+
+  return (
+    <div
+      style={{
+        margin: '8px 0',
+        border: '1px solid #e2e6ee',
+        borderRadius: 10,
+        background: '#fff',
+        overflow: 'hidden',
+        fontSize: 13,
+      }}
+    >
+      <div
+        style={{
+          padding: '12px 16px',
+          background: '#f8fafc',
+          borderBottom: '1px solid #e2e6ee',
+        }}
+      >
+        <div style={{ fontWeight: 700, fontSize: 16 }}>{result.raceName}</div>
+        <div style={{ color: '#5a6471', marginTop: 2 }}>
+          {result.circuitName}
+          {result.location
+            ? ` · ${result.location.locality}, ${result.location.country}`
+            : ''}
+          {result.weekendFormat
+            ? ` · ${result.weekendFormat.toUpperCase()} weekend`
+            : ''}
+        </div>
+      </div>
+
+      {result.circuitImageUrl ? (
+        <div style={{ padding: '12px 16px 0' }}>
+          <img
+            src={result.circuitImageUrl}
+            alt={`${result.circuitName ?? 'Circuit'} map`}
+            style={{
+              maxWidth: '100%',
+              maxHeight: 260,
+              objectFit: 'contain',
+              borderRadius: 6,
+              border: '1px solid #eef0f5',
+            }}
+          />
+        </div>
+      ) : null}
+
+      <div style={{ padding: '12px 16px' }}>
+        <div style={{ fontWeight: 700, marginBottom: 6 }}>Schedule</div>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'auto 1fr',
+            gap: '4px 12px',
+          }}
+        >
+          {isSprint && sessions.sprintQualifying ? (
+            <>
+              <div style={{ color: '#5a6471' }}>Sprint Qualifying</div>
+              <div>{formatIso(sessions.sprintQualifying)}</div>
+            </>
+          ) : null}
+          {isSprint && sessions.sprint ? (
+            <>
+              <div style={{ color: '#5a6471' }}>Sprint</div>
+              <div>{formatIso(sessions.sprint)}</div>
+            </>
+          ) : null}
+          <div style={{ color: '#5a6471' }}>Qualifying</div>
+          <div>{formatIso(sessions.qualifying)}</div>
+          <div style={{ color: '#5a6471' }}>Race</div>
+          <div>{formatIso(sessions.race)}</div>
+        </div>
+        {/* TODO: surface FP1/FP2/FP3 once nextRaceInfoCache tracks them. */}
+      </div>
+
+      {weather.qualifyingWeather && weather.raceWeather ? (
+        <div style={{ padding: '0 16px 12px' }}>
+          <div style={{ fontWeight: 700, marginBottom: 6 }}>
+            Weather forecast
+          </div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+            {isSprint ? (
+              <>
+                <WeatherChip
+                  label="SQ"
+                  entry={weather.sprintQualifyingWeather}
+                />
+                <WeatherChip label="Sprint" entry={weather.sprintWeather} />
+              </>
+            ) : null}
+            <WeatherChip label="Quali" entry={weather.qualifyingWeather} />
+            <WeatherChip label="Race" entry={weather.raceWeather} />
+          </div>
+        </div>
+      ) : null}
+
+      {stats.length > 0 ? (
+        <div style={{ padding: '0 16px 12px' }}>
+          <div style={{ fontWeight: 700, marginBottom: 6 }}>
+            Historical results
+          </div>
+          <table
+            style={{
+              width: '100%',
+              borderCollapse: 'collapse',
+              fontSize: 12,
+            }}
+          >
+            <thead>
+              <tr style={{ background: '#fafbfd', textAlign: 'left' }}>
+                <th style={cellHeader}>Year</th>
+                <th style={cellHeader}>Pole</th>
+                <th style={cellHeader}>Winner</th>
+                <th style={cellHeader}>2nd</th>
+                <th style={cellHeader}>3rd</th>
+                <th style={{ ...cellHeader, textAlign: 'center' }}>
+                  Finished
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {stats.map((row) => (
+                <tr
+                  key={String(row.season)}
+                  style={{ borderTop: '1px solid #f0f2f7' }}
+                >
+                  <td style={cellBody}>{row.season ?? '—'}</td>
+                  <td style={cellBody}>
+                    {row.polePosition ?? '—'}
+                    {row.poleConstructor ? (
+                      <span style={{ color: '#7d8693' }}>
+                        {' '}
+                        ({row.poleConstructor})
+                      </span>
+                    ) : null}
+                  </td>
+                  <td style={cellBody}>
+                    {row.winner ?? '—'}
+                    {row.constructor ? (
+                      <span style={{ color: '#7d8693' }}>
+                        {' '}
+                        ({row.constructor})
+                      </span>
+                    ) : null}
+                  </td>
+                  <td style={cellBody}>{row.secondPlaceDriver ?? '—'}</td>
+                  <td style={cellBody}>{row.thirdPlaceDriver ?? '—'}</td>
+                  <td style={{ ...cellBody, textAlign: 'center' }}>
+                    {row.carsFinished ?? '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+
+      {trackText ? (
+        <div
+          style={{
+            padding: '12px 16px',
+            background: '#fafbfd',
+            borderTop: '1px solid #eef0f5',
+            color: '#444',
+            whiteSpace: 'pre-wrap',
+          }}
+        >
+          <div
+            style={{
+              fontWeight: 700,
+              marginBottom: 6,
+              color: '#222',
+            }}
+          >
+            Track history
+          </div>
+          {trackText}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+const cellHeader: React.CSSProperties = {
+  padding: '6px 10px',
+  fontWeight: 600,
+  fontSize: 11,
+  textTransform: 'uppercase',
+  color: '#666',
+  letterSpacing: 0.4,
+};
+
+const cellBody: React.CSSProperties = {
+  padding: '6px 10px',
+  verticalAlign: 'top',
+};
+
+export function useRaceInfoAction() {
+  useCopilotAction({
+    name: 'get_next_race_info',
+    description:
+      'Get detailed info on the next F1 race: circuit, location, schedule, weather snapshot, historical stats, and track history.',
+    parameters: [],
+    available: 'frontend',
+    render: ({ status, result }) => {
+      if (status === 'inProgress' || status === 'executing') {
+        return (
+          <div style={{ padding: 10, color: '#666' }}>
+            Loading next race info…
+          </div>
+        );
+      }
+      const parsed = typeof result === 'string' ? safeParse(result) : result;
+      return <RaceInfoCard result={parsed as RaceInfoResult | undefined} />;
+    },
+  });
+}
+
+function safeParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}

--- a/web/src/components/WeatherForecast.tsx
+++ b/web/src/components/WeatherForecast.tsx
@@ -1,0 +1,217 @@
+import { useCopilotAction } from '@copilotkit/react-core';
+
+type Forecast = {
+  temperature?: number;
+  humidity?: number;
+  cloudCover?: number;
+  precipitation?: number;
+  precipitation_mm?: number;
+  wind?: number;
+};
+
+type SessionForecast = {
+  key: string;
+  label: string;
+  startsAt: string;
+  hours: string[];
+  forecasts: Forecast[];
+};
+
+type WeatherResult = {
+  status?: 'ok' | 'unavailable';
+  raceName?: string;
+  circuitName?: string;
+  location?: { locality?: string; country?: string };
+  isSprintWeekend?: boolean;
+  sessions?: SessionForecast[];
+  fetchFailed?: boolean;
+};
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function formatSessionStart(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function rainEmoji(precipitation?: number): string {
+  if (precipitation === undefined) return '';
+  if (precipitation >= 70) return '🌧';
+  if (precipitation >= 30) return '🌦';
+  if (precipitation >= 5) return '⛅';
+  return '☀️';
+}
+
+function WeatherForecast({ result }: { result?: WeatherResult }) {
+  if (!result || result.status === 'unavailable') {
+    return (
+      <div style={{ padding: 12, color: '#555' }}>
+        Weather forecast isn't available right now.
+      </div>
+    );
+  }
+
+  const sessions = result.sessions ?? [];
+
+  if (sessions.length === 0) {
+    return (
+      <div style={{ padding: 12, color: '#555' }}>
+        No upcoming sessions to forecast.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        margin: '8px 0',
+        border: '1px solid #e2e6ee',
+        borderRadius: 10,
+        background: '#fff',
+        overflow: 'hidden',
+        fontSize: 13,
+      }}
+    >
+      <div
+        style={{
+          padding: '12px 16px',
+          background: '#f8fafc',
+          borderBottom: '1px solid #e2e6ee',
+        }}
+      >
+        <div style={{ fontWeight: 700, fontSize: 15 }}>
+          Weather forecast — {result.raceName ?? 'Next race'}
+        </div>
+        {result.location ? (
+          <div style={{ color: '#5a6471', marginTop: 2 }}>
+            {result.location.locality}, {result.location.country}
+            {result.circuitName ? ` · ${result.circuitName}` : ''}
+          </div>
+        ) : null}
+      </div>
+
+      {sessions.map((session) => (
+        <div
+          key={session.key}
+          style={{
+            padding: '12px 16px',
+            borderTop: '1px solid #f0f2f7',
+          }}
+        >
+          <div
+            style={{
+              fontWeight: 700,
+              marginBottom: 6,
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: 8,
+              alignItems: 'baseline',
+            }}
+          >
+            <span>{session.label}</span>
+            <span style={{ fontSize: 12, color: '#5a6471', fontWeight: 500 }}>
+              {formatSessionStart(session.startsAt)}
+            </span>
+          </div>
+          {session.hours.length === 0 ? (
+            <div style={{ color: '#888' }}>(already underway)</div>
+          ) : (
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: `repeat(${session.hours.length}, 1fr)`,
+                gap: 8,
+              }}
+            >
+              {session.hours.map((hour, idx) => {
+                const f = session.forecasts[idx] || {};
+                return (
+                  <div
+                    key={hour}
+                    style={{
+                      border: '1px solid #eef0f5',
+                      borderRadius: 8,
+                      padding: '8px 10px',
+                      background: '#fafbfd',
+                    }}
+                  >
+                    <div
+                      style={{
+                        fontSize: 12,
+                        color: '#5a6471',
+                        marginBottom: 4,
+                      }}
+                    >
+                      {formatTime(hour)}
+                    </div>
+                    <div style={{ fontSize: 18, marginBottom: 2 }}>
+                      {rainEmoji(f.precipitation)}
+                    </div>
+                    <div style={{ fontWeight: 700 }}>
+                      {f.temperature ?? '—'}°C
+                    </div>
+                    <div style={{ color: '#5a6471', fontSize: 12 }}>
+                      🌧 {f.precipitation ?? 0}%
+                      {typeof f.precipitation_mm === 'number'
+                        ? ` (${f.precipitation_mm}mm)`
+                        : ''}
+                    </div>
+                    <div style={{ color: '#5a6471', fontSize: 12 }}>
+                      💨 {f.wind ?? '—'} km/h
+                    </div>
+                    <div style={{ color: '#5a6471', fontSize: 12 }}>
+                      💧 {f.humidity ?? '—'}% · ☁️ {f.cloudCover ?? '—'}%
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function useWeatherForecastAction() {
+  useCopilotAction({
+    name: 'get_race_weather',
+    description:
+      'Per-session hourly weather forecast (up to 3 hours per session) for the next F1 race weekend.',
+    parameters: [],
+    available: 'frontend',
+    render: ({ status, result }) => {
+      if (status === 'inProgress' || status === 'executing') {
+        return (
+          <div style={{ padding: 10, color: '#666' }}>
+            Fetching weather forecast…
+          </div>
+        );
+      }
+      const parsed = typeof result === 'string' ? safeParse(result) : result;
+      return <WeatherForecast result={parsed as WeatherResult | undefined} />;
+    },
+  });
+}
+
+function safeParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Phase 4 — race info / weather / deadline

Adds 3 new agent tools backed by pure cores extracted from existing Telegram handlers. Each tool has a tailored React render component on the web frontend. Telegram surface is byte-identical (existing handler tests stay green unchanged).

### New agent tools
- `get_next_race_info` — full info on the next race: circuit, location, weekend format, session timestamps, historical stats, multi-language track history, opportunistic weather snapshot.
- `get_race_weather` — per-session hourly weather forecast (up to 3 hours per session, filtered to drop past hours).
- `get_deadline` — next team-lock deadline. Server returns absolute timestamps; the React component does the live ticking with server-clock skew compensation.

### Cores (all status-tagged, pure)
- `src/cores/nextRaceInfoCore.js` + 6 tests — accepts `onFetch`/`onError` hooks the Telegram adapter wires into `sendLogMessage` / `sendErrorMessage` (matches existing handler test assertions byte-for-byte).
- `src/cores/raceWeatherCore.js` + 6 tests — `now` injection makes the `nowRounded` 3-hour filter testable.
- `src/cores/deadlineCore.js` + 5 tests — additive only. `deadlineHandler.js` is intentionally untouched — its tests import `formatDuration` / `getDeadlineSession` / `buildDeadlineMessage` / `getDeadlinePayload` directly, so the safest extraction was a separate agent-facing snapshot fn that reuses `fetchNextRace` + `getDeadlineSession`.

### Telegram handlers refactored to thin adapters
- `nextRaceInfoHandler.js` — 254 → 209 lines. Test 9/9 pass unchanged.
- `nextRaceWeatherHandler.js` — 130 → 65 lines. Test 3/3 pass unchanged.

### System prompt
New `get_next_race_info` / `get_race_weather` / `get_deadline` routing block placed AFTER scenarios-precedence and team-name rules, with an explicit exclusion clause — *"best team for the next race"* still routes to `get_best_teams`, not `get_next_race_info`.

### React components
- `RaceInfoCard.tsx` — header + circuit image + schedule + weather chips + historical results table + track history.
- `WeatherForecast.tsx` — per-session cards with up to 3 hourly forecast chips each (temp, rain %/mm, wind, humidity, cloud cover, weather emoji).
- `DeadlineCountdown.tsx` — live ticking countdown (days/hours/min/sec). Anchored to the server clock via `nowIso` skew compensation. Stops ticking after deadline passes; cleans up interval on unmount.

### Other
- `eslint.config.mjs` — added an `ignores` entry for `web/dist` / `web/node_modules` / `node_modules` / `coverage` (flat config doesn't auto-read `.eslintignore`, and the new `cd web && npm run build` verification step was tripping the pre-commit hook on bundled syntax).

### Verification
- `npm test` → **792/792** (was 775; +17 new core tests)
- `cd web && npm run build` → clean tsc + Vite build
- Playwright in-browser:
  - *"Tell me about the next race."* → `<RaceInfoCard />` ✅
  - *"What's the weather forecast for the next race?"* → `<WeatherForecast />` ✅
  - *"How long until the next deadline?"* → `<DeadlineCountdown />` ✅ live ticking (24:20 → 23:45 in ~3s)
  - *"best teams for Doron-Kilzi_3"* → `<BestTeamsTable />` ✅ (Phase 1-3 regression intact)

Closes Phase 4 of `docs/agent-rollout-plan.md`.