### PR TITLE
feat(agent): friendly tool-error UX with opaque errorId (Phase 6.2)

### DIFF
--- a/docs/agent-rollout-plan.md
+++ b/docs/agent-rollout-plan.md
@@ -19,9 +19,11 @@ live leaderboard. **Phase 6 (polish & hardening) is in progress and
 being shipped as small incremental PRs.** **Phase 6.1 — per-step
 token-usage logging via AI SDK middleware
 ([#188](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/188)) —
-is merged.** Remaining Phase 6 work: error UX, docs refresh,
-regression sweep, and optional history persistence. Frontend
-deployment is parked for now.
+and Phase 6.2 — friendly tool-error UX with opaque errorId
+([#189](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/189)) —
+are both merged.** Remaining Phase 6 work: docs refresh, regression
+sweep, and optional history persistence. Frontend deployment is
+parked for now.
 
 > Read [`AGENTS.md`](../AGENTS.md) → "Agent (Web Chat)" first if you're
 > new to this codebase. That section is the authoritative reference for
@@ -388,25 +390,49 @@ env: prod
 pid: 12345
 ```
 
-### Phase 6.2 — Error UX (next)
+### Phase 6.2 — Error UX ✅ MERGED ([#189](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/189))
 
-When a tool throws or the LLM fails, render a friendly message in the
-web chat. Concretely:
+When a tool throws or the LLM fails, the web chat renders a friendly
+red banner instead of leaking a raw Azure error string to the user.
 
-- `wrapToolExecute(name, fn)` returns
+**What landed:**
+
+- `src/agent/wrapToolExecute.js` — `wrapToolExecute(name, fn)` returns
   `{ status: 'tool_error', tool, errorId, userMessage }` on throw.
-  **Never** leaks raw `err.message` to the UI (Azure errors can contain
-  URLs, container names, request IDs).
-- Opaque `errorId` (e.g. `crypto.randomUUID().slice(0, 8)`) as a
-  user-visible correlation token.
-- Full technical error → `ERRORS_CHANNEL_ID` via
-  `sendErrorMessage(notifierBot, ...)`.
-- Shared `<ToolErrorFallback />` component + `isToolErrorResult()`
-  helper to avoid 12-place JSX duplication.
-- System prompt: "DO NOT retry the same tool / invent data / expose
-  errorId unless asked."
+  The 8-char `errorId` (slice of `randomUUID()`) is the user-visible
+  correlation token. **Never** leaks raw `err.message` to the UI —
+  Azure errors routinely include URLs, container names, request IDs,
+  and SAS tokens.
+- Full technical error (including stack) is pushed to
+  `ERRORS_CHANNEL_ID` via `sendErrorMessage(notifierBot, …)` — the
+  same notifier introduced in Phase 6.1. The notifier-send is itself
+  try/catched so a Telegram outage cannot break the tool dispatch
+  path.
+- All **14** tools in `src/agent/tools.js` are wrapped via this
+  helper. Two tools without rich UI (`list_user_leagues`,
+  `list_league_teams`) still benefit — their `tool_error` result is
+  narrated by the LLM via the new system-prompt rule.
+- `web/src/components/ToolErrorFallback.tsx` — shared red-banner
+  component + `isToolErrorResult()` type-guard. All 12 render hooks
+  short-circuit on `tool_error` with a uniform three-line addition.
+- `src/agent/systemPrompt.js` gained a "Tool error handling" section:
+  surface `userMessage`, suggest retry, **DO NOT** retry the same
+  tool with the same args, **DO NOT** invent data, **DO NOT** expose
+  `errorId` unless asked.
 
-### Phase 6.3 — Docs refresh
+**Tests:** 12 new tests in `wrapToolExecute.test.js` cover the
+discriminator, success passthrough (3 cases), async + sync + non-Error
+throws, full-error routing to the channel with matching `errorId`,
+**secret-leak regression guard** (asserts SAS tokens / URLs / sig
+params cannot reach the returned UI shape), notifier-failure
+resilience, and `errorId` uniqueness across 50 calls.
+
+**Format:**
+- UI banner: _"⚠️ Something went wrong — Please try again in a moment."_
+- Collapsed `<details>` block with `tool` + `errorId` for support.
+- Channel log: `Agent tool "<name>" threw [<errorId>]: <err.message>\n<stack>`.
+
+### Phase 6.3 — Docs refresh (next)
 
 Refresh `AGENTS.md` "Agent (Web Chat)" section to capture the new
 patterns from Phases 3–6.1 (token-logging middleware, notifier bot,
@@ -444,8 +470,8 @@ history" button.
 **Acceptance test:**
 
 - ✅ Token usage shows up in `LOG_CHANNEL_ID` (Phase 6.1 — merged).
-- Forcing a tool error shows a friendly message in the web chat
-  (Phase 6.2).
+- ✅ Forcing a tool error shows a friendly message in the web chat
+  (Phase 6.2 — merged).
 - All previous-phase acceptance tests still pass (regression sweep —
   Phase 6.4).
 

--- a/src/agent/systemPrompt.js
+++ b/src/agent/systemPrompt.js
@@ -189,6 +189,16 @@ Style rules:
 - If a tool returns no data or an error, say so plainly and suggest
   what the user can do next.
 
+Tool error handling:
+- If a tool returns a result with status="tool_error", briefly
+  apologize, surface the userMessage to the user, and suggest they
+  try again or rephrase. The frontend will render a red error banner
+  automatically — DO NOT restate that banner content in your message.
+- DO NOT retry the same tool with the same arguments unless the user
+  explicitly asks. DO NOT invent or fabricate data for the user. DO
+  NOT mention or expose the errorId in your reply unless the user
+  asks for a support / correlation reference.
+
 Today's date: ${new Date().toISOString().slice(0, 10)}.`;
 
 function getSystemPrompt() {

--- a/src/agent/tools.js
+++ b/src/agent/tools.js
@@ -32,6 +32,7 @@ const {
 const { listUserLeagues } = require('../leagueRegistryService');
 const { getAgentChatId } = require('./identity');
 const { ensureCacheReady } = require('./cacheBootstrap');
+const { wrapToolExecute } = require('./wrapToolExecute');
 
 // Trim a best-teams calculator row down to the fields the React component
 // actually renders. Sending the full driver/constructor dictionaries (which
@@ -67,9 +68,9 @@ const tools = [
     description:
       'Get the list of upcoming F1 races for the current season. Returns the season, an array of race objects (each with round, raceName, date/time, Circuit.circuitName, Circuit.Location.locality, Circuit.Location.country, and per-session schedules), and counts {total, sprint}. Use this for any question about upcoming races, race dates, locations, or country filtering — apply filters and sorting yourself on the returned array.',
     parameters: z.object({}),
-    execute: async () => {
+    execute: wrapToolExecute('get_next_races', async () => {
       return getNextRaces();
-    },
+    }),
   }),
 
   defineTool({
@@ -77,12 +78,12 @@ const tools = [
     description:
       'List the F1 Fantasy teams the user is tracking. Returns an array of teams with `teamId` (canonical identifier — pass this to other tools), `teamName` (friendly label like "kilzid3"), `isSelected`, `chip`, current drivers, current constructors, and roster metadata. ALWAYS call this first when the user mentions a team by name so you can resolve the name to a teamId before calling `get_best_teams`.',
     parameters: z.object({}),
-    execute: async () => {
+    execute: wrapToolExecute('list_user_teams', async () => {
       await ensureCacheReady();
       const chatId = getAgentChatId();
 
       return { teams: listUserTeams({ chatId }) };
-    },
+    }),
   }),
 
   defineTool({
@@ -127,7 +128,7 @@ const tools = [
         .optional()
         .describe('Constructor codes the team MUST NOT contain.'),
     }),
-    execute: async (args) => {
+    execute: wrapToolExecute('get_best_teams', async (args) => {
       await ensureCacheReady();
       const chatId = getAgentChatId();
       // Web component renders up to 10 teams at a time — anything beyond
@@ -169,7 +170,7 @@ const tools = [
         },
         bestTeams: result.bestTeams.map(summariseBestTeam),
       };
-    },
+    }),
   }),
 
   defineTool({
@@ -190,7 +191,7 @@ const tools = [
           'Exact teamName. Used only when teamId is not provided.',
         ),
     }),
-    execute: async (args) => {
+    execute: wrapToolExecute('get_best_team_scenarios', async (args) => {
       await ensureCacheReady();
       const chatId = getAgentChatId();
 
@@ -199,7 +200,7 @@ const tools = [
         teamId: args.teamId,
         teamName: args.teamName,
       });
-    },
+    }),
   }),
 
   defineTool({
@@ -207,12 +208,12 @@ const tools = [
     description:
       'List the F1 Fantasy teams the user is tracking, enriched with the leagues each team appears in plus the team\'s current position in each league. Returns { status, teams: [{ teamId, teamName, leagues: [{ leagueCode, leagueName, position }], isSelected }] }. status="empty" means the user has not followed any league team yet. ALWAYS call this when the user asks "which teams do I track" or asks a multi-team question like "best teams for every team I track" — for the multi-team case, surface the team names back to the user and ask which one to focus on (one team per get_best_teams call).',
     parameters: z.object({}),
-    execute: async () => {
+    execute: wrapToolExecute('list_followed_teams', async () => {
       await ensureCacheReady();
       const chatId = getAgentChatId();
 
       return await listFollowedTeams({ chatId });
-    },
+    }),
   }),
 
   defineTool({
@@ -220,7 +221,7 @@ const tools = [
     description:
       'List the private F1 Fantasy leagues the user has followed via /follow_league. Returns an array of { leagueCode, leagueName, registeredAt }. Use this when the user asks "which leagues do I follow" or when they name a league but you need to look up its `leagueCode` before calling `get_leaderboard`.',
     parameters: z.object({}),
-    execute: async () => {
+    execute: wrapToolExecute('list_user_leagues', async () => {
       await ensureCacheReady();
       const chatId = getAgentChatId();
       const leagues = await listUserLeagues(chatId);
@@ -232,7 +233,7 @@ const tools = [
           registeredAt: l.registeredAt || null,
         })),
       };
-    },
+    }),
   }),
 
   defineTool({
@@ -246,12 +247,12 @@ const tools = [
           'Canonical league code (e.g. "C7UYMMWIO07"). Look up via list_user_leagues if the user gave a display name.',
         ),
     }),
