### PR TITLE
feat(agent): per-step token usage logging via AI SDK middleware (Phase 6.1)

### DIFF
--- a/docs/agent-rollout-plan.md
+++ b/docs/agent-rollout-plan.md
@@ -5,7 +5,7 @@ user-facing surface for the Telegram bot, plus the cost-cap data fix
 that fell out of Phase 2. It's structured so anyone can pick up where
 we left off without prior context.
 
-**Current state (2026-05-17):** Phases 1, 2, 3, 4, 5, plus the cost-cap
+**Current state (2026-05-18):** Phases 1, 2, 3, 4, 5, plus the cost-cap
 data-source fix, the api-data `prices.json` producer, and the bot's
 `prices.json` consumer
 ([#183](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/183))
@@ -15,9 +15,13 @@ render component: upcoming races, tracked teams + leagues +
 leaderboards, best teams with filters, best-team scenarios
 (ppm × chip matrix), next race info, weather forecast, lock deadline,
 current saved roster, per-team live score breakdown, and all-teams
-live leaderboard. **Phase 6 (polish & hardening — token logging, error
-UX, CORS lockdown, optional history persistence) is the only remaining
-phase.**
+live leaderboard. **Phase 6 (polish & hardening) is in progress and
+being shipped as small incremental PRs.** **Phase 6.1 — per-step
+token-usage logging via AI SDK middleware
+([#188](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/188)) —
+is merged.** Remaining Phase 6 work: error UX, docs refresh,
+regression sweep, and optional history persistence. Frontend
+deployment is parked for now.
 
 > Read [`AGENTS.md`](../AGENTS.md) → "Agent (Web Chat)" first if you're
 > new to this codebase. That section is the authoritative reference for
@@ -342,21 +346,108 @@ Strengthened exclusion clause: questions about _projected_, _best_, _future_, _o
 ## Phase 6 — Polish & hardening
 
 **Goal:** make this maintainable in production. No new capabilities.
+Shipped as a series of small, incremental PRs (easier to review, easier
+to revert) rather than one big "Phase 6" PR.
 
-**Tasks:**
+### Phase 6.1 — Token usage logging ✅ MERGED ([#188](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/188))
 
-1. **Token usage logging**: per-turn `prompt/completion/total` tokens logged to the existing `LOG_CHANNEL_ID` via `sendLogMessage` (mirror `askHandler.js` pattern).
-2. **Error UX**: when a tool throws or the LLM fails, render a friendly message in the web chat. Log full error to a new Application Insights instance scoped to the agent Function App.
-3. **CORS hardening**: lock CORS allowlist to the production Static Web App URL only (currently permissive `*` for dev).
-4. **History persistence (optional)**: persist the last 20 user turns in browser localStorage so reloading doesn't lose context.
-5. **Docs**: refresh `AGENTS.md` "Agent (Web Chat)" section to capture any new gotchas discovered across Phases 3–5. Make sure the new-tool checklist still reflects current best practices.
-6. **Final regression sweep**: run full `npm test` + manual smoke on Telegram for the top-10 commands.
+Per-step LLM `prompt / completion / total` tokens logged to the existing
+`LOG_CHANNEL_ID` via `sendLogMessage` so we can monitor agent cost the
+same way the Telegram `/ask` command already does.
+
+**What landed:**
+
+- `src/agent/tokenUsageMiddleware.js` — a `LanguageModelV3Middleware`
+  attached via `wrapLanguageModel` from `ai`. Observes the raw stream
+  coming back from Azure and emits a log line for every `finish` chunk
+  it sees. Per-step (not per-turn) because that's the granularity the
+  underlying API exposes — a single agent turn with N tool calls
+  produces up to N+1 finish chunks.
+- `src/agent/notifierBot.js` — singleton **non-polling** `TelegramBot`
+  for the agent process, so it can `sendMessage` to the same log
+  channels the main bot uses without conflicting with the main bot's
+  long-polling loop. Falls back to a noop when `TELEGRAM_BOT_TOKEN` is
+  unset.
+- `src/agent/cacheBootstrap.js` — switched from an inline `getNoopBot()`
+  to the shared notifier so cache-init logs also land in Telegram.
+- `ai` is now an explicit dependency (was transitive via
+  `@copilotkit/runtime`).
+
+**Gotcha:** the V3 usage shape is **nested** (`usage.inputTokens.total`
+/ `usage.outputTokens.total`), not the flat V2 shape (`promptTokens` /
+`completionTokens`). There is no aggregated `totalTokens` in V3 — we
+compute it locally. Logging is fire-and-forget with sync + async catch
+guards so a Telegram outage cannot break the LLM stream piping back to
+the browser.
+
+**Log format:**
+
+```
+BOT: Agent step usage — model: gpt-4o, step: 1, prompt: 120, completion: 30, total: 150
+env: prod
+pid: 12345
+```
+
+### Phase 6.2 — Error UX (next)
+
+When a tool throws or the LLM fails, render a friendly message in the
+web chat. Concretely:
+
+- `wrapToolExecute(name, fn)` returns
+  `{ status: 'tool_error', tool, errorId, userMessage }` on throw.
+  **Never** leaks raw `err.message` to the UI (Azure errors can contain
+  URLs, container names, request IDs).
+- Opaque `errorId` (e.g. `crypto.randomUUID().slice(0, 8)`) as a
+  user-visible correlation token.
+- Full technical error → `ERRORS_CHANNEL_ID` via
+  `sendErrorMessage(notifierBot, ...)`.
+- Shared `<ToolErrorFallback />` component + `isToolErrorResult()`
+  helper to avoid 12-place JSX duplication.
+- System prompt: "DO NOT retry the same tool / invent data / expose
+  errorId unless asked."
+
+### Phase 6.3 — Docs refresh
+
+Refresh `AGENTS.md` "Agent (Web Chat)" section to capture the new
+patterns from Phases 3–6.1 (token-logging middleware, notifier bot,
+error-UX wrapper) and document the optional env vars
+(`TELEGRAM_BOT_TOKEN`, `LOG_CHANNEL_ID`, `ERRORS_CHANNEL_ID`) for the
+agent process. Make sure the new-tool checklist still reflects
+current best practices.
+
+### Phase 6.4 — Regression sweep
+
+Full `npm test` + manual smoke on Telegram for the top-10 commands +
+Playwright smoke on the agent. Summary-only — doesn't block other
+phases; each preceding PR already runs the test gate.
+
+### Phase 6.5 — History persistence
+
+Persist the last 20 user turns in browser localStorage so reloading
+doesn't lose context. **Only** persist `role: 'user' | 'assistant'`
+text content — strip tool calls, tool results, and large blobs
+(`availableTeams`, leaderboard rows, live-score payloads) so stale
+data never re-enters the LLM context. Schema-versioned payload
+(`{ version: 1, savedAt, messages }`) with hard caps (20 messages OR
+100 KB total), corruption / version-mismatch / quota errors trigger
+`clear()` + start fresh. Storage key:
+`localStorage.f1-fantasy-agent-history`. Includes a "Clear chat
+history" button.
+
+### Parked
+
+- **CORS hardening**: deferred along with the rest of frontend
+  deployment.
+- **Application Insights for the agent Function App**: deferred along
+  with deployment.
 
 **Acceptance test:**
 
-- Token usage shows up in `LOG_CHANNEL_ID`.
-- Forcing a tool error shows a friendly message in the web chat.
-- All previous-phase acceptance tests still pass.
+- ✅ Token usage shows up in `LOG_CHANNEL_ID` (Phase 6.1 — merged).
+- Forcing a tool error shows a friendly message in the web chat
+  (Phase 6.2).
+- All previous-phase acceptance tests still pass (regression sweep —
+  Phase 6.4).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@azure/keyvault-secrets": "^4.11.1",
         "@azure/storage-blob": "^12.27.0",
         "@copilotkit/runtime": "^1.57.1",
+        "ai": "^6.0.182",
         "dotenv": "^16.4.7",
         "node-telegram-bot-api": "^0.66.0",
         "openai": "^4.93.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@azure/keyvault-secrets": "^4.11.1",
     "@azure/storage-blob": "^12.27.0",
     "@copilotkit/runtime": "^1.57.1",
+    "ai": "^6.0.182",
     "dotenv": "^16.4.7",
     "node-telegram-bot-api": "^0.66.0",
     "openai": "^4.93.0",

--- a/src/agent/cacheBootstrap.js
+++ b/src/agent/cacheBootstrap.js
@@ -8,25 +8,20 @@
 //
 // `initializeCaches(bot)` only uses `bot` for the logging side-effects
 // (`sendLogMessage`, `sendErrorMessage`, `sendMessageToAdmins`, and
-// `saveUserTeam` for refreshed league rosters). We hand it a no-op
-// "bot" whose `sendMessage` simply resolves — the agent process has no
-// Telegram token. Note: cache init still touches Azure Storage (read +
-// occasionally write refreshed league teams), so the agent function
-// needs the same Azure credentials the bot does.
+// `saveUserTeam` for refreshed league rosters). We hand it the same
+// notifier bot the token-usage middleware uses — a non-polling
+// `TelegramBot` instance when `TELEGRAM_BOT_TOKEN` is set, or a noop
+// otherwise — so cache init logs land in the same Telegram channels as
+// the main bot.
 
 const { initializeCaches } = require('../cacheInitializer');
+const { getNotifierBot } = require('./notifierBot');
 
 let pendingCacheReady = null;
 
-function getNoopBot() {
-  return {
-    sendMessage: async () => undefined,
-  };
-}
-
 function ensureCacheReady() {
   if (!pendingCacheReady) {
-    pendingCacheReady = initializeCaches(getNoopBot()).catch((err) => {
+    pendingCacheReady = initializeCaches(getNotifierBot()).catch((err) => {
       // Reset on failure so the next tool invocation retries from
       // scratch (transient Azure errors should not brick the agent
       // until the process restarts).

--- a/src/agent/notifierBot.js
+++ b/src/agent/notifierBot.js
@@ -1,0 +1,59 @@
+// Notifier bot for the web-chat agent process.
+//
+// The agent runs in a separate process from the Telegram bot, so it has no
+// active `TelegramBot` instance available. We still want it to push token
+// usage / error logs into the same Telegram log + error channels the bot
+// uses. To do that, we instantiate a *non-polling* `TelegramBot` here. A
+// polling-disabled bot can still call `sendMessage` (Telegram's Bot API
+// allows multiple senders for the same token) without conflicting with the
+// main bot process which owns the long-polling loop.
+//
+// If `TELEGRAM_BOT_TOKEN` is unset (e.g. local dev without Telegram), we
+// fall back to a noop "bot" so `initializeCaches(bot)` and the token-usage
+// middleware still work — they just log to stdout via the
+// `sendLogMessage` / `sendErrorMessage` helpers which always
+// `console.log` first.
+
+const TelegramBot = require('node-telegram-bot-api');
+
+let cachedBot = null;
+
+function makeNoopBot() {
+  return {
+    sendMessage: async () => undefined,
+  };
+}
+
+function getNotifierBot() {
+  if (cachedBot) {
+    return cachedBot;
+  }
+
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  if (!token) {
+    console.log(
+      'AGENT: TELEGRAM_BOT_TOKEN not set — notifier bot is in noop mode (stdout only).',
+    );
+    cachedBot = makeNoopBot();
+
+    return cachedBot;
+  }
+
+  try {
+    cachedBot = new TelegramBot(token, { polling: false });
+  } catch (err) {
+    console.error(
+      'AGENT: Failed to construct notifier TelegramBot, falling back to noop:',
+      err,
+    );
+    cachedBot = makeNoopBot();
+  }
+
+  return cachedBot;
+}
+
+function resetNotifierBotForTests() {
+  cachedBot = null;
+}
+
+module.exports = { getNotifierBot, resetNotifierBotForTests };

--- a/src/agent/runtime.js
+++ b/src/agent/runtime.js
@@ -16,9 +16,12 @@ const {
   createCopilotRuntimeHandler,
 } = require('@copilotkit/runtime/v2');
 const { createAzure } = require('@ai-sdk/azure');
+const { wrapLanguageModel } = require('ai');
 
 const { tools } = require('./tools');
 const { getSystemPrompt } = require('./systemPrompt');
+const { getNotifierBot } = require('./notifierBot');
+const { createTokenUsageMiddleware } = require('./tokenUsageMiddleware');
 
 const COPILOTKIT_ENDPOINT = '/api/agent/copilotkit';
 const AZURE_OPENAI_API_VERSION = '2024-04-01-preview';
@@ -63,7 +66,14 @@ function buildAzureLanguageModel({ endpoint, apiKey, model }) {
 }
 
 function buildAgent(cfg) {
-  const model = buildAzureLanguageModel(cfg);
+  const rawModel = buildAzureLanguageModel(cfg);
+  // Wrap the Azure model with our token-usage middleware so every LLM step
+  // emits a log line into stdout + the Telegram log channel. The middleware
+  // is purely observational — it never mutates the stream.
+  const model = wrapLanguageModel({
+    model: rawModel,
+    middleware: createTokenUsageMiddleware({ bot: getNotifierBot() }),
+  });
 
   return new BuiltInAgent({
     model,

--- a/src/agent/tokenUsageMiddleware.js
+++ b/src/agent/tokenUsageMiddleware.js
@@ -1,0 +1,90 @@
+// Token-usage logging middleware for the web-chat agent.
+//
+// CopilotKit v2's `BuiltInAgent` does NOT expose an `onFinish` or
+// `onStepFinish` hook on the model layer, so we attach to the LLM via an
+// AI SDK v3 middleware (`LanguageModelV3Middleware`) and observe the raw
+// stream coming back from Azure. Each LLM round-trip emits exactly one
+// `finish` chunk carrying a `LanguageModelV3Usage` object. A single agent
+// turn with N tool calls produces up to N+1 finish chunks (one per step),
+// so we log per-step rather than per-turn — that's the granularity the
+// underlying API exposes.
+//
+// IMPORTANT — usage shape:
+// The V3 spec changed the usage shape from V2's flat `{ promptTokens,
+// completionTokens, totalTokens }` to a NESTED shape:
+//   usage.inputTokens.total      (prompt tokens)
+//   usage.outputTokens.total     (completion tokens)
+// There is no aggregated `totalTokens` — we compute it ourselves. Any of
+// these fields may be `undefined`, in which case we substitute 0 so the
+// log line still renders cleanly.
+//
+// Logging is wrapped in try/catch with sync + async failure handling
+// because a Telegram send error MUST NOT break the LLM stream the
+// CopilotKit runtime is piping back to the browser.
+
+const { sendLogMessage } = require('../utils/utils');
+
+function safeTotal(field) {
+  if (!field || typeof field !== 'object') {return 0;}
+  const value = field.total;
+
+  return Number.isFinite(value) ? value : 0;
+}
+
+function formatLine({ modelId, step, prompt, completion, total }) {
+  return `Agent step usage — model: ${modelId}, step: ${step}, prompt: ${prompt}, completion: ${completion}, total: ${total}`;
+}
+
+// `bot` is supplied by the runtime when the middleware is constructed so
+// that tests can inject a mock notifier bot.
+function createTokenUsageMiddleware({ bot }) {
+  return {
+    specificationVersion: 'v3',
+    wrapStream: async ({ doStream, model }) => {
+      const modelId = model && model.modelId ? model.modelId : 'unknown';
+      let stepIndex = 0;
+      const result = await doStream();
+
+      const observer = new TransformStream({
+        transform(chunk, controller) {
+          if (chunk && chunk.type === 'finish') {
+            stepIndex += 1;
+            const prompt = safeTotal(chunk.usage && chunk.usage.inputTokens);
+            const completion = safeTotal(
+              chunk.usage && chunk.usage.outputTokens,
+            );
+            const total = prompt + completion;
+            const line = formatLine({
+              modelId,
+              step: stepIndex,
+              prompt,
+              completion,
+              total,
+            });
+
+            // Fire-and-forget. We deliberately do NOT await here — the
+            // stream must keep flowing to the client even if Telegram is
+            // slow / down. We attach a .catch so an unhandled rejection
+            // never bubbles up and kills the process.
+            try {
+              Promise.resolve(sendLogMessage(bot, line)).catch((err) => {
+                console.error('AGENT: token usage log failed:', err);
+              });
+            } catch (err) {
+              console.error('AGENT: token usage log threw synchronously:', err);
+            }
+          }
+
+          controller.enqueue(chunk);
+        },
+      });
+
+      return {
+        ...result,
+        stream: result.stream.pipeThrough(observer),
+      };
+    },
+  };
+}
+
+module.exports = { createTokenUsageMiddleware, formatLine, safeTotal };

--- a/src/agent/tokenUsageMiddleware.test.js
+++ b/src/agent/tokenUsageMiddleware.test.js
@@ -1,0 +1,295 @@
+const {
+  createTokenUsageMiddleware,
+  formatLine,
+  safeTotal,
+} = require('./tokenUsageMiddleware');
+
+// Helper: collect every chunk that lands on the downstream end of a
+// ReadableStream so a test can assert on order/contents.
+async function collectStream(stream) {
+  const reader = stream.getReader();
+  const out = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {break;}
+    out.push(value);
+  }
+
+  return out;
+}
+
+function makeReadable(chunks) {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+}
+
+// `sendLogMessage(bot, line)` calls `bot.sendMessage(LOG_CHANNEL_ID, line)`
+// internally, so faking the bot is enough to observe what was logged.
+function makeBot() {
+  const calls = [];
+
+  return {
+    calls,
+    sendMessage: jest.fn(async (chatId, line) => {
+      calls.push({ chatId, line });
+    }),
+  };
+}
+
+const FAKE_MODEL = { modelId: 'gpt-test-1' };
+
+describe('safeTotal', () => {
+  test('returns 0 when field is missing', () => {
+    expect(safeTotal(undefined)).toBe(0);
+    expect(safeTotal(null)).toBe(0);
+  });
+
+  test('returns 0 when total is undefined / NaN', () => {
+    expect(safeTotal({ total: undefined })).toBe(0);
+    expect(safeTotal({ total: Number.NaN })).toBe(0);
+  });
+
+  test('returns total when finite', () => {
+    expect(safeTotal({ total: 42 })).toBe(42);
+    expect(safeTotal({ total: 0 })).toBe(0);
+  });
+});
+
+describe('formatLine', () => {
+  test('produces the expected log format', () => {
+    const line = formatLine({
+      modelId: 'gpt-4o',
+      step: 2,
+      prompt: 100,
+      completion: 50,
+      total: 150,
+    });
+    expect(line).toBe(
+      'Agent step usage — model: gpt-4o, step: 2, prompt: 100, completion: 50, total: 150',
+    );
+  });
+});
+
+describe('createTokenUsageMiddleware', () => {
+  beforeEach(() => {
+    // Suppress the console.error spam from intentionally-failing send paths
+    // so jest output stays readable.
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('emits a log line for each finish chunk with nested V3 usage', async () => {
+    const bot = makeBot();
+    const middleware = createTokenUsageMiddleware({ bot });
+
+    const upstream = makeReadable([
+      { type: 'text-delta', delta: 'hello ' },
+      {
+        type: 'finish',
+        finishReason: 'tool-calls',
+        usage: {
+          inputTokens: { total: 120 },
+          outputTokens: { total: 30 },
+        },
+      },
+      { type: 'text-delta', delta: 'world' },
+      {
+        type: 'finish',
+        finishReason: 'stop',
+        usage: {
+          inputTokens: { total: 200 },
+          outputTokens: { total: 80 },
+        },
+      },
+    ]);
+
+    const result = await middleware.wrapStream({
+      doStream: async () => ({ stream: upstream }),
+      doGenerate: async () => {
+        throw new Error('not used');
+      },
+      params: {},
+      model: FAKE_MODEL,
+    });
+
+    const out = await collectStream(result.stream);
+    expect(out).toHaveLength(4);
+
+    // Flush the fire-and-forget log promises before assertion.
+    await new Promise((r) => setImmediate(r));
+
+    expect(bot.sendMessage).toHaveBeenCalledTimes(2);
+    const firstLine = bot.calls[0].line;
+    const secondLine = bot.calls[1].line;
+    expect(firstLine).toContain('BOT: Agent step usage');
+    expect(firstLine).toContain('model: gpt-test-1');
+    expect(firstLine).toContain('step: 1');
+    expect(firstLine).toContain('prompt: 120');
+    expect(firstLine).toContain('completion: 30');
+    expect(firstLine).toContain('total: 150');
+
+    expect(secondLine).toContain('step: 2');
+    expect(secondLine).toContain('prompt: 200');
+    expect(secondLine).toContain('completion: 80');
+    expect(secondLine).toContain('total: 280');
+  });
+
+  test('treats missing nested totals as zero (no crash)', async () => {
+    const bot = makeBot();
+    const middleware = createTokenUsageMiddleware({ bot });
+
+    const upstream = makeReadable([
+      {
+        type: 'finish',
+        finishReason: 'stop',
+        usage: {
+          inputTokens: { total: undefined },
+          outputTokens: {},
+        },
+      },
+    ]);
+
+    const result = await middleware.wrapStream({
+      doStream: async () => ({ stream: upstream }),
+      doGenerate: async () => {
+        throw new Error('not used');
+      },
+      params: {},
+      model: FAKE_MODEL,
+    });
+    await collectStream(result.stream);
+    await new Promise((r) => setImmediate(r));
+
+    expect(bot.sendMessage).toHaveBeenCalledTimes(1);
+    expect(bot.calls[0].line).toContain('prompt: 0');
+    expect(bot.calls[0].line).toContain('completion: 0');
+    expect(bot.calls[0].line).toContain('total: 0');
+  });
+
+  test('non-finish chunks pass through without logging', async () => {
+    const bot = makeBot();
+    const middleware = createTokenUsageMiddleware({ bot });
+
+    const chunks = [
+      { type: 'text-delta', delta: 'a' },
+      { type: 'tool-call', toolCallId: 't1', toolName: 'foo', input: {} },
+      { type: 'text-delta', delta: 'b' },
+    ];
+    const upstream = makeReadable(chunks);
+
+    const result = await middleware.wrapStream({
+      doStream: async () => ({ stream: upstream }),
+      doGenerate: async () => {
+        throw new Error('not used');
+      },
+      params: {},
+      model: FAKE_MODEL,
+    });
+    const out = await collectStream(result.stream);
+    await new Promise((r) => setImmediate(r));
+
+    expect(out).toEqual(chunks);
+    expect(bot.sendMessage).not.toHaveBeenCalled();
+  });
+
+  test('telegram failure does not break the stream', async () => {
+    const bot = {
+      sendMessage: jest
+        .fn()
+        .mockRejectedValue(new Error('telegram is down')),
+    };
+    const middleware = createTokenUsageMiddleware({ bot });
+
+    const upstream = makeReadable([
+      {
+        type: 'finish',
+        finishReason: 'stop',
+        usage: {
+          inputTokens: { total: 10 },
+          outputTokens: { total: 5 },
+        },
+      },
+      { type: 'text-delta', delta: 'still flowing' },
+    ]);
+
+    const result = await middleware.wrapStream({
+      doStream: async () => ({ stream: upstream }),
+      doGenerate: async () => {
+        throw new Error('not used');
+      },
+      params: {},
+      model: FAKE_MODEL,
+    });
+
+    // The stream MUST still emit every upstream chunk even though the
+    // log-send is rejecting in the background.
+    const out = await collectStream(result.stream);
+    expect(out).toHaveLength(2);
+    expect(out[1]).toEqual({ type: 'text-delta', delta: 'still flowing' });
+
+    // Allow the unhandled-rejection-catch to run.
+    await new Promise((r) => setImmediate(r));
+    expect(bot.sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  test('preserves result fields beyond stream (request/response metadata)', async () => {
+    const bot = makeBot();
+    const middleware = createTokenUsageMiddleware({ bot });
+
+    const upstream = makeReadable([]);
+    const result = await middleware.wrapStream({
+      doStream: async () => ({
+        stream: upstream,
+        request: { body: { x: 1 } },
+        response: { headers: { 'x-foo': 'bar' } },
+      }),
+      doGenerate: async () => {
+        throw new Error('not used');
+      },
+      params: {},
+      model: FAKE_MODEL,
+    });
+
+    expect(result.request).toEqual({ body: { x: 1 } });
+    expect(result.response).toEqual({ headers: { 'x-foo': 'bar' } });
+  });
+
+  test('handles missing modelId gracefully', async () => {
+    const bot = makeBot();
+    const middleware = createTokenUsageMiddleware({ bot });
+
+    const upstream = makeReadable([
+      {
+        type: 'finish',
+        finishReason: 'stop',
+        usage: {
+          inputTokens: { total: 1 },
+          outputTokens: { total: 2 },
+        },
+      },
+    ]);
+
+    const result = await middleware.wrapStream({
+      doStream: async () => ({ stream: upstream }),
+      doGenerate: async () => {
+        throw new Error('not used');
+      },
+      params: {},
+      model: {},
+    });
+    await collectStream(result.stream);
+    await new Promise((r) => setImmediate(r));
+
+    expect(bot.calls[0].line).toContain('model: unknown');
+  });
+});


### PR DESCRIPTION
## Phase 6.1 — Token logging (cheapest, highest signal)

First slice of Phase 6 (polish & hardening). Adds per-step LLM token-usage observability to the web-chat agent so we can monitor cost the same way the Telegram `/ask` command already does.

### Why
- CopilotKit v2's `BuiltInAgent` does **not** expose any `onFinish` or `onStepFinish` hook on the model layer, so we have no built-in place to capture usage.
- Without this, every web-agent request is invisible cost: no way to spot a runaway prompt, a leaky tool result, or a model rollout that suddenly doubles output tokens.

### How
Attach a `LanguageModelV3Middleware` (from the `ai` package) at the `wrapLanguageModel` boundary — that's the only stable extension point on the AI SDK side. The middleware observes the raw stream coming back from Azure and emits a log line for every `finish` chunk it sees. A single agent turn with N tool calls produces up to N+1 finish chunks, so we log **per step** (not per turn) — that's the granularity the underlying API exposes.

### Key design notes
- **V3 usage shape is nested**: `usage.inputTokens.total` / `usage.outputTokens.total` (NOT the flat V2 `promptTokens` / `completionTokens`). There is no aggregated `totalTokens` in V3 — we compute it locally.
- **Fire-and-forget logging** with both sync and async catch guards — a Telegram outage MUST NOT break the LLM stream piping back to the browser.
- **`notifierBot.js`** is a singleton non-polling `TelegramBot`. Polling stays disabled so the agent process never conflicts with the main bot process that owns the long-polling loop on the same token. Falls back to a noop when `TELEGRAM_BOT_TOKEN` is unset (so local dev without Telegram still works).
- **`cacheBootstrap.js`** now reuses the same notifier, so cache-init logs from the agent process land in the same Telegram channels as the main bot. Previously they were stdout-only.
- **`ai` is now an explicit dependency** (was transitive via `@copilotkit/runtime`) so it can't disappear on a future bump.

### Files
| File | Change |
|---|---|
| `package.json` + lock | Added `ai@^6.0.182` as explicit dep |
| `src/agent/notifierBot.js` | NEW — singleton non-polling `TelegramBot`; noop fallback |
| `src/agent/tokenUsageMiddleware.js` | NEW — V3 middleware that logs per-step usage |
| `src/agent/tokenUsageMiddleware.test.js` | NEW — 10 tests |
| `src/agent/runtime.js` | Wrap Azure model with `wrapLanguageModel({ middleware })` |
| `src/agent/cacheBootstrap.js` | Switch from inline `getNoopBot()` to shared `getNotifierBot()` |

### Log format
```
BOT: Agent step usage — model: gpt-4o, step: 1, prompt: 120, completion: 30, total: 150
env: prod
pid: 12345
```

### Verification
- ✅ 838/838 tests pass (was 828; +10 new middleware tests covering V3 nested shape, missing totals, non-finish passthrough, telegram failure resilience, metadata preservation, missing modelId)
- ✅ `npm run lint` clean (only pre-existing warnings remain)
- ✅ `web && npm run build` succeeds
- ✅ Runtime smoke-test boots without error and correctly logs `"AGENT: TELEGRAM_BOT_TOKEN not set — notifier bot is in noop mode (stdout only)."` when token is absent

### Risk
Low. The middleware is purely observational — it pipes every chunk through a `TransformStream` unchanged. If the log path fails it's caught and console.error'd. If the middleware itself throws on construction, the agent fails to boot loudly (which is the correct behaviour).

### Follow-ups (later Phase 6 slices)
- **p6.2** — Error UX: `wrapToolExecute` + opaque `errorId` + `<ToolErrorFallback />`
- **p6.3** — Docs refresh
- **p6.4** — Regression sweep
- **p6.5** — History persistence (localStorage, schema-versioned, strips tool blobs)

🤖 Generated with [GitHub Copilot CLI](https://github.com/github/copilot-cli)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>