### PR TITLE
feat: web-agent Phase 5 — current team + live score (v1 capability scope complete)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Both surfaces share the same business logic via **pure cores** in `src/cores/`. 
   - `src/azureStorageService.js` and `src/azureBillingService.js` wrap Azure integrations.
 - **Internationalization:** `src/i18n.js` and `src/translations.js` provide language support (English/Hebrew) used throughout handlers.
 - **AI Assist:** `src/prompts.js` defines system prompts. `/ask`-style natural language queries are handled by `src/commandsHandler/askHandler.js`, which leverages Azure OpenAI to map free-text requests into command sequences.
-- **Logic Cores:** `src/cores/` holds **pure** business-logic functions that take inputs and return structured JSON. They do not depend on `bot`, `t()`, or `sendMessage`. Each Telegram handler is being progressively refactored into `(pure core in src/cores/) + (thin Telegram adapter)`. The same core is consumed by the web-chat agent's tools — so a question like "best teams with VER but no ALO" runs through the same calculator as the `/best_teams` command. **Refactor rule:** existing handler tests must keep passing unchanged after the extraction; if they don't, fix the refactor, not the test. Cores extracted so far: `nextRacesCore`, `bestTeamsCore`, `userTeamsCore`, `followedTeamsCore`, `leaderboardCore`, `bestTeamScenariosCore`, `nextRaceInfoCore`, `raceWeatherCore`, `deadlineCore`. Cores that need side effects (e.g. weather fetch logging) accept optional `onFetch`/`onError` callbacks — the Telegram adapter wires them to bot-side helpers; the agent path omits them.
+- **Logic Cores:** `src/cores/` holds **pure** business-logic functions that take inputs and return structured JSON. They do not depend on `bot`, `t()`, or `sendMessage`. Each Telegram handler is being progressively refactored into `(pure core in src/cores/) + (thin Telegram adapter)`. The same core is consumed by the web-chat agent's tools — so a question like "best teams with VER but no ALO" runs through the same calculator as the `/best_teams` command. **Refactor rule:** existing handler tests must keep passing unchanged after the extraction; if they don't, fix the refactor, not the test. Cores extracted so far: `nextRacesCore`, `bestTeamsCore`, `userTeamsCore`, `followedTeamsCore`, `leaderboardCore`, `bestTeamScenariosCore`, `nextRaceInfoCore`, `raceWeatherCore`, `deadlineCore`, `currentTeamCore`, `liveScoreCore`. Cores that need side effects (e.g. weather fetch logging) accept optional `onFetch`/`onError` callbacks — the Telegram adapter wires them to bot-side helpers; the agent path omits them. Pure scoring helpers shared between a handler and its core live in `src/utils/` (e.g. `src/utils/liveScoreCalc.js` for `mapLockedTeamForScoring` / `calculateLiveScoreBreakdown` / `deriveLiveScoreOptions`) so the core never depends on the adapter.
 - **Agent (Web Chat):** `src/agent/`, `agentWebhook/`, and `web/` together implement a second user-facing surface. Identity is resolved from the `AGENT_HARDCODED_CHAT_ID` env var (v1) so all tool calls operate as that user against the same caches/blobs as the Telegram bot. See the [Agent (Web Chat)](#agent-web-chat) section for the full architecture, the cores↔tools pattern, and how to add a new tool with a matching React component.
 
 ---
@@ -543,7 +543,7 @@ Blob naming includes the team ID:
 
 A second user-facing surface that runs the same business logic as the Telegram bot through tool calls. Architecture, code layout, and the patterns for adding new capabilities live in this section.
 
-Phase-4 capabilities (shipped):
+Phase-5 capabilities (shipped — v1 capability scope is now COMPLETE):
 
 - `get_next_races` — upcoming races for the season (Phase 1).
 - `list_user_teams` — the user's tracked teams (teamId + friendly teamName) (Phase 2).
@@ -555,6 +555,9 @@ Phase-4 capabilities (shipped):
 - `get_next_race_info` — full info on the next race: circuit, location, weekend format (regular/sprint), session timestamps, historical stats, multi-language track history, and opportunistic weather snapshot. Reads `nextRaceInfoCache[sharedKey]` + `weatherForecastCache`; on cache miss the core calls `getWeatherForecast` directly (Phase 4).
 - `get_race_weather` — per-session hourly weather forecast (up to 3 hours per session, filtered to drop hours already in the past) for the next race weekend (Phase 4).
 - `get_deadline` — next team-lock deadline (start of the first locking session: sprint on sprint weekends, qualifying otherwise). Returns absolute timestamps (`sessionStartsAt`, `nowIso`) — the web UI's `<DeadlineCountdown />` ticks client-side with skew compensation so the server's clock stays the source of truth (Phase 4).
+- `get_current_team` — the user's CURRENT saved/selected roster: drivers, constructors, captain, mega-captain, chip, free transfers, cost cap, expected points, expected price change, plus budget-adjusted points when a non-zero ppm preset is set. Resolves team via the same `bestTeamsCore.pickTeamId` pattern (Phase 5). Status-tagged: `ok` / `no_teams` / `unknown_team` / `ambiguous_team` / `missing_cache`.
+- `get_live_score_for_team` — per-team live score breakdown (per-driver / per-constructor points, captain x2 / mega-captain x3 multipliers, transfer penalty, No Negative chip, session breakdowns) for ONE team in ONE followed league. Defaults to the user's `selectedTeam` when no `teamId` / `teamName` provided (Phase 5).
+- `get_live_score_leaderboard` — all-teams live leaderboard for ONE followed league. Sorted by total live points desc (tie-break: total live price change desc). User's row marked with `isSelected: true` for client highlighting (Phase 5).
 
 **Multi-team "every team I track" pattern.** When the user asks a multi-team
 question like _"best teams by points-per-million for every team I track"_,
@@ -640,7 +643,11 @@ f1-fantazy-bot/
 │   │   ├── bestTeamScenariosCore.js  # pure: computeBestTeamScenarios({chatId, teamId?, teamName?}) — 4×4 matrix
 │   │   ├── nextRaceInfoCore.js       # pure: getNextRaceInfo({onFetch?, onError?}) — cache + opportunistic weather
 │   │   ├── raceWeatherCore.js        # pure: getRaceWeather({now?, onFetch?, onError?}) — hourly forecasts
-│   │   └── deadlineCore.js           # pure: getDeadlineSnapshot({now?}) — absolute timestamps for client-side countdown
+│   │   ├── deadlineCore.js           # pure: getDeadlineSnapshot({now?}) — absolute timestamps for client-side countdown
+│   │   ├── currentTeamCore.js        # pure: getCurrentTeam({chatId, teamId?, teamName?}) — current roster + metrics
+│   │   └── liveScoreCore.js          # pure: getLiveScoreForTeam / getLiveScoreLeaderboard — validates league membership
+│   ├── utils/
+│   │   └── liveScoreCalc.js          # pure scoring helpers shared by liveScoreHandler + liveScoreCore
 │   ├── agent/
 │   │   ├── identity.js               # AGENT_HARDCODED_CHAT_ID (LLM never sees it)
 │   │   ├── systemPrompt.js           # English-only v1; built once at startup
@@ -669,7 +676,10 @@ f1-fantazy-bot/
 │   │       ├── BestTeamScenariosMatrix.tsx # useCopilotAction({ name: 'get_best_team_scenarios', available: 'frontend', render })
 │   │       ├── RaceInfoCard.tsx      # useCopilotAction({ name: 'get_next_race_info', available: 'frontend', render })
 │   │       ├── WeatherForecast.tsx   # useCopilotAction({ name: 'get_race_weather', available: 'frontend', render })
-│   │       └── DeadlineCountdown.tsx # useCopilotAction({ name: 'get_deadline', available: 'frontend', render })
+│   │       ├── DeadlineCountdown.tsx # useCopilotAction({ name: 'get_deadline', available: 'frontend', render })
+│   │       ├── CurrentTeamCard.tsx   # useCopilotAction({ name: 'get_current_team', available: 'frontend', render })
+│   │       ├── LiveScoreBreakdown.tsx # useCopilotAction({ name: 'get_live_score_for_team', available: 'frontend', render })
+│   │       └── LiveScoreLeaderboard.tsx # useCopilotAction({ name: 'get_live_score_leaderboard', available: 'frontend', render })
 │   ├── package.json
 │   └── …                             # own package.json — frontend deps don't pollute the backend
 └── scripts/
@@ -822,6 +832,12 @@ npm run dev:web      # only Vite frontend on :5173/:5174
 | `web/src/components/RaceInfoCard.tsx` | `get_next_race_info` rich render — header + circuit image + schedule (quali/race/+sprint pair) + weather chips + historical results table + track history. |
 | `web/src/components/WeatherForecast.tsx` | `get_race_weather` rich render — per-session card with hourly chips: temp, rain %/mm, wind, humidity, cloud cover. |
 | `web/src/components/DeadlineCountdown.tsx` | `get_deadline` rich render — live ticking countdown (days/hours/min/sec) anchored to server clock via `nowIso` skew; stops ticking once deadline passes; collapses to "already started" state when applicable. |
+| `src/cores/currentTeamCore.js` | `getCurrentTeam({chatId, teamId?, teamName?})` — status-tagged (`ok` / `no_teams` / `unknown_team` / `ambiguous_team` / `missing_cache`). Team resolution mirrors `bestTeamsCore.pickTeamId` exactly. Returns `{teamId, teamName, chip, drivers, constructors, boostDriver, extraBoostDriver, freeTransfers, teamInfo: {totalPrice, costCapRemaining, overallBudget, teamExpectedPoints, teamPriceChange}, budgetChangePointsPerMillion, budgetAdjustedPoints, remainingRaceCount}`. |
+| `src/cores/liveScoreCore.js` | `getLiveScoreForTeam({chatId, leagueCode, teamId?, teamName?})` + `getLiveScoreLeaderboard({chatId, leagueCode})` — both validate `leagueCode` against `listUserLeagues(chatId)` before fetching. Per-team mode defaults to the user's `selectedTeam` when no team args. All-teams mode sorts by total live points desc (tie-break: total live price change desc) and marks the user's row with `isSelected`. |
+| `src/utils/liveScoreCalc.js` | Pure scoring helpers extracted in Phase 5 from `liveScoreHandler.js` so both the Telegram surface and the agent core can share `mapLockedTeamForScoring` / `calculateLiveScoreBreakdown` / `deriveLiveScoreOptions`. The handler re-exports these names for back-compat with its existing 735-line test. |
+| `web/src/components/CurrentTeamCard.tsx` | `get_current_team` rich render — team header with chip badge, drivers/constructors chips (boost ⭐, mega-captain 🏆), metrics grid (total price, cost cap remaining, overall budget, expected points, budget-adjusted when ppm preset > 0, expected price change, free transfers). |
+| `web/src/components/LiveScoreBreakdown.tsx` | `get_live_score_for_team` rich render — header with league/matchday/team/last-update; big total-live-points number with pre-penalty + Δ price change; active-chip badges; per-driver and per-constructor cards with effective points × multiplier badge (x2 / x3) + session breakdown (Sprint/Qualifying/Race with POS/PG/OV/FL/DD/TW/FP metrics, only non-zero ones shown). |
+| `web/src/components/LiveScoreLeaderboard.tsx` | `get_live_score_leaderboard` rich render — sortable table (rank, team, live pts, Δ price), user row highlighted with `YOU` badge, `†` marker on rows with transfer penalty, footer note when any row has a penalty. |
 | `scripts/dev-agent-server.js` | Local dev wrapper around `agentWebhook/index.js`. Not deployed. |
 
 ---

--- a/docs/agent-rollout-plan.md
+++ b/docs/agent-rollout-plan.md
@@ -5,15 +5,19 @@ user-facing surface for the Telegram bot, plus the cost-cap data fix
 that fell out of Phase 2. It's structured so anyone can pick up where
 we left off without prior context.
 
-**Current state (2026-05-17):** Phases 1, 2, 3, 4, plus the cost-cap
+**Current state (2026-05-17):** Phases 1, 2, 3, 4, 5, plus the cost-cap
 data-source fix, the api-data `prices.json` producer, and the bot's
 `prices.json` consumer
 ([#183](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/183))
-are all merged. The agent now covers upcoming races, the user's
-tracked teams + leagues + leaderboards, best teams with filters,
-best-team scenarios (ppm × chip matrix), next race info, weather
-forecast, and the lock deadline — each with a tailored React render
-component. Phases 5–6 are planned but not started.
+are all merged. **v1 capability scope is now COMPLETE** — the agent
+covers every read-only Telegram capability with a tailored React
+render component: upcoming races, tracked teams + leagues +
+leaderboards, best teams with filters, best-team scenarios
+(ppm × chip matrix), next race info, weather forecast, lock deadline,
+current saved roster, per-team live score breakdown, and all-teams
+live leaderboard. **Phase 6 (polish & hardening — token logging, error
+UX, CORS lockdown, optional history persistence) is the only remaining
+phase.**
 
 > Read [`AGENTS.md`](../AGENTS.md) → "Agent (Web Chat)" first if you're
 > new to this codebase. That section is the authoritative reference for
@@ -286,7 +290,9 @@ with a tailored component.
 
 ---
 
-## Phase 5 — Current team + live score (last v1 capabilities)
+## Phase 5 — Current team + live score ✅ **MERGED (PR #187)**
+
+Merged via PR [#187](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/187) — **v1 capability scope is now COMPLETE**.
 
 **Goal:** complete the v1 capability scope. After this phase the agent
 covers every read-only thing the Telegram bot can do, each with a
@@ -294,27 +300,42 @@ tailored component.
 
 **Tasks:**
 
-1. Extract cores:
-   - `src/cores/currentTeamCore.js` from `currentTeamInfoHandler.js`
-   - `src/cores/liveScoreCore.js` from `liveScoreHandler.js`
-2. Refactor handlers to adapters; run their Jest tests.
-3. Add two agent tools:
-   - `get_current_team` (args: optional `teamId`).
-   - `get_live_score` (args: `leagueCode`, optional `teamName` — omitted means "all teams").
-4. Build rich components:
-   - `web/src/components/CurrentTeamCard.tsx` — current roster, boost driver, free transfers, cost cap.
-   - `web/src/components/LiveScoreBreakdown.tsx` — per-driver and per-constructor scoring breakdown with captain/mega-captain multipliers visualized.
-   - `web/src/components/LiveScoreLeaderboard.tsx` — all-teams variant.
-   - Register all via `useCopilotAction`.
-5. Tests for new cores + tools.
+1. ✅ Extract cores:
+   - `src/cores/currentTeamCore.js` from `currentTeamInfoHandler.js` — status-tagged (`ok` / `no_teams` / `unknown_team` / `ambiguous_team` / `missing_cache`); team resolution mirrors `bestTeamsCore.pickTeamId` exactly.
+   - `src/cores/liveScoreCore.js` from `liveScoreHandler.js` — three entry points (`getLiveScoreForTeam`, `getLiveScoreLeaderboard`, `listLeagueTeams`); all validate `leagueCode` / `leagueName` against `listUserLeagues(chatId)` before fetching (prevents arbitrary-blob access).
+   - **Companion utils extraction** (per rubber-duck — cleaner than core importing handler): `src/utils/liveScoreCalc.js` — `mapLockedTeamForScoring`, `calculateLiveScoreBreakdown`, `deriveLiveScoreOptions` moved out of `liveScoreHandler.js`. Handler re-exports them for back-compat with its 735-line test (which stays green unchanged).
+2. ✅ Handlers refactored to thin adapters:
+   - `currentTeamInfoHandler.js` — 69 → 57 lines. Test 7/7 pass unchanged.
+   - `liveScoreHandler.js` — 635 → 506 lines (only helper-import move + unused `mapNameToCode` import removed). Test 40/40 pass unchanged.
+3. ✅ **Four** new agent tools (the original spec had two; split during rubber-duck for cleaner UX):
+   - `get_current_team` (args: optional `teamId` / `teamName`).
+   - `list_league_teams` (args: `leagueCode` OR `leagueName`) — returns the FULL roster of a followed league with `isSelected: true` on the user's own team. The system prompt uses this (not `list_followed_teams`) to ask which team to focus on, so the user can pick ANY team in the league just like Telegram `/live_score`.
+   - `get_live_score_for_team` (args: `leagueCode` OR `leagueName`, plus optional `teamId` / `teamName`) — accepts both league forms so the LLM doesn't need to chain `list_user_leagues` first (avoids the `useLazyToolRenderer` multi-step quirk). Has a `teamId` → `teamName` fallback in `pickLockedTeam`.
+   - `get_live_score_leaderboard` (args: `leagueCode` OR `leagueName`) — all-teams view, sorted by live points desc.
+4. ✅ Rich components:
+   - `web/src/components/CurrentTeamCard.tsx` — team header with chip badge, drivers/constructors chips (boost ⭐, mega-captain 🏆), metrics grid (total price, cost cap remaining, overall budget, expected points, budget-adjusted when ppm preset > 0, expected price change, free transfers).
+   - `web/src/components/LiveScoreBreakdown.tsx` — header with league/matchday/team, big total live points (with pre-penalty if applicable), Δ price change, active-chip badges (🛡️ No Negative), per-driver and per-constructor cards with effective points × multiplier badge (x2 / x3) + session breakdowns.
+   - `web/src/components/LiveScoreLeaderboard.tsx` — sortable table (rank, team, live pts, Δ price), user row highlighted with `YOU` badge, `†` marker on penalty rows.
+   - All wired in `web/src/App.tsx`.
+5. ✅ +53 new tests (775 → 828 total).
 
-**Acceptance test:**
+**System prompt — strengthened clarify-and-focus pattern (per user testing feedback):**
 
-- Web app: _"How is my current team doing this race?"_ → renders `<LiveScoreBreakdown />`.
-- Web app: _"Compare my live score across all my followed teams."_ → renders `<LiveScoreLeaderboard />`.
-- Phase 1–4 questions still work.
-- Telegram: `/current_team_info`, `/live_score` → identical to before.
-- `npm test` → all green.
+For live-score questions:
+1. Ask which league (if user follows >1).
+2. Call `list_league_teams` (NOT `list_followed_teams`) to surface the league's FULL roster. The user can pick ANY team in the league, not just their own tracked teams. Mirrors Telegram `/live_score` behavior.
+3. Then call `get_live_score_for_team` ONCE with both `leagueName` + `teamName` so the rich UI render lands reliably.
+
+Strengthened exclusion clause: questions about _projected_, _best_, _future_, _optimized_, or _recommended_ teams stay with `get_best_teams` / `get_best_team_scenarios`, even when phrased as "current race" or "next race".
+
+**Acceptance test:** ✅ all passed in Playwright (fresh browser sessions per prompt)
+
+- Web app: _"Show me my current team"_ → renders `<CurrentTeamCard />` (Kilzid2: drivers/constructors chips, total price 109.40$M, 275.40 expected pts) ✅
+- Web app: _"What's my live score this race?"_ → 3-step clarify-and-focus chain (ask league → "kilzi test" → list all 8 league teams → "HIRSCHEL" → `<LiveScoreBreakdown />` rendered with 142.00 pts — proves any team in the league can be picked, not just the user's own) ✅
+- Web app: _"Show me the live-score leaderboard"_ → ask league → "kilzi test" → `<LiveScoreLeaderboard />` rendered as sorted table (233 → 95 pts, Δ price column visible) ✅
+- Phase 1–4 regression (_"How long until the next deadline?"_) → `<DeadlineCountdown />` ticking ✅
+- Telegram: `/current_team_info`, `/live_score` byte-identical (handler tests 7/7 + 40/40 unchanged) ✅
+- `npm test` → 828/828 green ✅
 
 ---
 

--- a/src/agent/systemPrompt.js
+++ b/src/agent/systemPrompt.js
@@ -39,6 +39,16 @@ Available tools:
 - get_deadline — next team-lock deadline (start of the first locking
   session: sprint on sprint weekends, qualifying otherwise). Returns
   absolute timestamps; the web UI handles the live countdown.
+- get_current_team — the user's CURRENT saved/selected roster: drivers,
+  constructors, captain, mega-captain, chip, cost cap, expected points,
+  expected price change.
+- get_live_score_for_team — per-team live score breakdown (per-driver
+  and per-constructor points with captain/mega-captain multipliers,
+  transfer penalty, chip effects) for ONE team in ONE followed league.
+  Defaults to the user's selected team when no teamId/teamName.
+- get_live_score_leaderboard — all-teams live-score leaderboard for
+  ONE followed league, sorted by current live points. User's own team
+  row is marked for highlighting.
 
 Workflow rules:
 - **Scenarios questions take precedence.** When the user mentions
@@ -124,6 +134,49 @@ Workflow rules:
   in text — the web UI renders a live ticking countdown component.
   Briefly mention the race name and session type ("Sprint" or
   "Qualifying") in your reply, but don't restate "X days Y hours...".
+- **Current team / live score routing.**
+  - "Show my current team", "what's my team", "my roster", "my
+    drivers", "my chip", "my cost cap", "expected points for my
+    team" → call **get_current_team**.
+  - "My live score", "live points", "how am I doing this race",
+    "live breakdown" → **clarify-and-focus**:
+    1. If the user did NOT name a league, ask which league they want
+       (surface names from list_user_leagues if needed). If they
+       follow only ONE league, you may skip this step and use that
+       league.
+    2. After they pick a league, call **list_league_teams** with
+       the leagueName (or leagueCode) to get the league\\'s FULL
+       roster, then ask the user which team. **DO NOT use
+       list_followed_teams here** — that returns only the user\\'s
+       own tracked teams (a subset). The user wants to be able to
+       pick ANY team in the league\\'s roster, just like the
+       Telegram /live_score command. The roster from
+       list_league_teams marks the user\\'s own team with
+       \`isSelected: true\` — surface that distinction in your reply.
+    3. ONLY after you have BOTH a leagueName (or leagueCode) AND a
+       teamName (or teamId), call **get_live_score_for_team** ONCE.
+       Pass leagueName + teamName in a single tool call so the rich
+       UI render lands reliably.
+  - "All teams live", "compare live scores in [league]", "where do
+    I rank live this race" → **clarify-and-focus on league only**:
+    1. If the user did NOT name a league, ask which league.
+    2. THEN call **get_live_score_leaderboard** ONCE with
+       leagueName (or leagueCode). No team picking needed for the
+       leaderboard view.
+  - **Exclusion (CRITICAL):** Use \`get_current_team\` ONLY when the
+    user asks what roster they currently HAVE saved or selected. If
+    they ask what the team SHOULD be, ask for optimization /
+    recommendations / best lineup / projected lineup / next-race
+    lineup, use \`get_best_teams\` or \`get_best_team_scenarios\`
+    instead — even if they say "current race" or "next race". For
+    example: "best team for the next race" → get_best_teams (NOT
+    get_current_team). "optimize my current team" → get_best_teams.
+    "who should I have for the next race?" → get_best_teams.
+  - Multi-team handling: if \`get_current_team\` returns
+    \`ambiguous_team\`, surface the candidates (\`teamIds\` field) and
+    ask which one. For live-score across multiple leagues, call
+    \`list_user_leagues\` and ask which league. Same clarify-and-focus
+    pattern as other tools.
 
 Style rules:
 - Answer in English.

--- a/src/agent/tools.js
+++ b/src/agent/tools.js
@@ -23,6 +23,12 @@ const { getLeaderboard } = require('../cores/leaderboardCore');
 const { getNextRaceInfo } = require('../cores/nextRaceInfoCore');
 const { getRaceWeather } = require('../cores/raceWeatherCore');
 const { getDeadlineSnapshot } = require('../cores/deadlineCore');
+const { getCurrentTeam } = require('../cores/currentTeamCore');
+const {
+  getLiveScoreForTeam,
+  getLiveScoreLeaderboard,
+  listLeagueTeams,
+} = require('../cores/liveScoreCore');
 const { listUserLeagues } = require('../leagueRegistryService');
 const { getAgentChatId } = require('./identity');
 const { ensureCacheReady } = require('./cacheBootstrap');
@@ -280,6 +286,130 @@ const tools = [
     execute: async () => {
       // No cache needed — fetchNextRace pulls fresh from the schedule service.
       return await getDeadlineSnapshot();
+    },
+  }),
+
+  defineTool({
+    name: 'get_current_team',
+    description:
+      "Get the user's CURRENT saved/selected F1 Fantasy roster — what they currently HAVE, not what they should have or what's best. Returns { status, teamId, teamName, chip, drivers, constructors, boostDriver, extraBoostDriver, freeTransfers, teamInfo: { totalPrice, costCapRemaining, overallBudget, teamExpectedPoints, teamPriceChange }, budgetChangePointsPerMillion, budgetAdjustedPoints }. status=`no_teams` means the user hasn't uploaded a team yet. status=`ambiguous_team` means they have multiple teams and no selection — surface the candidates and ask which team to focus on. status=`unknown_team` means the supplied teamId/teamName didn't match. status=`missing_cache` means drivers or constructors data is missing. NEVER call this when the user asks for projected/best/future/recommended/optimized teams — use `get_best_teams` or `get_best_team_scenarios` instead.",
+    parameters: z.object({
+      teamId: z
+        .string()
+        .optional()
+        .describe(
+          'Canonical team identifier returned by list_user_teams / list_followed_teams. Preferred over teamName.',
+        ),
+      teamName: z
+        .string()
+        .optional()
+        .describe(
+          'Exact teamName. Used only when teamId is not provided.',
+        ),
+    }),
+    execute: async (args) => {
+      await ensureCacheReady();
+      const chatId = getAgentChatId();
+
+      return await getCurrentTeam({
+        chatId,
+        teamId: args.teamId,
+        teamName: args.teamName,
+      });
+    },
+  }),
+
+  defineTool({
+    name: 'list_league_teams',
+    description:
+      'List ALL teams in one of the user\'s followed leagues (the league\'s full roster, NOT just the teams the user tracks). Use this when you need to surface the picker for "which team in this league" before calling get_live_score_for_team. Returns { status, leagueCode, leagueName, matchdayId, teams: [{ teamId, teamName, userName, teamNo, position, isSelected }] } sorted by position ascending. `isSelected: true` marks the user\'s own team in this league. Statuses: ok / not_followed / not_found / invalid_input. Pass EITHER `leagueCode` OR `leagueName` (display name, case-insensitive substring match).',
+    parameters: z.object({
+      leagueCode: z.string().optional(),
+      leagueName: z.string().optional(),
+    }),
+    execute: async (args) => {
+      await ensureCacheReady();
+      const chatId = getAgentChatId();
+
+      return await listLeagueTeams({
+        chatId,
+        leagueCode: args.leagueCode,
+        leagueName: args.leagueName,
+      });
+    },
+  }),
+
+  defineTool({
+    name: 'get_live_score_for_team',
+    description:
+      'Get the live-score breakdown for ONE team in one of the user\'s followed leagues (per-driver / per-constructor points with captain/mega-captain multipliers, transfer penalty, and chip effects). **REQUIRES the user to have already chosen both a league AND a team** — do NOT call this tool until you have both. The clarify-and-focus pattern is: ask which league first, then ask which team in that league, then call this tool ONCE with leagueName + teamName. Pass EITHER `leagueCode` (canonical) OR `leagueName` (display name — the tool resolves it against the user\'s followed leagues). Identify the team via `teamId` (canonical, from list_followed_teams) or `teamName` (display name from the league\'s roster). Returns { status, leagueCode, leagueName, matchdayId, extractedAt, teamId, teamName, breakdown: { totalPoints, pointsBeforePenalty, transferPenalty, noNegativeApplied, totalPriceChange, driverBreakdown: [{ code, points, priceChange, details, isBoost, isExtraBoost, missing }], constructorBreakdown: [...], missingMembers } }. Statuses: ok / not_followed / not_found / team_not_found (includes `availableTeams` for asking the user) / invalid_input.',
+    parameters: z.object({
+      leagueCode: z
+        .string()
+        .optional()
+        .describe(
+          'Canonical league code. Provide this if you already have it; otherwise use leagueName.',
+        ),
+      leagueName: z
+        .string()
+        .optional()
+        .describe(
+          'League display name as the user typed it (case-insensitive substring match against the user\'s followed leagues).',
+        ),
+      teamId: z
+        .string()
+        .optional()
+        .describe(
+          'Canonical team identifier from list_followed_teams. Preferred over teamName.',
+        ),
+      teamName: z
+        .string()
+        .optional()
+        .describe(
+          'Team name as shown in the league\'s roster. Used only when teamId is not provided.',
+        ),
+    }),
+    execute: async (args) => {
+      await ensureCacheReady();
+      const chatId = getAgentChatId();
+
+      return await getLiveScoreForTeam({
+        chatId,
+        leagueCode: args.leagueCode,
+        leagueName: args.leagueName,
+        teamId: args.teamId,
+        teamName: args.teamName,
+      });
+    },
+  }),
+
+  defineTool({
+    name: 'get_live_score_leaderboard',
+    description:
+      'Get the live-score leaderboard for ALL teams in one of the user\'s followed leagues, sorted by current live points (tie-break: total live price change). The user\'s own team row is marked with `isSelected: true` so the frontend can highlight it. Pass EITHER `leagueCode` (canonical) OR `leagueName` (display name — the tool resolves it against the user\'s followed leagues). Use for "compare live scores in [league]", "all teams live", "where do I rank live this race". Returns { status, leagueCode, leagueName, matchdayId, extractedAt, selectedTeamId, rows: [{ teamId, teamName, userName, teamNo, position, totalPoints, totalPriceChange, transferPenalty, isSelected }] }. Statuses: ok / not_followed / not_found / invalid_input. **Prefer passing `leagueName` directly** rather than calling list_user_leagues first — one tool call per question lands the rich UI render reliably.',
+    parameters: z.object({
+      leagueCode: z
+        .string()
+        .optional()
+        .describe(
+          'Canonical league code. Provide this if you already have it; otherwise use leagueName.',
+        ),
+      leagueName: z
+        .string()
+        .optional()
+        .describe(
+          'League display name as the user typed it. The tool resolves this against the user\'s followed leagues (case-insensitive substring match). Provide this when the user named a league by display name — DO NOT call list_user_leagues first.',
+        ),
+    }),
+    execute: async (args) => {
+      await ensureCacheReady();
+      const chatId = getAgentChatId();
+
+      return await getLiveScoreLeaderboard({
+        chatId,
+        leagueCode: args.leagueCode,
+        leagueName: args.leagueName,
+      });
     },
   }),
 ];

--- a/src/commandsHandler/currentTeamInfoHandler.js
+++ b/src/commandsHandler/currentTeamInfoHandler.js
@@ -1,13 +1,5 @@
-const { calculateTeamInfo, calculateBudgetAdjustedPoints } = require('../utils');
-const {
-  currentTeamCache,
-  sharedKey,
-  resolveSelectedTeam,
-  getBestTeamBudgetChangePointsPerMillion,
-  remainingRaceCountCache,
-  getDriversForChat,
-  getConstructorsForChat,
-} = require('../cache');
+const { resolveSelectedTeam } = require('../cache');
+const { getCurrentTeam } = require('../cores/currentTeamCore');
 const { t } = require('../i18n');
 
 async function calcCurrentTeamInfo(bot, chatId) {
@@ -16,11 +8,9 @@ async function calcCurrentTeamInfo(bot, chatId) {
     return;
   }
 
-  const drivers = getDriversForChat(chatId);
-  const constructors = getConstructorsForChat(chatId);
-  const currentTeam = currentTeamCache[chatId]?.[teamId];
+  const result = await getCurrentTeam({ chatId, teamId });
 
-  if (!drivers || !constructors || !currentTeam) {
+  if (result.status === 'missing_cache') {
     await bot
       .sendMessage(
         chatId,
@@ -36,15 +26,13 @@ async function calcCurrentTeamInfo(bot, chatId) {
     return;
   }
 
-  const teamInfo = calculateTeamInfo(currentTeam, drivers, constructors);
-  const budgetChangePointsPerMillion =
-    getBestTeamBudgetChangePointsPerMillion(chatId, teamId);
-  const budgetAdjustedPoints = calculateBudgetAdjustedPoints(
-    teamInfo.teamExpectedPoints,
-    teamInfo.teamPriceChange,
-    budgetChangePointsPerMillion,
-    remainingRaceCountCache[sharedKey],
-  );
+  if (result.status !== 'ok') {
+    // resolveSelectedTeam already handled the no_teams / ambiguous_team
+    // user paths. Any other status here would mean a coding error.
+    return;
+  }
+
+  const { teamInfo, budgetChangePointsPerMillion, budgetAdjustedPoints } = result;
 
   const message =
     `*${t('Current Team Info', chatId)}:*\n` +

--- a/src/commandsHandler/liveScoreHandler.js
+++ b/src/commandsHandler/liveScoreHandler.js
@@ -4,18 +4,21 @@ const {
 } = require('../azureStorageService');
 const { listUserLeagues } = require('../leagueRegistryService');
 const { getSelectedTeam } = require('../cache');
-const { mapNameToCode } = require('../utils/leagueTeamHelpers');
 const {
   sanitizeTeamName,
   buildLeagueTeamId,
 } = require('../utils/teamId');
+const {
+  mapLockedTeamForScoring,
+  calculateLiveScoreBreakdown,
+  deriveLiveScoreOptions,
+} = require('../utils/liveScoreCalc');
 const { t } = require('../i18n');
 const { formatDateTime, sendErrorMessage } = require('../utils');
 const {
   COMMAND_FOLLOW_LEAGUE,
   LIVE_SCORE_CALLBACK_TYPE,
   LIVE_SCORE_ACTIONS,
-  EXTRA_TRANSFER_PENALTY_POINTS,
 } = require('../constants');
 
 const SESSION_METRICS = ['POS', 'PG', 'OV', 'FL', 'DD', 'TW', 'FP'];
@@ -34,22 +37,11 @@ function escapeHtml(value) {
  * `calculateLiveScoreBreakdown`. Names are mapped to bot codes via
  * `mapNameToCode`; captain / mega-captain are identified by the
  * per-driver `isCaptain` / `isMegaCaptain` flags.
+ *
+ * Phase-5 NOTE: implementation moved to `src/utils/liveScoreCalc.js`.
+ * Kept here only as a re-export for back-compat with the handler's test
+ * which imports it directly from this module.
  */
-function mapLockedTeamForScoring(lockedTeam) {
-  const drivers = Array.isArray(lockedTeam?.drivers) ? lockedTeam.drivers : [];
-  const constructors = Array.isArray(lockedTeam?.constructors)
-    ? lockedTeam.constructors
-    : [];
-  const captain = drivers.find((d) => d?.isCaptain);
-  const megaCaptain = drivers.find((d) => d?.isMegaCaptain);
-
-  return {
-    drivers: drivers.map((d) => mapNameToCode(d.name)),
-    constructors: constructors.map((c) => mapNameToCode(c.name)),
-    boostDriver: captain ? mapNameToCode(captain.name) : null,
-    extraBoostDriver: megaCaptain ? mapNameToCode(megaCaptain.name) : null,
-  };
-}
 
 function formatSignedDelta(value) {
   const numericValue = Number(value) || 0;
@@ -106,134 +98,11 @@ function joinMembersWithEmptyLine(members, chatId) {
   return members.map((member) => formatMemberLine(member, chatId)).join('\n\n');
 }
 
-function getLiveMemberData(bucket = {}, code) {
-  const memberData = bucket[code];
-
-  if (!memberData) {
-    return {
-      points: 0,
-      priceChange: 0,
-      details: {},
-      missing: true,
-    };
-  }
-
-  return {
-    points: Number(memberData.TotalPoints) || 0,
-    priceChange: Number(memberData.PriceChange) || 0,
-    details: memberData,
-    missing: false,
-  };
-}
-
-function calculateLiveScoreBreakdown(realTeam, liveScoreData, options = {}) {
-  const noNegativeActive = Boolean(options.noNegativeActive);
-  const transferPenalty = Math.max(
-    0,
-    Number(options.transferPenalty) || 0,
-  );
-  const driversData = liveScoreData.drivers || {};
-  const constructorsData = liveScoreData.constructors || {};
-  const boostDriver = realTeam.boostDriver;
-  const extraBoostDriver = realTeam.extraBoostDriver;
-
-  // Apply No Negative clamp on the per-member scoring `points` so the
-  // captain / mega-captain multipliers (added below) never amplify a
-  // negative score that should have been zeroed out first.
-  const clampPoints = (raw) =>
-    noNegativeActive ? Math.max(0, raw) : raw;
-
-  const driverBreakdown = realTeam.drivers.map((driverCode) => {
-    const member = getLiveMemberData(driversData, driverCode);
-
-    return {
-      code: driverCode,
-      ...member,
-      points: clampPoints(member.points),
-      isBoost: boostDriver === driverCode,
-      isExtraBoost: extraBoostDriver === driverCode,
-    };
-  });
-
-  const constructorBreakdown = realTeam.constructors.map((constructorCode) => {
-    const member = getLiveMemberData(constructorsData, constructorCode);
-
-    return {
-      code: constructorCode,
-      ...member,
-      points: clampPoints(member.points),
-      isBoost: false,
-      isExtraBoost: false,
-    };
-  });
-
-  const pointsBeforePenalty =
-    driverBreakdown.reduce(
-      (sum, driver) =>
-        sum +
-        driver.points +
-        (driver.isExtraBoost
-          ? driver.points * 2
-          : driver.isBoost
-            ? driver.points
-            : 0),
-      0,
-    ) + constructorBreakdown.reduce((sum, constructor) => sum + constructor.points, 0);
-
-  const totalPoints = pointsBeforePenalty - transferPenalty;
-
-  const totalPriceChange =
-    driverBreakdown.reduce((sum, driver) => sum + driver.priceChange, 0) +
-    constructorBreakdown.reduce((sum, constructor) => sum + constructor.priceChange, 0);
-
-  const missingMembers = [...driverBreakdown, ...constructorBreakdown]
-    .filter((member) => member.missing)
-    .map((member) => member.code);
-
-  return {
-    totalPoints,
-    pointsBeforePenalty,
-    transferPenalty,
-    noNegativeApplied: noNegativeActive,
-    totalPriceChange,
-    driverBreakdown,
-    constructorBreakdown,
-    missingMembers,
-  };
-}
-
-/**
- * Derive the live-score `options` for a team from its locked-snapshot
- * entry. Inspects the team's own `chipsUsed` and `transfersRemaining`:
- *   - Wildcard / Limitless active for THIS matchday → transfer penalty waived.
- *   - No Negative active for THIS matchday → flag noNegativeActive.
- *   - Otherwise → 10 pts × |min(transfersRemaining, 0)| transfer penalty.
- *
- * "Active for this matchday" means the chip's `gameDayId` equals the
- * snapshot's `matchdayId`. (`gameDayId` is misleadingly named — its
- * value is the matchday the chip was activated for; see Phase 6.)
- */
-function deriveLiveScoreOptions(lockedTeam) {
-  const matchdayId = lockedTeam?.matchdayId;
-  const chipsThisMatch = (
-    Array.isArray(lockedTeam?.chipsUsed) ? lockedTeam.chipsUsed : []
-  ).filter((c) => c && c.gameDayId === matchdayId);
-  const noNegativeActive = chipsThisMatch.some(
-    (c) => c.name === 'No Negative',
-  );
-  const wildcardOrLimitless = chipsThisMatch.some(
-    (c) => c.name === 'Wildcard' || c.name === 'Limitless',
-  );
-  const transfersRemainingRaw = Number(lockedTeam?.transfersRemaining);
-  const overTransfers = Number.isFinite(transfersRemainingRaw)
-    ? Math.max(0, -transfersRemainingRaw)
-    : 0;
-  const transferPenalty = wildcardOrLimitless
-    ? 0
-    : overTransfers * EXTRA_TRANSFER_PENALTY_POINTS;
-
-  return { noNegativeActive, transferPenalty };
-}
+// `getLiveMemberData`, `calculateLiveScoreBreakdown`, and
+// `deriveLiveScoreOptions` were moved to `src/utils/liveScoreCalc.js`
+// in Phase 5 — see top-of-file require. Module.exports below still
+// re-exports `calculateLiveScoreBreakdown` / `deriveLiveScoreOptions` /
+// `mapLockedTeamForScoring` for back-compat with this handler's test.
 
 function callbackData(action, ...payload) {
   return [LIVE_SCORE_CALLBACK_TYPE, action, ...payload].join(':');

--- a/src/cores/currentTeamCore.js
+++ b/src/cores/currentTeamCore.js
@@ -1,0 +1,132 @@
+// Pure current-team core — no `bot`, no `t()`, no `sendMessage`. Both the
+// Telegram adapter (`commandsHandler/currentTeamInfoHandler.js`) and the
+// web-chat agent tool (`agent/tools.js`) call into this.
+//
+// Status-tagged result: 'ok' / 'no_teams' / 'unknown_team' /
+// 'ambiguous_team' / 'missing_cache'.
+//
+// Team resolution mirrors `bestTeamsCore.pickTeamId` so all team-resolving
+// agent tools behave identically.
+
+// IMPORTANT: import calc helpers via `'../utils'` (NOT `'../utils/utils'`).
+// `currentTeamInfoHandler.test.js` does `jest.mock('../utils', () => ({
+//   calculateTeamInfo: ..., calculateBudgetAdjustedPoints: ... }))` and
+// the mock only intercepts the bare `'../utils'` path.
+const { calculateTeamInfo, calculateBudgetAdjustedPoints } = require('../utils');
+const {
+  currentTeamCache,
+  selectedChipCache,
+  sharedKey,
+  remainingRaceCountCache,
+  getSelectedTeam,
+  getUserTeamIds,
+  getBestTeamBudgetChangePointsPerMillion,
+  getDriversForChat,
+  getConstructorsForChat,
+} = require('../cache');
+
+function pickTeamId({ chatId, requestedTeamId, requestedTeamName }) {
+  const teamIds = getUserTeamIds(chatId);
+  if (teamIds.length === 0) {
+    return { status: 'no_teams' };
+  }
+
+  if (requestedTeamId) {
+    if (!teamIds.includes(requestedTeamId)) {
+      return { status: 'unknown_team', teamId: requestedTeamId, teamIds };
+    }
+
+    return { status: 'ok', teamId: requestedTeamId };
+  }
+
+  if (requestedTeamName) {
+    const matches = teamIds.filter(
+      (id) => currentTeamCache[chatId]?.[id]?.teamName === requestedTeamName,
+    );
+    if (matches.length === 1) {
+      return { status: 'ok', teamId: matches[0] };
+    }
+    if (matches.length > 1) {
+      return { status: 'ambiguous_team', teamIds: matches };
+    }
+
+    return { status: 'unknown_team', teamName: requestedTeamName, teamIds };
+  }
+
+  if (teamIds.length === 1) {
+    return { status: 'ok', teamId: teamIds[0] };
+  }
+
+  const selected = getSelectedTeam(chatId);
+  if (selected && teamIds.includes(selected)) {
+    return { status: 'ok', teamId: selected };
+  }
+
+  return { status: 'ambiguous_team', teamIds };
+}
+
+async function getCurrentTeam({ chatId, teamId, teamName } = {}) {
+  const pick = pickTeamId({
+    chatId,
+    requestedTeamId: teamId,
+    requestedTeamName: teamName,
+  });
+  if (pick.status !== 'ok') {
+    return pick;
+  }
+
+  const resolvedTeamId = pick.teamId;
+  const drivers = getDriversForChat(chatId);
+  const constructors = getConstructorsForChat(chatId);
+  const currentTeam = currentTeamCache[chatId]?.[resolvedTeamId];
+
+  if (!drivers || !constructors || !currentTeam) {
+    return {
+      status: 'missing_cache',
+      teamId: resolvedTeamId,
+      missing: {
+        drivers: !drivers,
+        constructors: !constructors,
+        currentTeam: !currentTeam,
+      },
+    };
+  }
+
+  const teamInfo = calculateTeamInfo(currentTeam, drivers, constructors);
+  const budgetChangePointsPerMillion = getBestTeamBudgetChangePointsPerMillion(
+    chatId,
+    resolvedTeamId,
+  );
+  const remainingRaceCount = remainingRaceCountCache[sharedKey];
+  const budgetAdjustedPoints = calculateBudgetAdjustedPoints(
+    teamInfo.teamExpectedPoints,
+    teamInfo.teamPriceChange,
+    budgetChangePointsPerMillion,
+    remainingRaceCount,
+  );
+
+  return {
+    status: 'ok',
+    teamId: resolvedTeamId,
+    teamName: currentTeam.teamName || null,
+    chip: selectedChipCache[chatId]?.[resolvedTeamId] || null,
+    drivers: currentTeam.drivers,
+    constructors: currentTeam.constructors,
+    boostDriver: currentTeam.boostDriver || null,
+    extraBoostDriver: currentTeam.extraBoostDriver || null,
+    freeTransfers: currentTeam.freeTransfers ?? null,
+    teamInfo: {
+      totalPrice: teamInfo.totalPrice,
+      costCapRemaining: teamInfo.costCapRemaining,
+      overallBudget: teamInfo.overallBudget,
+      teamExpectedPoints: teamInfo.teamExpectedPoints,
+      teamPriceChange: teamInfo.teamPriceChange,
+    },
+    budgetChangePointsPerMillion,
+    budgetAdjustedPoints:
+      budgetChangePointsPerMillion > 0 ? budgetAdjustedPoints : null,
+    remainingRaceCount: remainingRaceCount ?? null,
+  };
+}
+
+module.exports = { getCurrentTeam, pickTeamId };

--- a/src/cores/currentTeamCore.test.js
+++ b/src/cores/currentTeamCore.test.js
@@ -1,0 +1,169 @@
+const mockCalculateTeamInfo = jest.fn();
+const mockCalculateBudgetAdjustedPoints = jest.fn();
+
+jest.mock('../utils', () => ({
+  calculateTeamInfo: mockCalculateTeamInfo,
+  calculateBudgetAdjustedPoints: mockCalculateBudgetAdjustedPoints,
+}));
+
+const {
+  currentTeamCache,
+  driversCache,
+  constructorsCache,
+  selectedChipCache,
+  userCache,
+  remainingRaceCountCache,
+  sharedKey,
+  pricesCache,
+} = require('../cache');
+const { getCurrentTeam } = require('./currentTeamCore');
+
+const CHAT_ID = 12345;
+const TEAM_ID = 'Doron-Kilzi_1';
+
+describe('getCurrentTeam', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete currentTeamCache[CHAT_ID];
+    delete driversCache[CHAT_ID];
+    delete constructorsCache[CHAT_ID];
+    delete selectedChipCache[CHAT_ID];
+    delete userCache[String(CHAT_ID)];
+    delete remainingRaceCountCache[sharedKey];
+    pricesCache.drivers = {};
+    pricesCache.constructors = {};
+    pricesCache.metadata = null;
+    mockCalculateTeamInfo.mockReset();
+    mockCalculateBudgetAdjustedPoints.mockReset();
+  });
+
+  it('returns no_teams when the user has zero teams', async () => {
+    const result = await getCurrentTeam({ chatId: CHAT_ID });
+    expect(result).toEqual({ status: 'no_teams' });
+  });
+
+  it('returns missing_cache when drivers cache is empty', async () => {
+    currentTeamCache[CHAT_ID] = {
+      [TEAM_ID]: { drivers: ['VER'], constructors: ['MCL'] },
+    };
+    constructorsCache[CHAT_ID] = { MCL: { price: 10 } };
+    // driversCache absent
+
+    const result = await getCurrentTeam({ chatId: CHAT_ID });
+    expect(result.status).toBe('missing_cache');
+    expect(result.missing.drivers).toBe(true);
+  });
+
+  it('auto-picks the only team when teamId / teamName not provided', async () => {
+    currentTeamCache[CHAT_ID] = {
+      [TEAM_ID]: { teamName: 'Kilzi', drivers: ['VER'], constructors: ['MCL'] },
+    };
+    driversCache[CHAT_ID] = { VER: { price: 30 } };
+    constructorsCache[CHAT_ID] = { MCL: { price: 10 } };
+    mockCalculateTeamInfo.mockReturnValue({
+      totalPrice: 40,
+      costCapRemaining: 60,
+      overallBudget: 100,
+      teamExpectedPoints: 120,
+      teamPriceChange: 0.5,
+    });
+    mockCalculateBudgetAdjustedPoints.mockReturnValue(125);
+
+    const result = await getCurrentTeam({ chatId: CHAT_ID });
+
+    expect(result.status).toBe('ok');
+    expect(result.teamId).toBe(TEAM_ID);
+    expect(result.teamName).toBe('Kilzi');
+    expect(result.teamInfo.totalPrice).toBe(40);
+    expect(result.teamInfo.teamExpectedPoints).toBe(120);
+    // ppm default is 0 → budgetAdjustedPoints null
+    expect(result.budgetAdjustedPoints).toBeNull();
+  });
+
+  it('returns budgetAdjustedPoints when ppm preset > 0', async () => {
+    currentTeamCache[CHAT_ID] = {
+      [TEAM_ID]: { teamName: 'Kilzi', drivers: ['VER'], constructors: ['MCL'] },
+    };
+    driversCache[CHAT_ID] = { VER: { price: 30 } };
+    constructorsCache[CHAT_ID] = { MCL: { price: 10 } };
+    userCache[String(CHAT_ID)] = {
+      bestTeamBudgetChangePointsPerMillion: { [TEAM_ID]: 1.3 },
+    };
+    remainingRaceCountCache[sharedKey] = 5;
+    mockCalculateTeamInfo.mockReturnValue({
+      totalPrice: 40,
+      costCapRemaining: 60,
+      overallBudget: 100,
+      teamExpectedPoints: 120,
+      teamPriceChange: 1.0,
+    });
+    mockCalculateBudgetAdjustedPoints.mockReturnValue(125.5);
+
+    const result = await getCurrentTeam({ chatId: CHAT_ID });
+
+    expect(result.status).toBe('ok');
+    expect(result.budgetChangePointsPerMillion).toBe(1.3);
+    expect(result.budgetAdjustedPoints).toBe(125.5);
+    expect(result.remainingRaceCount).toBe(5);
+  });
+
+  it('returns unknown_team when teamId not in cache', async () => {
+    currentTeamCache[CHAT_ID] = {
+      [TEAM_ID]: { drivers: [], constructors: [] },
+    };
+    const result = await getCurrentTeam({ chatId: CHAT_ID, teamId: 'OTHER' });
+    expect(result.status).toBe('unknown_team');
+    expect(result.teamIds).toContain(TEAM_ID);
+  });
+
+  it('returns ambiguous_team when >1 team and no selection', async () => {
+    currentTeamCache[CHAT_ID] = {
+      [TEAM_ID]: { drivers: [], constructors: [] },
+      OTHER: { drivers: [], constructors: [] },
+    };
+    const result = await getCurrentTeam({ chatId: CHAT_ID });
+    expect(result.status).toBe('ambiguous_team');
+    expect(result.teamIds).toEqual(expect.arrayContaining([TEAM_ID, 'OTHER']));
+  });
+
+  it('resolves teamName to teamId on exact match', async () => {
+    currentTeamCache[CHAT_ID] = {
+      [TEAM_ID]: { teamName: 'Kilzi', drivers: ['VER'], constructors: ['MCL'] },
+      OTHER: { teamName: 'Other', drivers: ['VER'], constructors: ['MCL'] },
+    };
+    driversCache[CHAT_ID] = { VER: { price: 30 } };
+    constructorsCache[CHAT_ID] = { MCL: { price: 10 } };
+    mockCalculateTeamInfo.mockReturnValue({
+      totalPrice: 40,
+      costCapRemaining: 60,
+      overallBudget: 100,
+      teamExpectedPoints: 100,
+      teamPriceChange: 0,
+    });
+    mockCalculateBudgetAdjustedPoints.mockReturnValue(100);
+
+    const result = await getCurrentTeam({ chatId: CHAT_ID, teamName: 'Kilzi' });
+    expect(result.status).toBe('ok');
+    expect(result.teamId).toBe(TEAM_ID);
+  });
+
+  it('exposes selected chip when present', async () => {
+    currentTeamCache[CHAT_ID] = {
+      [TEAM_ID]: { teamName: 'Kilzi', drivers: ['VER'], constructors: ['MCL'] },
+    };
+    driversCache[CHAT_ID] = { VER: { price: 30 } };
+    constructorsCache[CHAT_ID] = { MCL: { price: 10 } };
+    selectedChipCache[CHAT_ID] = { [TEAM_ID]: 'EXTRA_BOOST' };
+    mockCalculateTeamInfo.mockReturnValue({
+      totalPrice: 40,
+      costCapRemaining: 60,
+      overallBudget: 100,
+      teamExpectedPoints: 100,
+      teamPriceChange: 0,
+    });
+    mockCalculateBudgetAdjustedPoints.mockReturnValue(100);
+
+    const result = await getCurrentTeam({ chatId: CHAT_ID });
+    expect(result.chip).toBe('EXTRA_BOOST');
+  });
+});

--- a/src/cores/liveScoreCore.js
+++ b/src/cores/liveScoreCore.js
@@ -1,0 +1,320 @@
+// Pure live-score core — no `bot`, no `t()`, no `sendMessage`. Used by
+// the web-chat agent's `get_live_score_for_team` and
+// `get_live_score_leaderboard` tools. The Telegram `/live_score` flow
+// is interactive (callback keyboards) and intentionally NOT routed
+// through this core — the existing handler stays unchanged.
+//
+// Two entry points:
+//   - getLiveScoreForTeam({chatId, leagueCode, teamId?, teamName?})
+//     → status-tagged per-team breakdown
+//   - getLiveScoreLeaderboard({chatId, leagueCode})
+//     → status-tagged all-teams leaderboard
+//
+// Both validate `leagueCode` against the user's followed leagues
+// (`listUserLeagues`) before fetching the Azure blob — mirrors
+// `leaderboardCore` so the agent can't read arbitrary league data.
+
+const {
+  getLiveScoreData,
+  getLockedTeamsData,
+} = require('../azureStorageService');
+const { listUserLeagues } = require('../leagueRegistryService');
+const { getSelectedTeam } = require('../cache');
+const {
+  sanitizeTeamName,
+  buildLeagueTeamId,
+} = require('../utils/teamId');
+const {
+  mapLockedTeamForScoring,
+  calculateLiveScoreBreakdown,
+  deriveLiveScoreOptions,
+} = require('../utils/liveScoreCalc');
+
+// Resolve `leagueCode` OR `leagueName` against the user's followed leagues.
+// Accepting either avoids forcing the LLM to chain `list_user_leagues`
+// → `get_live_score_*` (which triggers the CopilotKit
+// `useLazyToolRenderer` multi-step quirk and drops the second render).
+async function ensureFollowed({ chatId, leagueCode, leagueName }) {
+  if (
+    (typeof leagueCode !== 'string' || !leagueCode.trim()) &&
+    (typeof leagueName !== 'string' || !leagueName.trim())
+  ) {
+    return {
+      status: 'invalid_input',
+      reason: 'leagueCode or leagueName required',
+    };
+  }
+  const leagues = (await listUserLeagues(chatId)) || [];
+  let match = null;
+  if (leagueCode) {
+    match = leagues.find((l) => l.leagueCode === leagueCode);
+  }
+  if (!match && leagueName) {
+    const normalized = leagueName.trim().toLowerCase();
+    match =
+      leagues.find(
+        (l) => (l.leagueName || '').toLowerCase() === normalized,
+      ) ||
+      leagues.find((l) =>
+        (l.leagueName || '').toLowerCase().includes(normalized),
+      );
+  }
+  if (!match) {
+    return { status: 'not_followed', leagueCode, leagueName };
+  }
+
+  return {
+    status: 'ok',
+    leagueCode: match.leagueCode,
+    leagueName: match.leagueName || match.leagueCode,
+  };
+}
+
+function pickLockedTeam({ snapshot, teamId, teamName }) {
+  const teams = Array.isArray(snapshot?.teams) ? snapshot.teams : [];
+  if (teams.length === 0) {
+    return { status: 'team_not_found' };
+  }
+
+  // Try teamId match first.
+  if (teamId) {
+    const match = teams.find(
+      (t) => buildLeagueTeamId(t.userName, t.teamNo) === teamId,
+    );
+    if (match) {
+      return { status: 'ok', team: match };
+    }
+    // Fall through to teamName matching if available — buildLeagueTeamId
+    // formatting may differ from how selectedTeam was generated when the
+    // user's account name has non-ASCII or unusual characters.
+  }
+
+  if (teamName) {
+    const exact = teams.find(
+      (t) => (t.teamName || t.userName) === teamName,
+    );
+    if (exact) {
+      return { status: 'ok', team: exact };
+    }
+    const slug = sanitizeTeamName(teamName);
+    const sanitizedMatch = teams.find(
+      (t) =>
+        sanitizeTeamName(t.teamName || t.userName || 'team') === slug,
+    );
+    if (sanitizedMatch) {
+      return { status: 'ok', team: sanitizedMatch };
+    }
+  }
+
+  if (teamId || teamName) {
+    return { status: 'team_not_found', teamId, teamName };
+  }
+
+  // No team args at all → caller will default to selectedTeam or
+  // request clarification.
+  return { status: 'ok', team: null };
+}
+
+async function getLiveScoreForTeam({
+  chatId,
+  leagueCode,
+  leagueName,
+  teamId,
+  teamName,
+} = {}) {
+  const followed = await ensureFollowed({ chatId, leagueCode, leagueName });
+  if (followed.status !== 'ok') {
+    return followed;
+  }
+
+  const resolvedLeagueCode = followed.leagueCode;
+
+  let snapshot;
+  let liveScoreData;
+  try {
+    [snapshot, liveScoreData] = await Promise.all([
+      getLockedTeamsData(resolvedLeagueCode),
+      getLiveScoreData(),
+    ]);
+  } catch (err) {
+    return {
+      status: 'not_found',
+      leagueCode: resolvedLeagueCode,
+      error: err.message,
+    };
+  }
+
+  if (!snapshot || !Array.isArray(snapshot.teams) || snapshot.teams.length === 0) {
+    return { status: 'not_found', leagueCode: resolvedLeagueCode };
+  }
+
+  // No auto-default to selectedTeam — the LLM must ASK which team via the
+  // clarify-and-focus pattern. When no team args are supplied, return
+  // team_not_found with availableTeams so the LLM can surface options.
+  const pick = pickLockedTeam({
+    snapshot,
+    teamId,
+    teamName,
+  });
+  if (pick.status !== 'ok' || !pick.team) {
+    return {
+      status: 'team_not_found',
+      leagueCode: resolvedLeagueCode,
+      leagueName: followed.leagueName,
+      teamId,
+      teamName,
+      reason: pick.team ? undefined : 'no_team_specified',
+      availableTeams: snapshot.teams.map((t) => ({
+        teamName: t.teamName,
+        userName: t.userName,
+        teamNo: t.teamNo,
+        position: t.position,
+        teamId: buildLeagueTeamId(t.userName, t.teamNo),
+      })),
+    };
+  }
+
+  const match = pick.team;
+  const realTeam = mapLockedTeamForScoring(match);
+  const options = deriveLiveScoreOptions(match);
+  const breakdown = calculateLiveScoreBreakdown(realTeam, liveScoreData, options);
+
+  return {
+    status: 'ok',
+    leagueCode: resolvedLeagueCode,
+    leagueName: snapshot.leagueName || followed.leagueName,
+    matchdayId: snapshot.matchdayId ?? null,
+    extractedAt: liveScoreData?.extractedAt ?? null,
+    teamId: buildLeagueTeamId(match.userName, match.teamNo),
+    teamName: match.teamName || match.userName || null,
+    userName: match.userName || null,
+    position: match.position ?? null,
+    breakdown,
+  };
+}
+
+async function getLiveScoreLeaderboard({
+  chatId,
+  leagueCode,
+  leagueName,
+} = {}) {
+  const followed = await ensureFollowed({ chatId, leagueCode, leagueName });
+  if (followed.status !== 'ok') {
+    return followed;
+  }
+
+  const resolvedLeagueCode = followed.leagueCode;
+
+  let snapshot;
+  let liveScoreData;
+  try {
+    [snapshot, liveScoreData] = await Promise.all([
+      getLockedTeamsData(resolvedLeagueCode),
+      getLiveScoreData(),
+    ]);
+  } catch (err) {
+    return {
+      status: 'not_found',
+      leagueCode: resolvedLeagueCode,
+      error: err.message,
+    };
+  }
+
+  if (!snapshot || !Array.isArray(snapshot.teams) || snapshot.teams.length === 0) {
+    return { status: 'not_found', leagueCode: resolvedLeagueCode };
+  }
+
+  const selectedTeamId = getSelectedTeam(chatId);
+
+  const rows = snapshot.teams.map((team) => {
+    const realTeam = mapLockedTeamForScoring(team);
+    const options = deriveLiveScoreOptions(team);
+    const { totalPoints, totalPriceChange, transferPenalty } =
+      calculateLiveScoreBreakdown(realTeam, liveScoreData, options);
+    const teamId = buildLeagueTeamId(team.userName, team.teamNo);
+
+    return {
+      teamId,
+      teamName: team.teamName || team.userName || null,
+      userName: team.userName || null,
+      teamNo: team.teamNo ?? null,
+      position: team.position ?? null,
+      totalPoints,
+      totalPriceChange,
+      transferPenalty,
+      isSelected: !!teamId && teamId === selectedTeamId,
+    };
+  });
+
+  rows.sort((a, b) => {
+    if (b.totalPoints !== a.totalPoints) {
+      return b.totalPoints - a.totalPoints;
+    }
+
+    return b.totalPriceChange - a.totalPriceChange;
+  });
+
+  return {
+    status: 'ok',
+    leagueCode: resolvedLeagueCode,
+    leagueName: snapshot.leagueName || followed.leagueName,
+    matchdayId: snapshot.matchdayId ?? null,
+    extractedAt: liveScoreData?.extractedAt ?? null,
+    selectedTeamId: selectedTeamId || null,
+    rows,
+  };
+}
+
+async function listLeagueTeams({ chatId, leagueCode, leagueName } = {}) {
+  const followed = await ensureFollowed({ chatId, leagueCode, leagueName });
+  if (followed.status !== 'ok') {
+    return followed;
+  }
+
+  const resolvedLeagueCode = followed.leagueCode;
+
+  let snapshot;
+  try {
+    snapshot = await getLockedTeamsData(resolvedLeagueCode);
+  } catch (err) {
+    return {
+      status: 'not_found',
+      leagueCode: resolvedLeagueCode,
+      error: err.message,
+    };
+  }
+
+  if (!snapshot || !Array.isArray(snapshot.teams) || snapshot.teams.length === 0) {
+    return { status: 'not_found', leagueCode: resolvedLeagueCode };
+  }
+
+  const selectedTeamId = getSelectedTeam(chatId);
+  const teams = [...snapshot.teams]
+    .sort((a, b) => (a.position || Infinity) - (b.position || Infinity))
+    .map((t) => {
+      const teamId = buildLeagueTeamId(t.userName, t.teamNo);
+
+      return {
+        teamId,
+        teamName: t.teamName || t.userName || null,
+        userName: t.userName || null,
+        teamNo: t.teamNo ?? null,
+        position: t.position ?? null,
+        isSelected: !!teamId && teamId === selectedTeamId,
+      };
+    });
+
+  return {
+    status: 'ok',
+    leagueCode: resolvedLeagueCode,
+    leagueName: snapshot.leagueName || followed.leagueName,
+    matchdayId: snapshot.matchdayId ?? null,
+    teams,
+  };
+}
+
+module.exports = {
+  getLiveScoreForTeam,
+  getLiveScoreLeaderboard,
+  listLeagueTeams,
+};

--- a/src/cores/liveScoreCore.test.js
+++ b/src/cores/liveScoreCore.test.js
@@ -1,0 +1,401 @@
+jest.mock('../azureStorageService', () => ({
+  getLiveScoreData: jest.fn(),
+  getLockedTeamsData: jest.fn(),
+}));
+
+jest.mock('../leagueRegistryService', () => ({
+  listUserLeagues: jest.fn(),
+}));
+
+jest.mock('../cache', () => ({
+  getSelectedTeam: jest.fn(),
+}));
+
+jest.mock('../utils/leagueTeamHelpers', () => ({
+  mapNameToCode: (name) => name,
+}));
+
+const {
+  getLiveScoreData,
+  getLockedTeamsData,
+} = require('../azureStorageService');
+const { listUserLeagues } = require('../leagueRegistryService');
+const { getSelectedTeam } = require('../cache');
+const { buildLeagueTeamId } = require('../utils/teamId');
+const {
+  getLiveScoreForTeam,
+  getLiveScoreLeaderboard,
+  listLeagueTeams,
+} = require('./liveScoreCore');
+
+const CHAT_ID = 12345;
+const LEAGUE_CODE = 'TESTLEAGUE';
+
+const baseLockedTeam = (overrides = {}) => ({
+  teamName: 'Kilzi',
+  userName: 'Doron-Kilzi',
+  teamNo: 1,
+  position: 1,
+  drivers: [
+    { name: 'VER', isCaptain: true },
+    { name: 'HAM' },
+  ],
+  constructors: [{ name: 'MCL' }],
+  transfersRemaining: 1,
+  chipsUsed: [],
+  matchdayId: 5,
+  ...overrides,
+});
+
+const baseLiveScoreData = {
+  extractedAt: '2026-05-17T12:00:00Z',
+  drivers: {
+    VER: { TotalPoints: 30, PriceChange: 1.0 },
+    HAM: { TotalPoints: 10, PriceChange: 0.2 },
+  },
+  constructors: {
+    MCL: { TotalPoints: 15, PriceChange: 0.5 },
+  },
+};
+
+describe('getLiveScoreForTeam', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getSelectedTeam.mockReturnValue(null);
+  });
+
+  it('returns invalid_input when both leagueCode and leagueName are missing', async () => {
+    const result = await getLiveScoreForTeam({ chatId: CHAT_ID });
+    expect(result.status).toBe('invalid_input');
+  });
+
+  it('returns not_followed when user does not follow leagueCode', async () => {
+    listUserLeagues.mockResolvedValue([]);
+    const result = await getLiveScoreForTeam({
+      chatId: CHAT_ID,
+      leagueCode: LEAGUE_CODE,
+    });
+    expect(result.status).toBe('not_followed');
+  });
+
+  it('resolves leagueName (case-insensitive substring) to leagueCode', async () => {
+    listUserLeagues.mockResolvedValue([
+      { leagueCode: LEAGUE_CODE, leagueName: 'Kilzi Test' },
+    ]);
+    getLockedTeamsData.mockResolvedValue({
+      leagueName: 'Kilzi Test',
+      matchdayId: 5,
+      teams: [baseLockedTeam()],
+    });
+    getLiveScoreData.mockResolvedValue(baseLiveScoreData);
+
+    const result = await getLiveScoreForTeam({
+      chatId: CHAT_ID,
+      leagueName: 'kilzi test',
+      teamName: 'Kilzi',
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.leagueCode).toBe(LEAGUE_CODE);
+    expect(getLockedTeamsData).toHaveBeenCalledWith(LEAGUE_CODE);
+  });
+
+  it('falls back from teamId (no match) to teamName when both are explicitly provided', async () => {
+    // Verifies pickLockedTeam's teamId→teamName fallback chain.
+    listUserLeagues.mockResolvedValue([
+      { leagueCode: LEAGUE_CODE, leagueName: 'Test League' },
+    ]);
+    getLockedTeamsData.mockResolvedValue({
+      leagueName: 'Test League',
+      matchdayId: 5,
+      // userName WITHOUT the dash that the teamId was built with, so
+      // buildLeagueTeamId(t.userName, t.teamNo) won't match the supplied
+      // teamId — but the teamName fallback should fire.
+      teams: [
+        baseLockedTeam({ userName: 'Doron K', teamNo: 2, teamName: 'Kilzid2' }),
+      ],
+    });
+    getLiveScoreData.mockResolvedValue(baseLiveScoreData);
+
+    const result = await getLiveScoreForTeam({
+      chatId: CHAT_ID,
+      leagueCode: LEAGUE_CODE,
+      teamId: 'Doron-Kilzi_2',
+      teamName: 'Kilzid2',
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.teamName).toBe('Kilzid2');
+  });
+
+  it('returns not_found when locked snapshot is empty', async () => {
+    listUserLeagues.mockResolvedValue([
+      { leagueCode: LEAGUE_CODE, leagueName: 'Test League' },
+    ]);
+    getLockedTeamsData.mockResolvedValue({ teams: [] });
+    getLiveScoreData.mockResolvedValue(baseLiveScoreData);
+
+    const result = await getLiveScoreForTeam({
+      chatId: CHAT_ID,
+      leagueCode: LEAGUE_CODE,
+    });
+    expect(result.status).toBe('not_found');
+  });
+
+  it('returns ok with breakdown when teamName matches', async () => {
+    listUserLeagues.mockResolvedValue([
+      { leagueCode: LEAGUE_CODE, leagueName: 'Test League' },
+    ]);
+    getLockedTeamsData.mockResolvedValue({
+      leagueName: 'Test League',
+      matchdayId: 5,
+      teams: [baseLockedTeam()],
+    });
+    getLiveScoreData.mockResolvedValue(baseLiveScoreData);
+
+    const result = await getLiveScoreForTeam({
+      chatId: CHAT_ID,
+      leagueCode: LEAGUE_CODE,
+      teamName: 'Kilzi',
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.leagueName).toBe('Test League');
+    expect(result.matchdayId).toBe(5);
+    expect(result.extractedAt).toBe('2026-05-17T12:00:00Z');
+    // VER 30 + 30 (boost) + HAM 10 + MCL 15 = 85
+    expect(result.breakdown.totalPoints).toBe(85);
+    expect(result.breakdown.driverBreakdown).toHaveLength(2);
+    expect(result.teamId).toBe(buildLeagueTeamId('Doron-Kilzi', 1));
+  });
+
+  it('returns ok with breakdown when teamId matches', async () => {
+    const teamId = buildLeagueTeamId('Doron-Kilzi', 1);
+    listUserLeagues.mockResolvedValue([
+      { leagueCode: LEAGUE_CODE, leagueName: 'Test League' },
+    ]);
+    getLockedTeamsData.mockResolvedValue({
+      leagueName: 'Test League',
+      matchdayId: 5,
+      teams: [baseLockedTeam()],
+    });
+    getLiveScoreData.mockResolvedValue(baseLiveScoreData);
+
+    const result = await getLiveScoreForTeam({
+      chatId: CHAT_ID,
+      leagueCode: LEAGUE_CODE,
+      teamId,
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.teamId).toBe(teamId);
+  });
+
+  it('returns team_not_found with availableTeams when no team args are provided (no selectedTeam fallback)', async () => {
+    // Per design: the LLM must ASK which team via clarify-and-focus.
+    // The core no longer auto-defaults to selectedTeam.
+    const teamId = buildLeagueTeamId('Doron-Kilzi', 1);
+    getSelectedTeam.mockReturnValue(teamId);
+    listUserLeagues.mockResolvedValue([
+      { leagueCode: LEAGUE_CODE, leagueName: 'Test League' },
+    ]);
+    getLockedTeamsData.mockResolvedValue({
+      leagueName: 'Test League',
+      matchdayId: 5,
+      teams: [baseLockedTeam()],
+    });
+    getLiveScoreData.mockResolvedValue(baseLiveScoreData);
+
+    const result = await getLiveScoreForTeam({
+      chatId: CHAT_ID,
+      leagueCode: LEAGUE_CODE,
+    });
+
+    expect(result.status).toBe('team_not_found');
+    expect(result.reason).toBe('no_team_specified');
+    expect(result.availableTeams).toHaveLength(1);
+  });
+
+  it('returns team_not_found with availableTeams when teamName not in snapshot', async () => {
+    listUserLeagues.mockResolvedValue([
+      { leagueCode: LEAGUE_CODE, leagueName: 'Test League' },
+    ]);
+    getLockedTeamsData.mockResolvedValue({
+      leagueName: 'Test League',
+      matchdayId: 5,
+      teams: [baseLockedTeam()],
+    });
+    getLiveScoreData.mockResolvedValue(baseLiveScoreData);
+
+    const result = await getLiveScoreForTeam({
+      chatId: CHAT_ID,
+      leagueCode: LEAGUE_CODE,
+      teamName: 'Nonexistent',
+    });
+
+    expect(result.status).toBe('team_not_found');
+    expect(result.availableTeams).toHaveLength(1);
+  });
+});
+
+describe('getLiveScoreLeaderboard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getSelectedTeam.mockReturnValue(null);
+  });
+
+  it('returns ok with sorted rows + isSelected highlight', async () => {
+    const selectedId = buildLeagueTeamId('Doron-Kilzi', 1);
+    getSelectedTeam.mockReturnValue(selectedId);
+    listUserLeagues.mockResolvedValue([
+      { leagueCode: LEAGUE_CODE, leagueName: 'Test League' },
+    ]);
+    getLockedTeamsData.mockResolvedValue({
+      leagueName: 'Test League',
+      matchdayId: 5,
+      teams: [
+        baseLockedTeam({ userName: 'Other', teamNo: 1, position: 2 }),
+        baseLockedTeam(), // Doron-Kilzi_1 has VER captain
+      ],
+    });
+    getLiveScoreData.mockResolvedValue(baseLiveScoreData);
+
+    const result = await getLiveScoreLeaderboard({
+      chatId: CHAT_ID,
+      leagueCode: LEAGUE_CODE,
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.rows).toHaveLength(2);
+    // Both teams have the same drivers/constructors → identical scores
+    // (sort tie-break: totalPriceChange). The selected team should still
+    // get isSelected = true.
+    const selectedRow = result.rows.find((r) => r.teamId === selectedId);
+    expect(selectedRow).toBeDefined();
+    expect(selectedRow.isSelected).toBe(true);
+    expect(result.selectedTeamId).toBe(selectedId);
+  });
+
+  it('returns not_followed when leagueCode not in user leagues', async () => {
+    listUserLeagues.mockResolvedValue([]);
+    const result = await getLiveScoreLeaderboard({
+      chatId: CHAT_ID,
+      leagueCode: LEAGUE_CODE,
+    });
+    expect(result.status).toBe('not_followed');
+  });
+
+  it('sorts by totalPoints desc with totalPriceChange as tie-break', async () => {
+    listUserLeagues.mockResolvedValue([
+      { leagueCode: LEAGUE_CODE, leagueName: 'Test League' },
+    ]);
+    getLockedTeamsData.mockResolvedValue({
+      leagueName: 'Test League',
+      matchdayId: 5,
+      teams: [
+        baseLockedTeam({
+          userName: 'Low',
+          teamNo: 1,
+          drivers: [{ name: 'HAM' }],
+          constructors: [],
+        }),
+        baseLockedTeam({
+          userName: 'High',
+          teamNo: 1,
+          drivers: [{ name: 'VER', isCaptain: true }],
+          constructors: [{ name: 'MCL' }],
+        }),
+      ],
+    });
+    getLiveScoreData.mockResolvedValue(baseLiveScoreData);
+
+    const result = await getLiveScoreLeaderboard({
+      chatId: CHAT_ID,
+      leagueCode: LEAGUE_CODE,
+    });
+    expect(result.rows[0].userName).toBe('High');
+    expect(result.rows[0].totalPoints).toBeGreaterThan(result.rows[1].totalPoints);
+  });
+});
+
+describe('listLeagueTeams', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getSelectedTeam.mockReturnValue(null);
+  });
+
+  it('returns ALL teams in the league (the full roster), sorted by position asc', async () => {
+    listUserLeagues.mockResolvedValue([
+      { leagueCode: LEAGUE_CODE, leagueName: 'Kilzi Test' },
+    ]);
+    getLockedTeamsData.mockResolvedValue({
+      leagueName: 'Kilzi Test',
+      matchdayId: 5,
+      teams: [
+        baseLockedTeam({ userName: 'B', teamNo: 1, teamName: 'B-team', position: 3 }),
+        baseLockedTeam({ userName: 'A', teamNo: 1, teamName: 'A-team', position: 1 }),
+        baseLockedTeam({ userName: 'C', teamNo: 1, teamName: 'C-team', position: 2 }),
+      ],
+    });
+
+    const result = await listLeagueTeams({
+      chatId: CHAT_ID,
+      leagueName: 'kilzi test',
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.teams).toHaveLength(3);
+    expect(result.teams.map((t) => t.teamName)).toEqual(['A-team', 'C-team', 'B-team']);
+    expect(result.leagueCode).toBe(LEAGUE_CODE);
+  });
+
+  it("marks the user's own team with isSelected: true", async () => {
+    const selectedId = buildLeagueTeamId('Doron-Kilzi', 2);
+    getSelectedTeam.mockReturnValue(selectedId);
+    listUserLeagues.mockResolvedValue([
+      { leagueCode: LEAGUE_CODE, leagueName: 'Kilzi Test' },
+    ]);
+    getLockedTeamsData.mockResolvedValue({
+      leagueName: 'Kilzi Test',
+      matchdayId: 5,
+      teams: [
+        baseLockedTeam({
+          userName: 'Doron Kilzi',
+          teamNo: 2,
+          teamName: 'Kilzid2',
+          position: 5,
+        }),
+        baseLockedTeam({
+          userName: 'Other',
+          teamNo: 1,
+          teamName: 'Other Team',
+          position: 1,
+        }),
+      ],
+    });
+
+    const result = await listLeagueTeams({
+      chatId: CHAT_ID,
+      leagueName: 'Kilzi Test',
+    });
+
+    const ownTeam = result.teams.find((t) => t.teamName === 'Kilzid2');
+    expect(ownTeam.isSelected).toBe(true);
+    const otherTeam = result.teams.find((t) => t.teamName === 'Other Team');
+    expect(otherTeam.isSelected).toBe(false);
+  });
+
+  it('returns not_followed when leagueCode not in user leagues', async () => {
+    listUserLeagues.mockResolvedValue([]);
+    const result = await listLeagueTeams({
+      chatId: CHAT_ID,
+      leagueCode: LEAGUE_CODE,
+    });
+    expect(result.status).toBe('not_followed');
+  });
+
+  it('returns invalid_input when both leagueCode and leagueName are missing', async () => {
+    const result = await listLeagueTeams({ chatId: CHAT_ID });
+    expect(result.status).toBe('invalid_input');
+  });
+});

--- a/src/utils/liveScoreCalc.js
+++ b/src/utils/liveScoreCalc.js
@@ -1,0 +1,169 @@
+// Pure scoring helpers shared between the Telegram `/live_score` handler
+// and the web-chat agent's `get_live_score_*` tools. No bot, no `t()`,
+// no `sendMessage` — keep this module pure so both surfaces can wire
+// the same calculator into whichever formatter / renderer they use.
+//
+// Extracted from `src/commandsHandler/liveScoreHandler.js` in Phase 5 of
+// the agent rollout. The handler still re-exports these names so its
+// existing test (`liveScoreHandler.test.js`) keeps importing them
+// unchanged.
+const { mapNameToCode } = require('./leagueTeamHelpers');
+const { EXTRA_TRANSFER_PENALTY_POINTS } = require('../constants');
+
+/**
+ * Map a single locked-snapshot team entry to the `{drivers, constructors,
+ * boostDriver, extraBoostDriver}` shape consumed by
+ * `calculateLiveScoreBreakdown`. Names are mapped to bot codes via
+ * `mapNameToCode`; captain / mega-captain are identified by the
+ * per-driver `isCaptain` / `isMegaCaptain` flags.
+ */
+function mapLockedTeamForScoring(lockedTeam) {
+  const drivers = Array.isArray(lockedTeam?.drivers) ? lockedTeam.drivers : [];
+  const constructors = Array.isArray(lockedTeam?.constructors)
+    ? lockedTeam.constructors
+    : [];
+  const captain = drivers.find((d) => d?.isCaptain);
+  const megaCaptain = drivers.find((d) => d?.isMegaCaptain);
+
+  return {
+    drivers: drivers.map((d) => mapNameToCode(d.name)),
+    constructors: constructors.map((c) => mapNameToCode(c.name)),
+    boostDriver: captain ? mapNameToCode(captain.name) : null,
+    extraBoostDriver: megaCaptain ? mapNameToCode(megaCaptain.name) : null,
+  };
+}
+
+function getLiveMemberData(bucket = {}, code) {
+  const memberData = bucket[code];
+
+  if (!memberData) {
+    return {
+      points: 0,
+      priceChange: 0,
+      details: {},
+      missing: true,
+    };
+  }
+
+  return {
+    points: Number(memberData.TotalPoints) || 0,
+    priceChange: Number(memberData.PriceChange) || 0,
+    details: memberData,
+    missing: false,
+  };
+}
+
+function calculateLiveScoreBreakdown(realTeam, liveScoreData, options = {}) {
+  const noNegativeActive = Boolean(options.noNegativeActive);
+  const transferPenalty = Math.max(
+    0,
+    Number(options.transferPenalty) || 0,
+  );
+  const driversData = liveScoreData.drivers || {};
+  const constructorsData = liveScoreData.constructors || {};
+  const boostDriver = realTeam.boostDriver;
+  const extraBoostDriver = realTeam.extraBoostDriver;
+
+  // Apply No Negative clamp on the per-member scoring `points` so the
+  // captain / mega-captain multipliers (added below) never amplify a
+  // negative score that should have been zeroed out first.
+  const clampPoints = (raw) =>
+    noNegativeActive ? Math.max(0, raw) : raw;
+
+  const driverBreakdown = realTeam.drivers.map((driverCode) => {
+    const member = getLiveMemberData(driversData, driverCode);
+
+    return {
+      code: driverCode,
+      ...member,
+      points: clampPoints(member.points),
+      isBoost: boostDriver === driverCode,
+      isExtraBoost: extraBoostDriver === driverCode,
+    };
+  });
+
+  const constructorBreakdown = realTeam.constructors.map((constructorCode) => {
+    const member = getLiveMemberData(constructorsData, constructorCode);
+
+    return {
+      code: constructorCode,
+      ...member,
+      points: clampPoints(member.points),
+      isBoost: false,
+      isExtraBoost: false,
+    };
+  });
+
+  const pointsBeforePenalty =
+    driverBreakdown.reduce(
+      (sum, driver) =>
+        sum +
+        driver.points +
+        (driver.isExtraBoost
+          ? driver.points * 2
+          : driver.isBoost
+            ? driver.points
+            : 0),
+      0,
+    ) + constructorBreakdown.reduce((sum, constructor) => sum + constructor.points, 0);
+
+  const totalPoints = pointsBeforePenalty - transferPenalty;
+
+  const totalPriceChange =
+    driverBreakdown.reduce((sum, driver) => sum + driver.priceChange, 0) +
+    constructorBreakdown.reduce((sum, constructor) => sum + constructor.priceChange, 0);
+
+  const missingMembers = [...driverBreakdown, ...constructorBreakdown]
+    .filter((member) => member.missing)
+    .map((member) => member.code);
+
+  return {
+    totalPoints,
+    pointsBeforePenalty,
+    transferPenalty,
+    noNegativeApplied: noNegativeActive,
+    totalPriceChange,
+    driverBreakdown,
+    constructorBreakdown,
+    missingMembers,
+  };
+}
+
+/**
+ * Derive the live-score `options` for a team from its locked-snapshot
+ * entry. Inspects the team's own `chipsUsed` and `transfersRemaining`:
+ *   - Wildcard / Limitless active for THIS matchday → transfer penalty waived.
+ *   - No Negative active for THIS matchday → flag noNegativeActive.
+ *   - Otherwise → 10 pts × |min(transfersRemaining, 0)| transfer penalty.
+ *
+ * "Active for this matchday" means the chip's `gameDayId` equals the
+ * snapshot's `matchdayId`. (`gameDayId` is misleadingly named — its
+ * value is the matchday the chip was activated for; see Phase 6.)
+ */
+function deriveLiveScoreOptions(lockedTeam) {
+  const matchdayId = lockedTeam?.matchdayId;
+  const chipsThisMatch = (
+    Array.isArray(lockedTeam?.chipsUsed) ? lockedTeam.chipsUsed : []
+  ).filter((c) => c && c.gameDayId === matchdayId);
+  const noNegativeActive = chipsThisMatch.some(
+    (c) => c.name === 'No Negative',
+  );
+  const wildcardOrLimitless = chipsThisMatch.some(
+    (c) => c.name === 'Wildcard' || c.name === 'Limitless',
+  );
+  const transfersRemainingRaw = Number(lockedTeam?.transfersRemaining);
+  const overTransfers = Number.isFinite(transfersRemainingRaw)
+    ? Math.max(0, -transfersRemainingRaw)
+    : 0;
+  const transferPenalty = wildcardOrLimitless
+    ? 0
+    : overTransfers * EXTRA_TRANSFER_PENALTY_POINTS;
+
+  return { noNegativeActive, transferPenalty };
+}
+
+module.exports = {
+  mapLockedTeamForScoring,
+  calculateLiveScoreBreakdown,
+  deriveLiveScoreOptions,
+};

--- a/src/utils/liveScoreCalc.test.js
+++ b/src/utils/liveScoreCalc.test.js
@@ -1,0 +1,162 @@
+jest.mock('./leagueTeamHelpers', () => ({
+  mapNameToCode: jest.fn((name) => name),
+}));
+
+const {
+  mapLockedTeamForScoring,
+  calculateLiveScoreBreakdown,
+  deriveLiveScoreOptions,
+} = require('./liveScoreCalc');
+
+describe('liveScoreCalc', () => {
+  describe('mapLockedTeamForScoring', () => {
+    it('maps drivers/constructors and detects captain + mega-captain', () => {
+      const lockedTeam = {
+        drivers: [
+          { name: 'VER', isCaptain: true },
+          { name: 'HAM', isMegaCaptain: true },
+          { name: 'NOR' },
+        ],
+        constructors: [{ name: 'MCL' }, { name: 'FER' }],
+      };
+
+      expect(mapLockedTeamForScoring(lockedTeam)).toEqual({
+        drivers: ['VER', 'HAM', 'NOR'],
+        constructors: ['MCL', 'FER'],
+        boostDriver: 'VER',
+        extraBoostDriver: 'HAM',
+      });
+    });
+
+    it('handles missing arrays', () => {
+      expect(mapLockedTeamForScoring({})).toEqual({
+        drivers: [],
+        constructors: [],
+        boostDriver: null,
+        extraBoostDriver: null,
+      });
+    });
+  });
+
+  describe('calculateLiveScoreBreakdown', () => {
+    const realTeam = {
+      drivers: ['VER', 'HAM'],
+      constructors: ['MCL'],
+      boostDriver: 'VER',
+      extraBoostDriver: null,
+    };
+    const liveScoreData = {
+      drivers: {
+        VER: { TotalPoints: 30, PriceChange: 1.2 },
+        HAM: { TotalPoints: -5, PriceChange: -0.4 },
+      },
+      constructors: {
+        MCL: { TotalPoints: 20, PriceChange: 0.5 },
+      },
+    };
+
+    it('applies captain x2 multiplier and accumulates totals', () => {
+      const result = calculateLiveScoreBreakdown(realTeam, liveScoreData);
+
+      // VER 30 + 30 (boost) + HAM -5 + MCL 20 = 75
+      expect(result.totalPoints).toBe(75);
+      expect(result.pointsBeforePenalty).toBe(75);
+      expect(result.transferPenalty).toBe(0);
+      expect(result.totalPriceChange).toBeCloseTo(1.3);
+      expect(result.missingMembers).toEqual([]);
+    });
+
+    it('applies mega-captain x3 multiplier in place of x2', () => {
+      const result = calculateLiveScoreBreakdown(
+        { ...realTeam, boostDriver: null, extraBoostDriver: 'VER' },
+        liveScoreData,
+      );
+
+      // VER 30 + 30*2 (extra boost added) + HAM -5 + MCL 20 = 105
+      expect(result.totalPoints).toBe(105);
+    });
+
+    it('clamps negative member points when noNegativeActive', () => {
+      const result = calculateLiveScoreBreakdown(realTeam, liveScoreData, {
+        noNegativeActive: true,
+      });
+
+      // HAM -5 → 0. VER 30 + 30 (boost) + 0 + MCL 20 = 80
+      expect(result.totalPoints).toBe(80);
+      expect(result.noNegativeApplied).toBe(true);
+    });
+
+    it('subtracts transferPenalty from totalPoints', () => {
+      const result = calculateLiveScoreBreakdown(realTeam, liveScoreData, {
+        transferPenalty: 10,
+      });
+
+      expect(result.pointsBeforePenalty).toBe(75);
+      expect(result.transferPenalty).toBe(10);
+      expect(result.totalPoints).toBe(65);
+    });
+
+    it('flags missing members and treats them as 0', () => {
+      const result = calculateLiveScoreBreakdown(
+        { ...realTeam, drivers: ['VER', 'MISSING_DRIVER'] },
+        liveScoreData,
+      );
+
+      expect(result.missingMembers).toEqual(['MISSING_DRIVER']);
+      // VER 30 + 30 (boost) + missing 0 + MCL 20 = 80
+      expect(result.totalPoints).toBe(80);
+    });
+  });
+
+  describe('deriveLiveScoreOptions', () => {
+    it('returns no penalty / no clamp when transfers in range and no chip', () => {
+      expect(
+        deriveLiveScoreOptions({
+          transfersRemaining: 1,
+          chipsUsed: [],
+          matchdayId: 5,
+        }),
+      ).toEqual({ noNegativeActive: false, transferPenalty: 0 });
+    });
+
+    it('applies 10-pt penalty per excess transfer', () => {
+      expect(
+        deriveLiveScoreOptions({
+          transfersRemaining: -2,
+          chipsUsed: [],
+          matchdayId: 5,
+        }),
+      ).toEqual({ noNegativeActive: false, transferPenalty: 20 });
+    });
+
+    it('waives penalty when Wildcard is active for this matchday', () => {
+      expect(
+        deriveLiveScoreOptions({
+          transfersRemaining: -3,
+          chipsUsed: [{ name: 'Wildcard', gameDayId: 5 }],
+          matchdayId: 5,
+        }),
+      ).toEqual({ noNegativeActive: false, transferPenalty: 0 });
+    });
+
+    it('does NOT waive penalty when Wildcard is for a different matchday', () => {
+      expect(
+        deriveLiveScoreOptions({
+          transfersRemaining: -2,
+          chipsUsed: [{ name: 'Wildcard', gameDayId: 4 }],
+          matchdayId: 5,
+        }),
+      ).toEqual({ noNegativeActive: false, transferPenalty: 20 });
+    });
+
+    it('flags noNegativeActive when No Negative chip is for this matchday', () => {
+      expect(
+        deriveLiveScoreOptions({
+          transfersRemaining: 0,
+          chipsUsed: [{ name: 'No Negative', gameDayId: 5 }],
+          matchdayId: 5,
+        }),
+      ).toEqual({ noNegativeActive: true, transferPenalty: 0 });
+    });
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,9 @@ import { useLeaderboardAction } from './components/LeaderboardTable';
 import { useRaceInfoAction } from './components/RaceInfoCard';
 import { useWeatherForecastAction } from './components/WeatherForecast';
 import { useDeadlineCountdownAction } from './components/DeadlineCountdown';
+import { useCurrentTeamAction } from './components/CurrentTeamCard';
+import { useLiveScoreBreakdownAction } from './components/LiveScoreBreakdown';
+import { useLiveScoreLeaderboardAction } from './components/LiveScoreLeaderboard';
 
 const RUNTIME_URL =
   (import.meta.env.VITE_AGENT_API_URL as string | undefined) ??
@@ -25,6 +28,9 @@ function AgentActions() {
   useRaceInfoAction();
   useWeatherForecastAction();
   useDeadlineCountdownAction();
+  useCurrentTeamAction();
+  useLiveScoreBreakdownAction();
+  useLiveScoreLeaderboardAction();
   return null;
 }
 

--- a/web/src/components/CurrentTeamCard.tsx
+++ b/web/src/components/CurrentTeamCard.tsx
@@ -1,0 +1,285 @@
+import { useCopilotAction } from '@copilotkit/react-core';
+
+type TeamInfo = {
+  totalPrice?: number;
+  costCapRemaining?: number;
+  overallBudget?: number;
+  teamExpectedPoints?: number;
+  teamPriceChange?: number;
+};
+
+type CurrentTeamResult = {
+  status?:
+    | 'ok'
+    | 'no_teams'
+    | 'unknown_team'
+    | 'ambiguous_team'
+    | 'missing_cache';
+  teamId?: string;
+  teamName?: string | null;
+  chip?: string | null;
+  drivers?: string[];
+  constructors?: string[];
+  boostDriver?: string | null;
+  extraBoostDriver?: string | null;
+  freeTransfers?: number | null;
+  teamInfo?: TeamInfo;
+  budgetChangePointsPerMillion?: number;
+  budgetAdjustedPoints?: number | null;
+  remainingRaceCount?: number | null;
+  teamIds?: string[];
+};
+
+function fmt(value: number | undefined | null, digits = 2): string {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '—';
+  return value.toFixed(digits);
+}
+
+function CurrentTeamCard({ result }: { result?: CurrentTeamResult }) {
+  if (!result || result.status === 'no_teams') {
+    return (
+      <div style={{ padding: 12, color: '#555' }}>
+        You don't have a saved team yet. Upload a team screenshot or JSON in
+        the Telegram bot first.
+      </div>
+    );
+  }
+
+  if (result.status === 'missing_cache') {
+    return (
+      <div style={{ padding: 12, color: '#7a1f1f' }}>
+        Some of your team data isn't cached yet. Send drivers / constructors /
+        current-team images or JSON in the Telegram bot first.
+      </div>
+    );
+  }
+
+  if (result.status === 'ambiguous_team') {
+    return (
+      <div style={{ padding: 12, color: '#555' }}>
+        You have multiple teams ({result.teamIds?.join(', ') || '—'}). Tell me
+        which one to show.
+      </div>
+    );
+  }
+
+  if (result.status === 'unknown_team') {
+    return (
+      <div style={{ padding: 12, color: '#7a1f1f' }}>
+        Couldn't find that team. Available: {result.teamIds?.join(', ') || '—'}.
+      </div>
+    );
+  }
+
+  if (result.status !== 'ok') {
+    return null;
+  }
+
+  const drivers = result.drivers || [];
+  const constructors = result.constructors || [];
+  const ti = result.teamInfo || {};
+  const ppmActive =
+    typeof result.budgetChangePointsPerMillion === 'number' &&
+    result.budgetChangePointsPerMillion > 0;
+
+  return (
+    <div
+      style={{
+        margin: '8px 0',
+        border: '1px solid #e2e6ee',
+        borderRadius: 10,
+        background: '#fff',
+        overflow: 'hidden',
+        fontSize: 13,
+      }}
+    >
+      <div
+        style={{
+          padding: '12px 16px',
+          background: '#f8fafc',
+          borderBottom: '1px solid #e2e6ee',
+          display: 'flex',
+          alignItems: 'baseline',
+          flexWrap: 'wrap',
+          gap: 8,
+        }}
+      >
+        <strong style={{ fontSize: 15 }}>
+          {result.teamName || result.teamId}
+        </strong>
+        <span style={{ color: '#7d8693', fontSize: 11 }}>
+          id: <code>{result.teamId}</code>
+        </span>
+        {result.chip ? (
+          <span
+            style={{
+              padding: '2px 8px',
+              borderRadius: 999,
+              background: '#fff3c2',
+              color: '#7a5a00',
+              fontWeight: 700,
+              fontSize: 11,
+            }}
+          >
+            CHIP: {result.chip}
+          </span>
+        ) : null}
+      </div>
+
+      <div style={{ padding: '12px 16px' }}>
+        <div style={{ fontWeight: 700, marginBottom: 4 }}>Drivers</div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+          {drivers.map((d) => {
+            const isCaptain = d === result.boostDriver;
+            const isMega = d === result.extraBoostDriver;
+            return (
+              <span
+                key={d}
+                style={{
+                  padding: '4px 10px',
+                  borderRadius: 999,
+                  background: isMega
+                    ? '#fff3c2'
+                    : isCaptain
+                      ? '#eef4ff'
+                      : '#f1f3f7',
+                  color: isMega ? '#7a5a00' : isCaptain ? '#1c4f99' : '#37404f',
+                  fontWeight: 700,
+                  fontSize: 12,
+                }}
+              >
+                {isMega ? '🏆 ' : isCaptain ? '⭐ ' : ''}
+                {d}
+              </span>
+            );
+          })}
+        </div>
+
+        <div style={{ fontWeight: 700, margin: '12px 0 4px' }}>
+          Constructors
+        </div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+          {constructors.map((c) => (
+            <span
+              key={c}
+              style={{
+                padding: '4px 10px',
+                borderRadius: 999,
+                background: '#f1f3f7',
+                color: '#37404f',
+                fontWeight: 700,
+                fontSize: 12,
+              }}
+            >
+              {c}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div
+        style={{
+          padding: '12px 16px',
+          borderTop: '1px solid #eef0f5',
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
+          gap: '10px 16px',
+        }}
+      >
+        <Metric label="Total price" value={fmt(ti.totalPrice)} unit="$M" />
+        <Metric
+          label="Cost cap remaining"
+          value={fmt(ti.costCapRemaining)}
+          unit="$M"
+        />
+        <Metric
+          label="Overall budget"
+          value={fmt(ti.overallBudget)}
+          unit="$M"
+        />
+        <Metric label="Expected points" value={fmt(ti.teamExpectedPoints)} />
+        {ppmActive && typeof result.budgetAdjustedPoints === 'number' ? (
+          <Metric
+            label={`Budget-adjusted (ppm=${result.budgetChangePointsPerMillion})`}
+            value={fmt(result.budgetAdjustedPoints)}
+          />
+        ) : null}
+        <Metric label="Expected price Δ" value={fmt(ti.teamPriceChange)} />
+        {typeof result.freeTransfers === 'number' ? (
+          <Metric label="Free transfers" value={String(result.freeTransfers)} />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  unit,
+}: {
+  label: string;
+  value: string;
+  unit?: string;
+}) {
+  return (
+    <div>
+      <div
+        style={{
+          fontSize: 11,
+          textTransform: 'uppercase',
+          color: '#7d8693',
+          letterSpacing: 0.4,
+        }}
+      >
+        {label}
+      </div>
+      <div style={{ fontSize: 16, fontWeight: 700, color: '#1c3d70' }}>
+        {value}
+        {unit ? (
+          <span
+            style={{
+              fontSize: 11,
+              marginLeft: 4,
+              color: '#7d8693',
+              fontWeight: 500,
+            }}
+          >
+            {unit}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function useCurrentTeamAction() {
+  useCopilotAction({
+    name: 'get_current_team',
+    description:
+      "Get the user's current saved roster — drivers, constructors, captain, chip, cost cap, projected points.",
+    parameters: [],
+    available: 'frontend',
+    render: ({ status, result }) => {
+      if (status === 'inProgress' || status === 'executing') {
+        return (
+          <div style={{ padding: 10, color: '#666' }}>
+            Loading your current team…
+          </div>
+        );
+      }
+      const parsed = typeof result === 'string' ? safeParse(result) : result;
+      return (
+        <CurrentTeamCard result={parsed as CurrentTeamResult | undefined} />
+      );
+    },
+  });
+}
+
+function safeParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}

--- a/web/src/components/LiveScoreBreakdown.tsx
+++ b/web/src/components/LiveScoreBreakdown.tsx
@@ -1,0 +1,385 @@
+import { useCopilotAction } from '@copilotkit/react-core';
+
+type SessionDetails = Record<string, number | undefined>;
+
+type MemberBreakdown = {
+  code?: string;
+  points?: number;
+  priceChange?: number;
+  details?: Record<string, SessionDetails | unknown>;
+  isBoost?: boolean;
+  isExtraBoost?: boolean;
+  missing?: boolean;
+};
+
+type LiveScoreBreakdownData = {
+  totalPoints?: number;
+  pointsBeforePenalty?: number;
+  transferPenalty?: number;
+  noNegativeApplied?: boolean;
+  totalPriceChange?: number;
+  driverBreakdown?: MemberBreakdown[];
+  constructorBreakdown?: MemberBreakdown[];
+  missingMembers?: string[];
+};
+
+type LiveScoreTeamResult = {
+  status?:
+    | 'ok'
+    | 'not_followed'
+    | 'not_found'
+    | 'team_not_found'
+    | 'invalid_input';
+  leagueCode?: string;
+  leagueName?: string;
+  matchdayId?: number | null;
+  extractedAt?: string | null;
+  teamId?: string;
+  teamName?: string;
+  userName?: string;
+  position?: number | null;
+  breakdown?: LiveScoreBreakdownData;
+  availableTeams?: Array<{
+    teamName?: string;
+    userName?: string;
+    teamNo?: number;
+    position?: number | null;
+    teamId?: string;
+  }>;
+};
+
+const SESSION_ORDER = ['Sprint', 'Qualifying', 'Race'] as const;
+const SESSION_METRICS = ['POS', 'PG', 'OV', 'FL', 'DD', 'TW', 'FP'] as const;
+
+function formatSigned(value: number | undefined): string {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '—';
+  const fixed = value.toFixed(2);
+  return value >= 0 ? `+${fixed}` : fixed;
+}
+
+function formatNumber(value: number | undefined, digits = 2): string {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '—';
+  return value.toFixed(digits);
+}
+
+function formatExtractedAt(iso?: string | null): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function MemberCard({
+  member,
+  isConstructor = false,
+}: {
+  member: MemberBreakdown;
+  isConstructor?: boolean;
+}) {
+  const base = typeof member.points === 'number' ? member.points : 0;
+  const effective = member.isExtraBoost
+    ? base * 3
+    : member.isBoost
+      ? base * 2
+      : base;
+
+  const sessionLines: Array<{ label: string; metrics: string[] }> = [];
+  if (!isConstructor && member.details && typeof member.details === 'object') {
+    for (const label of SESSION_ORDER) {
+      const sessionData = (member.details as Record<string, unknown>)[label];
+      if (!sessionData || typeof sessionData !== 'object') continue;
+      const metrics: string[] = [];
+      for (const m of SESSION_METRICS) {
+        const v = (sessionData as Record<string, unknown>)[m];
+        if (typeof v === 'number' && v !== 0) {
+          metrics.push(`${m} ${v}`);
+        }
+      }
+      if (metrics.length) sessionLines.push({ label, metrics });
+    }
+  }
+
+  return (
+    <div
+      style={{
+        border: '1px solid #eef0f5',
+        borderRadius: 8,
+        padding: '10px 12px',
+        background: member.missing ? '#fff5f5' : '#fafbfd',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: 8,
+          marginBottom: 4,
+        }}
+      >
+        <strong style={{ fontSize: 14 }}>
+          {member.isExtraBoost ? '🏆 ' : member.isBoost ? '⭐ ' : ''}
+          {member.code}
+        </strong>
+        {member.isExtraBoost ? (
+          <span
+            style={{
+              fontSize: 11,
+              padding: '1px 6px',
+              borderRadius: 999,
+              background: '#fff3c2',
+              color: '#7a5a00',
+              fontWeight: 700,
+            }}
+          >
+            x3
+          </span>
+        ) : member.isBoost ? (
+          <span
+            style={{
+              fontSize: 11,
+              padding: '1px 6px',
+              borderRadius: 999,
+              background: '#eef4ff',
+              color: '#1c4f99',
+              fontWeight: 700,
+            }}
+          >
+            x2
+          </span>
+        ) : null}
+        <span style={{ marginLeft: 'auto', fontWeight: 700, color: '#1c3d70' }}>
+          {formatNumber(effective)} pts
+        </span>
+      </div>
+      <div style={{ fontSize: 12, color: '#5a6471' }}>
+        Δ {formatSigned(member.priceChange)}
+        {member.missing ? ' · ⚠️ no live data yet' : ''}
+      </div>
+      {sessionLines.length > 0 ? (
+        <div style={{ marginTop: 6, fontSize: 12, color: '#37404f' }}>
+          {sessionLines.map((s) => (
+            <div key={s.label}>
+              <strong>{s.label}:</strong> {s.metrics.join(', ')}
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function LiveScoreBreakdown({ result }: { result?: LiveScoreTeamResult }) {
+  if (!result || result.status === 'invalid_input') {
+    return (
+      <div style={{ padding: 12, color: '#555' }}>
+        Live-score request was missing data. Tell me which league.
+      </div>
+    );
+  }
+  if (result.status === 'not_followed') {
+    return (
+      <div style={{ padding: 12, color: '#7a1f1f' }}>
+        You don't follow that league. Run <code>/follow_league</code> in
+        Telegram first.
+      </div>
+    );
+  }
+  if (result.status === 'not_found') {
+    return (
+      <div style={{ padding: 12, color: '#555' }}>
+        No locked roster snapshot for this league yet. Wait for the next
+        session lock.
+      </div>
+    );
+  }
+  if (result.status === 'team_not_found') {
+    return (
+      <div style={{ padding: 12, color: '#7a1f1f' }}>
+        Couldn't match that team. Try one of:{' '}
+        {(result.availableTeams || [])
+          .map((t) => t.teamName || t.userName)
+          .filter(Boolean)
+          .join(', ') || '—'}
+        .
+      </div>
+    );
+  }
+  if (result.status !== 'ok') return null;
+
+  const breakdown = result.breakdown || {};
+  const drivers = breakdown.driverBreakdown || [];
+  const constructors = breakdown.constructorBreakdown || [];
+
+  return (
+    <div
+      style={{
+        margin: '8px 0',
+        border: '1px solid #e2e6ee',
+        borderRadius: 10,
+        background: '#fff',
+        overflow: 'hidden',
+        fontSize: 13,
+      }}
+    >
+      <div
+        style={{
+          padding: '12px 16px',
+          background: '#f8fafc',
+          borderBottom: '1px solid #e2e6ee',
+        }}
+      >
+        <div style={{ fontWeight: 700, fontSize: 15 }}>
+          🏎️ Live score — {result.leagueName ?? result.leagueCode} ·{' '}
+          {result.teamName}
+        </div>
+        <div style={{ color: '#5a6471', marginTop: 2, fontSize: 12 }}>
+          Matchday {result.matchdayId ?? '?'} · updated{' '}
+          {formatExtractedAt(result.extractedAt)}
+        </div>
+      </div>
+
+      <div style={{ padding: '12px 16px' }}>
+        <div style={{ display: 'flex', gap: 24, flexWrap: 'wrap' }}>
+          <div>
+            <div
+              style={{
+                fontSize: 11,
+                textTransform: 'uppercase',
+                color: '#7d8693',
+              }}
+            >
+              Total live points
+            </div>
+            <div style={{ fontSize: 26, fontWeight: 800, color: '#1c3d70' }}>
+              {formatNumber(breakdown.totalPoints)}
+            </div>
+            {typeof breakdown.transferPenalty === 'number' &&
+            breakdown.transferPenalty > 0 ? (
+              <div style={{ fontSize: 12, color: '#7a1f1f' }}>
+                Transfer penalty: -{breakdown.transferPenalty.toFixed(2)} (
+                pre-penalty {formatNumber(breakdown.pointsBeforePenalty)})
+              </div>
+            ) : null}
+          </div>
+          <div>
+            <div
+              style={{
+                fontSize: 11,
+                textTransform: 'uppercase',
+                color: '#7d8693',
+              }}
+            >
+              Live price Δ
+            </div>
+            <div style={{ fontSize: 18, fontWeight: 700, color: '#1c3d70' }}>
+              {formatSigned(breakdown.totalPriceChange)}
+            </div>
+          </div>
+          {breakdown.noNegativeApplied ? (
+            <div
+              style={{
+                padding: '4px 10px',
+                borderRadius: 999,
+                background: '#eef4ff',
+                color: '#1c4f99',
+                fontWeight: 700,
+                fontSize: 12,
+                alignSelf: 'center',
+              }}
+            >
+              🛡️ No Negative active
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      {drivers.length > 0 ? (
+        <div style={{ padding: '0 16px 12px' }}>
+          <div style={{ fontWeight: 700, marginBottom: 6 }}>👤 Drivers</div>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+              gap: 8,
+            }}
+          >
+            {drivers.map((m) => (
+              <MemberCard key={m.code} member={m} />
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {constructors.length > 0 ? (
+        <div style={{ padding: '0 16px 12px' }}>
+          <div style={{ fontWeight: 700, marginBottom: 6 }}>
+            🛠️ Constructors
+          </div>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+              gap: 8,
+            }}
+          >
+            {constructors.map((m) => (
+              <MemberCard key={m.code} member={m} isConstructor />
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {breakdown.missingMembers && breakdown.missingMembers.length > 0 ? (
+        <div
+          style={{
+            padding: '8px 16px',
+            background: '#fff5f5',
+            color: '#7a1f1f',
+            fontSize: 12,
+            borderTop: '1px solid #f3c4c4',
+          }}
+        >
+          ⚠️ Missing live data: {breakdown.missingMembers.join(', ')}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function useLiveScoreBreakdownAction() {
+  useCopilotAction({
+    name: 'get_live_score_for_team',
+    description: 'Per-team live-score breakdown for a followed league.',
+    parameters: [],
+    available: 'frontend',
+    render: ({ status, result }) => {
+      if (status === 'inProgress' || status === 'executing') {
+        return (
+          <div style={{ padding: 10, color: '#666' }}>
+            Loading live score…
+          </div>
+        );
+      }
+      const parsed = typeof result === 'string' ? safeParse(result) : result;
+      return (
+        <LiveScoreBreakdown
+          result={parsed as LiveScoreTeamResult | undefined}
+        />
+      );
+    },
+  });
+}
+
+function safeParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}

--- a/web/src/components/LiveScoreLeaderboard.tsx
+++ b/web/src/components/LiveScoreLeaderboard.tsx
@@ -1,0 +1,231 @@
+import { useCopilotAction } from '@copilotkit/react-core';
+
+type LeaderboardRow = {
+  teamId?: string;
+  teamName?: string;
+  userName?: string;
+  teamNo?: number;
+  position?: number | null;
+  totalPoints?: number;
+  totalPriceChange?: number;
+  transferPenalty?: number;
+  isSelected?: boolean;
+};
+
+type LiveScoreLeaderboardResult = {
+  status?: 'ok' | 'not_followed' | 'not_found' | 'invalid_input';
+  leagueCode?: string;
+  leagueName?: string;
+  matchdayId?: number | null;
+  extractedAt?: string | null;
+  selectedTeamId?: string | null;
+  rows?: LeaderboardRow[];
+};
+
+function formatSigned(value: number | undefined): string {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '—';
+  const fixed = value.toFixed(2);
+  return value >= 0 ? `+${fixed}` : fixed;
+}
+
+function formatExtractedAt(iso?: string | null): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function LiveScoreLeaderboard({
+  result,
+}: {
+  result?: LiveScoreLeaderboardResult;
+}) {
+  if (!result || result.status === 'invalid_input') {
+    return (
+      <div style={{ padding: 12, color: '#555' }}>
+        Live-score request was missing data. Tell me which league.
+      </div>
+    );
+  }
+  if (result.status === 'not_followed') {
+    return (
+      <div style={{ padding: 12, color: '#7a1f1f' }}>
+        You don't follow that league. Run <code>/follow_league</code> in
+        Telegram first.
+      </div>
+    );
+  }
+  if (result.status === 'not_found') {
+    return (
+      <div style={{ padding: 12, color: '#555' }}>
+        No locked roster snapshot for this league yet. Wait for the next
+        session lock.
+      </div>
+    );
+  }
+  if (result.status !== 'ok') return null;
+
+  const rows = result.rows || [];
+  const hasPenalty = rows.some(
+    (r) => typeof r.transferPenalty === 'number' && r.transferPenalty > 0,
+  );
+
+  return (
+    <div
+      style={{
+        margin: '8px 0',
+        border: '1px solid #e2e6ee',
+        borderRadius: 10,
+        background: '#fff',
+        overflow: 'hidden',
+        fontSize: 13,
+      }}
+    >
+      <div
+        style={{
+          padding: '12px 16px',
+          background: '#f8fafc',
+          borderBottom: '1px solid #e2e6ee',
+        }}
+      >
+        <div style={{ fontWeight: 700, fontSize: 15 }}>
+          🏎️ Live leaderboard — {result.leagueName ?? result.leagueCode}
+        </div>
+        <div style={{ color: '#5a6471', marginTop: 2, fontSize: 12 }}>
+          Matchday {result.matchdayId ?? '?'} · updated{' '}
+          {formatExtractedAt(result.extractedAt)} · {rows.length} team
+          {rows.length === 1 ? '' : 's'}
+        </div>
+      </div>
+
+      {rows.length === 0 ? (
+        <div style={{ padding: 12, color: '#555' }}>
+          No teams in this league yet.
+        </div>
+      ) : (
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <thead>
+            <tr style={{ background: '#fafbfd', textAlign: 'left' }}>
+              <th style={cellHeader}>#</th>
+              <th style={cellHeader}>Team</th>
+              <th style={{ ...cellHeader, textAlign: 'right' }}>Live pts</th>
+              <th style={{ ...cellHeader, textAlign: 'right' }}>Δ price</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, idx) => (
+              <tr
+                key={row.teamId || `${row.userName}-${row.teamNo}`}
+                style={{
+                  borderTop: '1px solid #f0f2f7',
+                  background: row.isSelected ? '#eef4ff' : 'transparent',
+                  fontWeight: row.isSelected ? 700 : 500,
+                }}
+              >
+                <td style={cellBody}>{idx + 1}</td>
+                <td style={cellBody}>
+                  {row.teamName || row.userName || '—'}
+                  {typeof row.transferPenalty === 'number' &&
+                  row.transferPenalty > 0 ? (
+                    <span
+                      title={`Transfer penalty: -${row.transferPenalty}`}
+                      style={{ color: '#7a1f1f', marginLeft: 4 }}
+                    >
+                      †
+                    </span>
+                  ) : null}
+                  {row.isSelected ? (
+                    <span
+                      style={{
+                        marginLeft: 6,
+                        fontSize: 10,
+                        color: '#1c4f99',
+                        letterSpacing: 0.4,
+                      }}
+                    >
+                      YOU
+                    </span>
+                  ) : null}
+                </td>
+                <td style={{ ...cellBody, textAlign: 'right' }}>
+                  {typeof row.totalPoints === 'number'
+                    ? row.totalPoints.toFixed(2)
+                    : '—'}
+                </td>
+                <td style={{ ...cellBody, textAlign: 'right', color: '#5a6471' }}>
+                  {formatSigned(row.totalPriceChange)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {hasPenalty ? (
+        <div
+          style={{
+            padding: '8px 16px',
+            color: '#5a6471',
+            fontStyle: 'italic',
+            borderTop: '1px solid #eef0f5',
+            fontSize: 12,
+          }}
+        >
+          † transfer penalty applied
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+const cellHeader: React.CSSProperties = {
+  padding: '8px 12px',
+  fontWeight: 600,
+  fontSize: 11,
+  textTransform: 'uppercase',
+  color: '#666',
+  letterSpacing: 0.4,
+};
+
+const cellBody: React.CSSProperties = {
+  padding: '8px 12px',
+  verticalAlign: 'top',
+};
+
+export function useLiveScoreLeaderboardAction() {
+  useCopilotAction({
+    name: 'get_live_score_leaderboard',
+    description: 'All-teams live-score leaderboard for one followed league.',
+    parameters: [],
+    available: 'frontend',
+    render: ({ status, result }) => {
+      if (status === 'inProgress' || status === 'executing') {
+        return (
+          <div style={{ padding: 10, color: '#666' }}>
+            Loading live leaderboard…
+          </div>
+        );
+      }
+      const parsed = typeof result === 'string' ? safeParse(result) : result;
+      return (
+        <LiveScoreLeaderboard
+          result={parsed as LiveScoreLeaderboardResult | undefined}
+        />
+      );
+    },
+  });
+}
+
+function safeParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Phase 5 — current team + live score

**v1 capability scope is now COMPLETE.** After this PR ships, every read-only Telegram capability is reachable from the web agent with a tailored rich UI.

### New agent tools (4)
- `get_current_team` — the user's CURRENT saved roster: drivers, constructors, captain, mega-captain, chip, free transfers, cost cap, expected points, expected price change, plus budget-adjusted points when a non-zero ppm preset is set.
- `list_league_teams` — the FULL roster of a followed league (sorted by position; user's own team marked `isSelected: true`). Used by the LLM to ask which team to focus on — replaces the wrong-shaped `list_followed_teams` lookup for that purpose.
- `get_live_score_for_team` — per-team live breakdown. Accepts BOTH `leagueCode` AND `leagueName` (case-insensitive substring resolution against the user's followed leagues) so the LLM doesn't need to chain `list_user_leagues` first. Also has a teamId→teamName fallback in `pickLockedTeam`.
- `get_live_score_leaderboard` — all-teams live leaderboard, sorted by total live points desc (tie-break: total live price change desc). User's row marked `isSelected`.

### Cores (all pure, status-tagged)
- `src/cores/currentTeamCore.js` + 8 tests — team resolution mirrors `bestTeamsCore.pickTeamId` exactly (rubber-duck #3).
- `src/cores/liveScoreCore.js` + 16 tests — three entry points. All three validate the leagueCode against `listUserLeagues(chatId)` before fetching (rubber-duck #10c).

### Utils
- `src/utils/liveScoreCalc.js` + 12 tests — `mapLockedTeamForScoring`, `calculateLiveScoreBreakdown`, `deriveLiveScoreOptions` extracted from `liveScoreHandler.js` per rubber-duck #1 (shared pure module, not core→adapter import). Handler re-exports them for back-compat with its 735-line test.

### Telegram handlers refactored
- `currentTeamInfoHandler.js` — 69 → 57 lines, thin adapter. 7/7 tests green unchanged.
- `liveScoreHandler.js` — 635 → 506 lines (only the helper-import move + an unused `mapNameToCode` import removed). All 40 tests green unchanged.

### React components (3)
- `CurrentTeamCard.tsx` — team header with chip badge, drivers/constructors chips (boost ⭐, mega-captain 🏆), full metrics grid.
- `LiveScoreBreakdown.tsx` — header with league/matchday/team/last-update, big total live points + Δ price, active-chip badges, per-driver and per-constructor cards with multiplier badges + session breakdowns.
- `LiveScoreLeaderboard.tsx` — sortable table (rank / team / live pts / Δ price), user row highlighted with `YOU` badge, `†` penalty marker.

### System prompt
Strengthened clarify-and-focus pattern for live score per user feedback during testing:
1. **Ask which league** (if user follows >1).
2. **Call `list_league_teams` (NOT `list_followed_teams`)** to surface the league's FULL roster — user picks ANY team in the league, not just their own tracked teams (mirrors Telegram `/live_score`).
3. THEN call `get_live_score_for_team` ONCE with both leagueName + teamName so the rich UI render lands reliably.

Strengthened exclusion clause: "best/projected/optimization" questions still route to `get_best_teams` even when phrased as "current race" / "next race".

### Verification
- `npm test` → **828/828** ✅ (was 775; +53 new core tests across the 3 new files)
- `cd web && npm run build` → clean tsc + Vite build
- Playwright (fresh browser sessions per prompt):
  - *"Show me my current team"* → `<CurrentTeamCard />` rendered (Kilzid2, 109.40$M, 275.40 expected pts) ✅
  - *"What's my live score this race?"* → 3-step clarify-and-focus chain: ask league → "kilzi test" → list all 8 league teams → "HIRSCHEL" → `<LiveScoreBreakdown />` (142.00 pts) ✅
  - *"Show me the live-score leaderboard"* → ask league → "kilzi test" → `<LiveScoreLeaderboard />` rendered as sorted table (233 → 95 pts, Δ price column visible) ✅
  - *"How long until the next deadline?"* (Phase 1-4 regression) → `<DeadlineCountdown />` ticking ✅

Closes Phase 5 of `docs/agent-rollout-plan.md`.