-    execute: async (args) => {
+    execute: wrapToolExecute('get_leaderboard', async (args) => {
       await ensureCacheReady();
       const chatId = getAgentChatId();
 
       return await getLeaderboard({ chatId, leagueCode: args.leagueCode });
-    },
+    }),
   }),
 
   defineTool({
@@ -259,11 +260,11 @@ const tools = [
     description:
       'Get detailed information about the next upcoming F1 race: race name, circuit, location, weekend format (regular or sprint), session timestamps (qualifying / race, plus sprintQualifying / sprint on sprint weekends), historical race stats for that track, multi-language track history, circuit image URL, and an optional pre-fetched weather snapshot. Use for questions like "tell me about the next race", "what circuit is next", "give me race info", "what is the schedule for the next race", "track history", or "historical stats for this race". Returns { status, raceName, circuitName, circuitImageUrl, location, weekendFormat, isSprintWeekend, sessions, historicalRaceStats, trackHistory, weather }. status="unavailable" means the race-info cache has not been populated yet.',
     parameters: z.object({}),
-    execute: async () => {
+    execute: wrapToolExecute('get_next_race_info', async () => {
       await ensureCacheReady();
 
       return await getNextRaceInfo();
-    },
+    }),
   }),
 
   defineTool({
@@ -271,11 +272,11 @@ const tools = [
     description:
       'Get the per-session hourly weather forecast (up to 3 hours per session, starting from each session start time, filtered to drop hours already in the past) for the next F1 race. Use for questions about weather, rain, temperature, wind, humidity, or cloud cover for the upcoming race weekend. Returns { status, raceName, circuitName, location, isSprintWeekend, sessions: [{ key, label, startsAt, hours: [iso], forecasts: [{ temperature, humidity, cloudCover, precipitation, precipitation_mm, wind }] }] }. status="unavailable" means either the race-info cache is empty or the weather API call failed.',
     parameters: z.object({}),
-    execute: async () => {
+    execute: wrapToolExecute('get_race_weather', async () => {
       await ensureCacheReady();
 
       return await getRaceWeather();
-    },
+    }),
   }),
 
   defineTool({
@@ -283,10 +284,10 @@ const tools = [
     description:
       'Get the next F1 Fantasy team-lock deadline. The deadline is the start time of the first locking session of the weekend: sprint (on sprint weekends) or qualifying (on regular weekends). Use for questions like "when does the team lock", "how long until the deadline", "next deadline", or "countdown to lock". Returns { status, raceName, sessionType, sessionLabel, sessionStartsAt: ISO, nowIso: ISO, alreadyStarted }. The web UI uses `sessionStartsAt` to render a live ticking countdown — return the result as-is and let the rich component handle the display.',
     parameters: z.object({}),
-    execute: async () => {
+    execute: wrapToolExecute('get_deadline', async () => {
       // No cache needed — fetchNextRace pulls fresh from the schedule service.
       return await getDeadlineSnapshot();
-    },
+    }),
   }),
 
   defineTool({
@@ -307,7 +308,7 @@ const tools = [
           'Exact teamName. Used only when teamId is not provided.',
         ),
     }),
-    execute: async (args) => {
+    execute: wrapToolExecute('get_current_team', async (args) => {
       await ensureCacheReady();
       const chatId = getAgentChatId();
 
@@ -316,7 +317,7 @@ const tools = [
         teamId: args.teamId,
         teamName: args.teamName,
       });
-    },
+    }),
   }),
 
   defineTool({
@@ -327,7 +328,7 @@ const tools = [
       leagueCode: z.string().optional(),
       leagueName: z.string().optional(),
     }),
-    execute: async (args) => {
+    execute: wrapToolExecute('list_league_teams', async (args) => {
       await ensureCacheReady();
       const chatId = getAgentChatId();
 
@@ -336,7 +337,7 @@ const tools = [
         leagueCode: args.leagueCode,
         leagueName: args.leagueName,
       });
-    },
+    }),
   }),
 
   defineTool({
@@ -369,7 +370,7 @@ const tools = [
           'Team name as shown in the league\'s roster. Used only when teamId is not provided.',
         ),
     }),
-    execute: async (args) => {
+    execute: wrapToolExecute('get_live_score_for_team', async (args) => {
       await ensureCacheReady();
       const chatId = getAgentChatId();
 
@@ -380,7 +381,7 @@ const tools = [
         teamId: args.teamId,
         teamName: args.teamName,
       });
-    },
+    }),
   }),
 
   defineTool({
@@ -401,7 +402,7 @@ const tools = [
           'League display name as the user typed it. The tool resolves this against the user\'s followed leagues (case-insensitive substring match). Provide this when the user named a league by display name — DO NOT call list_user_leagues first.',
         ),
     }),
-    execute: async (args) => {
+    execute: wrapToolExecute('get_live_score_leaderboard', async (args) => {
       await ensureCacheReady();
       const chatId = getAgentChatId();
 
@@ -410,7 +411,7 @@ const tools = [
         leagueCode: args.leagueCode,
         leagueName: args.leagueName,
       });
-    },
+    }),
   }),
 ];
 

--- a/src/agent/wrapToolExecute.js
+++ b/src/agent/wrapToolExecute.js
@@ -1,0 +1,100 @@
+// Error UX wrapper for agent tool `execute` functions.
+//
+// CopilotKit dispatches tool calls by invoking the function passed to
+// `defineTool({ execute })`. If that function throws, CopilotKit
+// surfaces the raw error to the LLM (and indirectly to the user) —
+// Azure errors routinely include URLs, container names, request IDs,
+// and stack traces that we MUST NOT expose in the UI.
+//
+// `wrapToolExecute(toolName, fn)` wraps an execute function in a
+// try/catch that:
+//   1. Routes the full technical error (including stack) to the
+//      Telegram error channel via `sendErrorMessage(getNotifierBot())`.
+//   2. Returns a normalized, safe-to-display tool result:
+//        { status: 'tool_error', tool, errorId, userMessage }
+//      The 8-char `errorId` is the user-visible correlation token —
+//      the user can quote it in a bug report to look up the full
+//      error in the channel. We deliberately log the errorId on BOTH
+//      sides so they match.
+//
+// The frontend renders a shared `<ToolErrorFallback />` whenever it
+// sees `status === 'tool_error'`; the LLM follows a system-prompt
+// rule that says "surface userMessage, do not retry, do not invent
+// data."
+//
+// Resilience: a failure in the error-channel send path NEVER breaks
+// the tool dispatch — we catch and `console.error` it. The user
+// still gets the friendly fallback.
+
+const { randomUUID } = require('crypto');
+const { sendErrorMessage } = require('../utils/utils');
+const { getNotifierBot } = require('./notifierBot');
+
+const TOOL_ERROR_STATUS = 'tool_error';
+const DEFAULT_USER_MESSAGE =
+  'Something went wrong while looking that up. Please try again in a moment.';
+
+function isToolErrorResult(value) {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    value.status === TOOL_ERROR_STATUS
+  );
+}
+
+function extractTechnicalMessage(err) {
+  if (err && typeof err === 'object') {
+    const parts = [];
+    if (typeof err.message === 'string' && err.message.length > 0) {
+      parts.push(err.message);
+    } else {
+      parts.push(String(err));
+    }
+    if (typeof err.stack === 'string') {
+      parts.push(err.stack);
+    }
+
+    return parts.join('\n');
+  }
+
+  return String(err);
+}
+
+function wrapToolExecute(toolName, fn) {
+  return async function wrappedExecute(args) {
+    try {
+      return await fn(args);
+    } catch (err) {
+      const errorId = randomUUID().slice(0, 8);
+      const technical = extractTechnicalMessage(err);
+
+      try {
+        await sendErrorMessage(
+          getNotifierBot(),
+          `Agent tool "${toolName}" threw [${errorId}]: ${technical}`,
+        );
+      } catch (logErr) {
+        // A notifier outage MUST NOT swallow the original error path —
+        // we still return the friendly fallback to the LLM/UI.
+        console.error(
+          `AGENT: failed to log tool error [${errorId}] for "${toolName}":`,
+          logErr,
+        );
+      }
+
+      return {
+        status: TOOL_ERROR_STATUS,
+        tool: toolName,
+        errorId,
+        userMessage: DEFAULT_USER_MESSAGE,
+      };
+    }
+  };
+}
+
+module.exports = {
+  wrapToolExecute,
+  isToolErrorResult,
+  TOOL_ERROR_STATUS,
+  DEFAULT_USER_MESSAGE,
+};

--- a/src/agent/wrapToolExecute.test.js
+++ b/src/agent/wrapToolExecute.test.js
@@ -1,0 +1,199 @@
+// Mock the notifier bot + sendErrorMessage seam BEFORE requiring the
+// module under test. Jest hoists `jest.mock` factories above any
+// `const` declarations in this file, so we cannot reference outer
+// variables from inside the factory — we declare `jest.fn()` inline
+// and reach back into it via `require()` once the wrapper module is
+// loaded.
+
+jest.mock('../utils/utils', () => ({
+  sendErrorMessage: jest.fn(),
+}));
+
+jest.mock('./notifierBot', () => ({
+  getNotifierBot: () => ({ sendMessage: jest.fn() }),
+}));
+
+const { sendErrorMessage } = require('../utils/utils');
+const {
+  wrapToolExecute,
+  isToolErrorResult,
+  TOOL_ERROR_STATUS,
+  DEFAULT_USER_MESSAGE,
+} = require('./wrapToolExecute');
+
+beforeEach(() => {
+  sendErrorMessage.mockReset();
+  sendErrorMessage.mockResolvedValue(undefined);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('isToolErrorResult', () => {
+  test('matches the exact discriminator shape', () => {
+    expect(isToolErrorResult({ status: TOOL_ERROR_STATUS })).toBe(true);
+    expect(
+      isToolErrorResult({ status: TOOL_ERROR_STATUS, tool: 'x', errorId: 'y' }),
+    ).toBe(true);
+  });
+
+  test('rejects everything else', () => {
+    expect(isToolErrorResult(null)).toBe(false);
+    expect(isToolErrorResult(undefined)).toBe(false);
+    expect(isToolErrorResult('tool_error')).toBe(false);
+    expect(isToolErrorResult({ status: 'ok' })).toBe(false);
+    expect(isToolErrorResult({ status: 'no_teams' })).toBe(false);
+    expect(isToolErrorResult({ tool: 'foo' })).toBe(false);
+    expect(isToolErrorResult(42)).toBe(false);
+  });
+});
+
+describe('wrapToolExecute — success path', () => {
+  test('passes the return value through unchanged', async () => {
+    const fn = jest.fn(async () => ({ status: 'ok', data: [1, 2, 3] }));
+    const wrapped = wrapToolExecute('my_tool', fn);
+
+    const result = await wrapped({ foo: 'bar' });
+
+    expect(result).toEqual({ status: 'ok', data: [1, 2, 3] });
+    expect(sendErrorMessage).not.toHaveBeenCalled();
+  });
+
+  test('preserves args exactly (object identity)', async () => {
+    const receivedArgs = [];
+    const fn = jest.fn(async (args) => {
+      receivedArgs.push(args);
+
+      return 'ok';
+    });
+    const wrapped = wrapToolExecute('my_tool', fn);
+
+    const inputs = { a: 1, nested: { b: 2 } };
+    await wrapped(inputs);
+
+    expect(receivedArgs).toHaveLength(1);
+    expect(receivedArgs[0]).toBe(inputs);
+  });
+
+  test('handles `undefined` return as a real value (not an error)', async () => {
+    const fn = jest.fn(async () => undefined);
+    const wrapped = wrapToolExecute('my_tool', fn);
+
+    const result = await wrapped();
+
+    expect(result).toBeUndefined();
+    expect(sendErrorMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('wrapToolExecute — error path', () => {
+  test('catches async rejection and returns tool_error shape', async () => {
+    const err = new Error('boom');
+    const fn = jest.fn(async () => {
+      throw err;
+    });
+    const wrapped = wrapToolExecute('my_tool', fn);
+
+    const result = await wrapped();
+
+    expect(isToolErrorResult(result)).toBe(true);
+    expect(result.tool).toBe('my_tool');
+    expect(typeof result.errorId).toBe('string');
+    expect(result.errorId).toHaveLength(8);
+    expect(result.userMessage).toBe(DEFAULT_USER_MESSAGE);
+  });
+
+  test('catches sync throw inside the execute body', async () => {
+    const fn = () => {
+      throw new Error('sync boom');
+    };
+    const wrapped = wrapToolExecute('my_tool', fn);
+
+    const result = await wrapped();
+
+    expect(isToolErrorResult(result)).toBe(true);
+    expect(result.tool).toBe('my_tool');
+  });
+
+  test('handles non-Error throw values gracefully (string, object, number)', async () => {
+    for (const thrown of ['string error', { code: 42 }, 42, null]) {
+      const fn = async () => {
+        // eslint-disable-next-line no-throw-literal
+        throw thrown;
+      };
+      const wrapped = wrapToolExecute('t', fn);
+      const result = await wrapped();
+      expect(isToolErrorResult(result)).toBe(true);
+      expect(result.tool).toBe('t');
+    }
+  });
+
+  test('routes the full technical error to the error channel with the same errorId', async () => {
+    const err = new Error('Azure storage 403 https://x.blob.core.windows.net/whatever');
+    err.stack = 'Error: Azure storage 403 ...\n    at foo (bar.js:1:1)';
+    const fn = async () => {
+      throw err;
+    };
+    const wrapped = wrapToolExecute('storage_tool', fn);
+
+    const result = await wrapped();
+
+    expect(sendErrorMessage).toHaveBeenCalledTimes(1);
+    const [, sentMessage] = sendErrorMessage.mock.calls[0];
+    expect(sentMessage).toContain('Agent tool "storage_tool" threw');
+    expect(sentMessage).toContain(`[${result.errorId}]`);
+    expect(sentMessage).toContain('Azure storage 403');
+    // Stack is included so we can debug from the error channel.
+    expect(sentMessage).toContain('at foo (bar.js:1:1)');
+  });
+
+  test('NEVER includes the raw technical message in the returned user-facing result', async () => {
+    const fn = async () => {
+      throw new Error(
+        'leaky secret: https://storage.blob.core.windows.net/?sig=abc',
+      );
+    };
+    const wrapped = wrapToolExecute('t', fn);
+
+    const result = await wrapped();
+    const serialized = JSON.stringify(result);
+
+    expect(serialized).not.toContain('leaky secret');
+    expect(serialized).not.toContain('storage.blob.core.windows.net');
+    expect(serialized).not.toContain('sig=abc');
+  });
+
+  test('sendErrorMessage failure does NOT break the tool — still returns tool_error', async () => {
+    sendErrorMessage.mockRejectedValue(new Error('telegram down'));
+    const fn = async () => {
+      throw new Error('original');
+    };
+    const wrapped = wrapToolExecute('t', fn);
+
+    const result = await wrapped();
+
+    expect(isToolErrorResult(result)).toBe(true);
+    expect(result.tool).toBe('t');
+    // The log-failure path uses console.error — we mocked it but we
+    // can still assert it was reached.
+    // eslint-disable-next-line no-console
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  test('errorId is unique across calls (sample of 50)', async () => {
+    const fn = async () => {
+      throw new Error('x');
+    };
+    const wrapped = wrapToolExecute('t', fn);
+
+    const ids = new Set();
+    for (let i = 0; i < 50; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const r = await wrapped();
+      ids.add(r.errorId);
+    }
+    expect(ids.size).toBe(50);
+  });
+});

--- a/web/src/components/BestTeamScenariosMatrix.tsx
+++ b/web/src/components/BestTeamScenariosMatrix.tsx
@@ -1,4 +1,5 @@
 import { useCopilotAction } from '@copilotkit/react-core';
+import { ToolErrorFallback, isToolErrorResult } from './ToolErrorFallback';
 
 type ScenarioResult = {
   chipKey: string | null;
@@ -217,6 +218,9 @@ export function useBestTeamScenariosAction() {
         );
       }
       const parsed = typeof result === 'string' ? safeParse(result) : result;
+      if (isToolErrorResult(parsed)) {
+        return <ToolErrorFallback result={parsed} />;
+      }
       return (
         <BestTeamScenariosMatrix
           result={parsed as BestTeamScenariosResult | undefined}

--- a/web/src/components/BestTeamsTable.tsx
+++ b/web/src/components/BestTeamsTable.tsx
@@ -1,4 +1,5 @@
 import { useCopilotAction } from '@copilotkit/react-core';
+import { ToolErrorFallback, isToolErrorResult } from './ToolErrorFallback';
 
 type BestTeamRow = {
   row: number;
@@ -337,6 +338,9 @@ export function useBestTeamsAction() {
         );
       }
       const parsed = typeof result === 'string' ? safeParse(result) : result;
+      if (isToolErrorResult(parsed)) {
+        return <ToolErrorFallback result={parsed} />;
+      }
       return <BestTeamsTable result={parsed as GetBestTeamsResult | undefined} />;
     },
   });

--- a/web/src/components/CurrentTeamCard.tsx
+++ b/web/src/components/CurrentTeamCard.tsx
@@ -1,4 +1,5 @@
 import { useCopilotAction } from '@copilotkit/react-core';
+import { ToolErrorFallback, isToolErrorResult } from './ToolErrorFallback';
 
 type TeamInfo = {
   totalPrice?: number;
@@ -269,6 +270,9 @@ export function useCurrentTeamAction() {
         );
       }
       const parsed = typeof result === 'string' ? safeParse(result) : result;
+      if (isToolErrorResult(parsed)) {
+        return <ToolErrorFallback result={parsed} />;
+      }
       return (
         <CurrentTeamCard result={parsed as CurrentTeamResult | undefined} />
       );

--- a/web/src/components/DeadlineCountdown.tsx
+++ b/web/src/components/DeadlineCountdown.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useCopilotAction } from '@copilotkit/react-core';
+import { ToolErrorFallback, isToolErrorResult } from './ToolErrorFallback';
 
 type DeadlineResult = {
   status?: 'ok' | 'unavailable';
@@ -203,6 +204,9 @@ export function useDeadlineCountdownAction() {
         );
       }
       const parsed = typeof result === 'string' ? safeParse(result) : result;
+      if (isToolErrorResult(parsed)) {
+        return <ToolErrorFallback result={parsed} />;
+      }
       return (
         <DeadlineCountdown result={parsed as DeadlineResult | undefined} />
       );

--- a/web/src/components/FollowedTeamsGrid.tsx
+++ b/web/src/components/FollowedTeamsGrid.tsx
@@ -1,4 +1,5 @@
 import { useCopilotAction } from '@copilotkit/react-core';
+import { ToolErrorFallback, isToolErrorResult } from './ToolErrorFallback';
 
 type LeagueRow = {
   leagueCode: string;
@@ -150,6 +151,9 @@ export function useFollowedTeamsAction() {
         );
       }
       const parsed = typeof result === 'string' ? safeParse(result) : result;
+      if (isToolErrorResult(parsed)) {
+        return <ToolErrorFallback result={parsed} />;
+      }
       return (
         <FollowedTeamsGrid
           result={parsed as ListFollowedTeamsResult | undefined}

--- a/web/src/components/LeaderboardTable.tsx
+++ b/web/src/components/LeaderboardTable.tsx
@@ -1,4 +1,5 @@
 import { useCopilotAction } from '@copilotkit/react-core';
+import { ToolErrorFallback, isToolErrorResult } from './ToolErrorFallback';
 
 type StandingsRow = {
   position: number | null;
@@ -187,6 +188,9 @@ export function useLeaderboardAction() {
         );
       }
       const parsed = typeof result === 'string' ? safeParse(result) : result;
+      if (isToolErrorResult(parsed)) {
+        return <ToolErrorFallback result={parsed} />;
+      }
       return (
         <LeaderboardTable result={parsed as LeaderboardResult | undefined} />
       );

--- a/web/src/components/LiveScoreBreakdown.tsx
+++ b/web/src/components/LiveScoreBreakdown.tsx
@@ -1,4 +1,5 @@
 import { useCopilotAction } from '@copilotkit/react-core';
+import { ToolErrorFallback, isToolErrorResult } from './ToolErrorFallback';
 
 type SessionDetails = Record<string, number | undefined>;
 
@@ -367,6 +368,9 @@ export function useLiveScoreBreakdownAction() {
         );
       }
       const parsed = typeof result === 'string' ? safeParse(result) : result;
+      if (isToolErrorResult(parsed)) {
+        return <ToolErrorFallback result={parsed} />;
+      }
       return (
         <LiveScoreBreakdown
           result={parsed as LiveScoreTeamResult | undefined}

--- a/web/src/components/LiveScoreLeaderboard.tsx
+++ b/web/src/components/LiveScoreLeaderboard.tsx
@@ -1,4 +1,5 @@
 import { useCopilotAction } from '@copilotkit/react-core';
+import { ToolErrorFallback, isToolErrorResult } from './ToolErrorFallback';
 
 type LeaderboardRow = {
   teamId?: string;
@@ -213,6 +214,9 @@ export function useLiveScoreLeaderboardAction() {
         );
       }
       const parsed = typeof result === 'string' ? safeParse(result) : result;
+      if (isToolErrorResult(parsed)) {
+        return <ToolErrorFallback result={parsed} />;
+      }
       return (
         <LiveScoreLeaderboard
           result={parsed as LiveScoreLeaderboardResult | undefined}

--- a/web/src/components/NextRacesTable.tsx
+++ b/web/src/components/NextRacesTable.tsx
@@ -1,4 +1,5 @@
 import { useCopilotAction } from '@copilotkit/react-core';
+import { ToolErrorFallback, isToolErrorResult } from './ToolErrorFallback';
 
 type Session = { date?: string; time?: string };
 
@@ -158,6 +159,9 @@ export function useNextRacesAction() {
         );
       }
       const parsed = typeof result === 'string' ? safeParse(result) : result;
+      if (isToolErrorResult(parsed)) {
+        return <ToolErrorFallback result={parsed} />;
+      }
       return <NextRacesTable result={parsed as NextRacesResult | undefined} />;
     },
   });

--- a/web/src/components/RaceInfoCard.tsx
+++ b/web/src/components/RaceInfoCard.tsx
@@ -1,4 +1,5 @@
 import { useCopilotAction } from '@copilotkit/react-core';
+import { ToolErrorFallback, isToolErrorResult } from './ToolErrorFallback';
 
 type Sessions = {
   qualifying?: string;
@@ -331,6 +332,9 @@ export function useRaceInfoAction() {
         );
       }
       const parsed = typeof result === 'string' ? safeParse(result) : result;
+      if (isToolErrorResult(parsed)) {
+        return <ToolErrorFallback result={parsed} />;
+      }
       return <RaceInfoCard result={parsed as RaceInfoResult | undefined} />;
     },
   });

--- a/web/src/components/ToolErrorFallback.tsx
+++ b/web/src/components/ToolErrorFallback.tsx
@@ -1,0 +1,66 @@
+// Shared fallback component rendered by every tool-render hook when
+// the backend returned `{ status: 'tool_error', ... }` (produced by
+// `wrapToolExecute` in `src/agent/wrapToolExecute.js`).
+//
+// Design rules:
+// - NEVER display the raw technical error in the UI. Azure error
+//   messages routinely leak URLs, container names, request IDs.
+// - Show the friendly `userMessage` prominently.
+// - Show the `errorId` in a collapsed `<details>` block so users can
+//   quote it in a bug report — that's the correlation token to find
+//   the full error in the Telegram error channel.
+
+export type ToolErrorResult = {
+  status: 'tool_error';
+  tool?: string;
+  errorId?: string;
+  userMessage?: string;
+};
+
+export function isToolErrorResult(value: unknown): value is ToolErrorResult {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    (value as { status?: unknown }).status === 'tool_error'
+  );
+}
+
+const DEFAULT_USER_MESSAGE =
+  'Something went wrong while looking that up. Please try again in a moment.';
+
+export function ToolErrorFallback({ result }: { result: ToolErrorResult }) {
+  const message =
+    typeof result.userMessage === 'string' && result.userMessage.length > 0
+      ? result.userMessage
+      : DEFAULT_USER_MESSAGE;
+
+  return (
+    <div
+      role="alert"
+      style={{
+        padding: '12px 14px',
+        background: '#fff1f1',
+        border: '1px solid #f3c2c2',
+        borderRadius: 8,
+        color: '#7a1f1f',
+        margin: '6px 0',
+      }}
+    >
+      <div style={{ fontWeight: 700, marginBottom: 4 }}>
+        ⚠️ Something went wrong
+      </div>
+      <div style={{ fontSize: 13, lineHeight: 1.4 }}>{message}</div>
+      {(result.tool || result.errorId) && (
+        <details style={{ marginTop: 8, fontSize: 11, color: '#a04545' }}>
+          <summary style={{ cursor: 'pointer', userSelect: 'none' }}>
+            Support details
+          </summary>
+          <div style={{ marginTop: 4, fontFamily: 'monospace' }}>
+            {result.tool ? <div>tool: {result.tool}</div> : null}
+            {result.errorId ? <div>errorId: {result.errorId}</div> : null}
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/UserTeamsList.tsx
+++ b/web/src/components/UserTeamsList.tsx
@@ -1,4 +1,5 @@
 import { useCopilotAction } from '@copilotkit/react-core';
+import { ToolErrorFallback, isToolErrorResult } from './ToolErrorFallback';
 
 type UserTeam = {
   teamId: string;
@@ -130,6 +131,9 @@ export function useUserTeamsAction() {
         );
       }
       const parsed = typeof result === 'string' ? safeParse(result) : result;
+      if (isToolErrorResult(parsed)) {
+        return <ToolErrorFallback result={parsed} />;
+      }
       return <UserTeamsList result={parsed as ListUserTeamsResult | undefined} />;
     },
   });

--- a/web/src/components/WeatherForecast.tsx
+++ b/web/src/components/WeatherForecast.tsx
@@ -1,4 +1,5 @@
 import { useCopilotAction } from '@copilotkit/react-core';
+import { ToolErrorFallback, isToolErrorResult } from './ToolErrorFallback';
 
 type Forecast = {
   temperature?: number;
@@ -203,6 +204,9 @@ export function useWeatherForecastAction() {
         );
       }
       const parsed = typeof result === 'string' ? safeParse(result) : result;
+      if (isToolErrorResult(parsed)) {
+        return <ToolErrorFallback result={parsed} />;
+      }
       return <WeatherForecast result={parsed as WeatherResult | undefined} />;
     },
   });


### PR DESCRIPTION
## Phase 6.2 — Error UX

Second slice of Phase 6 (polish & hardening). Replaces the cryptic raw Azure error that previously surfaced to web-chat users when an agent tool throws with a friendly red banner, while still preserving the full technical detail in the Telegram error channel for debugging.

### Why
- Today an Azure timeout / 403 / network blip surfaces to the LLM as a raw error string. The LLM then passes that to the user verbatim — exposing URLs, container names, request IDs, SAS tokens, stack traces, etc.
- We've also been making it hard for the user to file a useful bug report — they had no correlation token, so we couldn't find their failed request in our logs.

### How
```
agent tool throws
        ↓
wrapToolExecute(name, fn) catches → generates 8-char errorId
        ↓
   ┌──── full err + errorId → sendErrorMessage(notifierBot, …) → ERRORS_CHANNEL_ID
   │     (try/catched — telegram outage cannot break the tool path)
   ↓
{ status: 'tool_error', tool, errorId, userMessage } → LLM + UI
        ↓
   ┌── system prompt: surface userMessage, no retry, no fabrication
   ↓
   <ToolErrorFallback result={parsed} /> → red banner + collapsed support details (tool + errorId)
```

### Files
| File | Change |
|---|---|
| `src/agent/wrapToolExecute.js` | NEW — try/catch helper |
| `src/agent/wrapToolExecute.test.js` | NEW — 12 tests |
| `web/src/components/ToolErrorFallback.tsx` | NEW — shared red banner + `isToolErrorResult()` type-guard |
| `src/agent/tools.js` | Wrap all **14** `defineTool({ execute })` |
| `src/agent/systemPrompt.js` | Append `tool_error` handling rules |
| 12 component files in `web/src/components/` | Add 3-line fallback check after `safeParse` |

### Design rationale
- **Opaque `errorId`** is the only thing the user sees that could correlate to logs. The raw error never reaches the UI — there is an explicit test guarding against this (`NEVER includes the raw technical message in the returned user-facing result`) that asserts URLs / SAS tokens / signatures cannot leak.
- **Notifier failure is non-fatal**: `sendErrorMessage` is itself wrapped in try/catch. Telegram down ⇒ user still gets the friendly fallback, error path logged to stderr.
- **Backend wrap applies to ALL 14 tools** even the 2 without rich UI (`list_user_leagues`, `list_league_teams`). Their error case is narrated by the LLM via the system-prompt rule.
- **Shared frontend fallback** keeps the 12-place addition uniform (3 lines per component, no JSX duplication).

### What the user sees
- Friendly banner: _"⚠️ Something went wrong — Please try again in a moment."_
- Collapsed `<details>` block with `tool: get_live_score_for_team` + `errorId: 7e8f2a1b` (only if they expand it).
- LLM follow-up: brief apology + suggestion to rephrase. No retry. No fabrication. No errorId exposure unless asked.

### What the on-call sees
- `Agent tool "get_live_score_for_team" threw [7e8f2a1b]: <full err.message>\n<full stack>` in `ERRORS_CHANNEL_ID`.
- Same `errorId` lets us match support tickets to channel messages.

### Verification
- ✅ 850/850 tests pass (838 → 850, +12 new wrapper tests)
- ✅ `web && npm run build` succeeds; TS type-checks the fallback prop shape across all 12 components
- ✅ `npm run lint` clean (only pre-existing warnings)
- ✅ Runtime smoke-test boots cleanly with all 14 wrapped tools registered
- ✅ Secret-leak regression test: even with a poisoned URL+SAS token in `err.message`, the serialized tool result returned to LLM/UI never contains it.

### Risk
Medium. Touches every tool + every render component. Mitigated by:
- 100% additive (no existing behavior removed; happy-path is transparent)
- Single source of truth for the wrapper and the fallback
- Exhaustive unit tests on the wrapper
- Build + lint gates catch typos in the 12-component change

### Follow-ups (later Phase 6 slices)
- **p6.3** — Docs refresh (`AGENTS.md`: token-logging pattern, error-UX pattern, env vars, secret-redaction policy)
- **p6.4** — Regression sweep (full suite + Telegram top-10 smoke)
- **p6.5** — History persistence (localStorage, strips tool blobs, schema-versioned)

🤖 Generated with [GitHub Copilot CLI](https://github.com/github/copilot-cli)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>