### PR TITLE
feat(agent): chat history persistence in localStorage (Phase 6.5)

### DIFF
--- a/docs/agent-rollout-plan.md
+++ b/docs/agent-rollout-plan.md
@@ -9,22 +9,24 @@ we left off without prior context.
 data-source fix, the api-data `prices.json` producer, and the bot's
 `prices.json` consumer
 ([#183](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/183))
-are all merged. **v1 capability scope is now COMPLETE** — the agent
+are all merged. **v1 capability scope is COMPLETE** — the agent
 covers every read-only Telegram capability with a tailored React
 render component: upcoming races, tracked teams + leagues +
 leaderboards, best teams with filters, best-team scenarios
 (ppm × chip matrix), next race info, weather forecast, lock deadline,
 current saved roster, per-team live score breakdown, and all-teams
-live leaderboard. **Phase 6 (polish & hardening) is mostly done.**
-Phase 6.1 — token-usage logging
+live leaderboard. **Phase 6 (polish & hardening) is COMPLETE.**
+All five sub-phases are merged: Phase 6.1 — token-usage logging
 ([#188](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/188)),
 Phase 6.2 — tool-error UX
 ([#189](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/189)),
 Phase 6.3 — AGENTS.md refresh
 ([#190](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/190)),
-and Phase 6.4 — final regression sweep (this PR) **are all merged**.
-The only remaining Phase 6 work is the optional Phase 6.5 (chat
-history persistence). Frontend deployment is parked for now.
+Phase 6.4 — final regression sweep
+([#192](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/192)),
+and Phase 6.5 — chat history persistence (this PR). The **only**
+remaining piece of work is frontend deployment + CORS hardening,
+both currently parked.
 
 > Read [`AGENTS.md`](../AGENTS.md) → "Agent (Web Chat)" first if you're
 > new to this codebase. That section is the authoritative reference for
@@ -461,7 +463,7 @@ work without re-deriving the Phase 6 patterns from the merged PRs.
   `ToolErrorFallback.tsx`. One stale duplicate "Identity model (v1)"
   heading removed.
 
-### Phase 6.4 — Regression sweep ✅ MERGED ([#TBD](#))
+### Phase 6.4 — Regression sweep ✅ MERGED ([#192](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/192))
 
 Final v1 verification before history-persistence ships. Confirmed
 that nothing in Phases 6.1 / 6.2 / 6.3 broke an existing capability.
@@ -497,18 +499,77 @@ on GitHub PR):**
   Phase 6, so behaviour drift is highly unlikely but worth a final
   manual confirmation before deployment.
 
-### Phase 6.5 — History persistence (next)
+### Phase 6.5 — History persistence ✅ MERGED ([#193](https://github.com/F1-fantazy-bot/f1-fantazy-bot/pull/193))
 
-Persist the last 20 user turns in browser localStorage so reloading
-doesn't lose context. **Only** persist `role: 'user' | 'assistant'`
-text content — strip tool calls, tool results, and large blobs
-(`availableTeams`, leaderboard rows, live-score payloads) so stale
-data never re-enters the LLM context. Schema-versioned payload
-(`{ version: 1, savedAt, messages }`) with hard caps (20 messages OR
-100 KB total), corruption / version-mismatch / quota errors trigger
-`clear()` + start fresh. Storage key:
-`localStorage.f1-fantasy-agent-history`. Includes a "Clear chat
-history" button.
+Final v1 polish slice. After a page reload, the last 20 user-or-
+assistant **text** messages reappear in the chat — but no tool
+calls, tool results, or large blobs (`availableTeams`, leaderboard
+rows, live-score payloads) are persisted. Reloads cannot
+re-introduce stale data into the LLM context.
+
+**What landed:**
+
+- `web/src/lib/chatHistoryStore.ts` — schema-versioned localStorage
+  payload `{ version: 1, savedAt, messages: StoredMessage[] }` with
+  strict per-item validation, dedupe-on-load, double caps (20
+  messages **or** 100 KB total — whichever hits first), and
+  whole-payload-reject on any corruption / version mismatch / per-
+  field failure. Quota errors and read errors both swallowed with
+  a `clear()` fallback. Exports `load`, `save`, `clear`,
+  `toStoredMessages` (AG-UI → persistence shape), and
+  `toAgUiMessages` (persistence → AG-UI). Strict allowlist when
+  flattening `ContentBlock[]` content — only `type === 'text'`
+  blocks survive.
+- `web/src/components/HistoryRestorer.tsx` — uses
+  `useAgent({ agentId: 'default', updates: [OnMessagesChanged,
+  OnRunStatusChanged] })`. Tracks restoration per-agent-instance
+  via `restoredAgentRef.current === agent` (handles the stub →
+  real swap). Gates the save effect on a `hydrated` state flag
+  that flips on a `queueMicrotask` after restore, so the very first
+  `OnMessagesChanged` from the restored array can't trigger an
+  empty-save race. Auto-save is debounced 500 ms AND gated on
+  `agent.isRunning === false` — `OnRunStatusChanged` guarantees we
+  re-trigger when a stream completes, so reloading mid-stream
+  cannot persist a half-formed assistant reply. Uses a cheap
+  fingerprint (`length:lastId:lastContentLen`) as the React dep so
+  in-place message-array mutations still fire the effect.
+- `web/src/components/ClearHistoryButton.tsx` — small button next
+  to the header; on click `clear()` + `agent?.setMessages([])`.
+- `web/src/App.tsx` — single `<CopilotKit>` provider wrapping the
+  whole header + chat (so all three hooks share the same agent
+  instance); `<HistoryRestorer />` mounted inside.
+
+**API correction worth flagging:** The earlier rubber-duck pass
+assumed `useCopilotMessagesContext()` was the right hook. It does
+**NOT** exist in the installed CopilotKit version. The real hooks
+live at `@copilotkit/react-core/v2` (subpath import — `useAgent`,
+`UseAgentUpdate` are **not** in the root). Future contributors:
+always check `node_modules/@copilotkit/react-core/dist/v2/...d.cts`
+when looking for the v2 hooks, not the root index typedef.
+
+**Rubber-duck-vetted (second pass):** This phase went through a
+second rubber-duck critique that surfaced three blockers — restore
+overwritten by an early empty save, agent stub→real swap losing
+restoration, and mid-stream partial saves persisting half-formed
+replies — plus six important findings. All addressed in the
+shipped code; design rationale captured inline in
+`HistoryRestorer.tsx`.
+
+**Deferred (run before any deployment cut):**
+
+- Manual reload-after-conversation smoke. Boot the dev frontend
+  (`npm run dev`), run a 3-turn conversation that includes at
+  least ONE tool call, reload the page. Expect: (a) the 3 user
+  messages + 3 assistant text replies appear in order, (b) the
+  rich tool-render component does NOT reappear (intentional —
+  tool blobs are stripped on persist), (c) the localStorage
+  `f1-fantasy-agent-history` key is well-formed JSON with
+  `version: 1`, (d) reloading mid-stream does NOT persist a
+  half-formed assistant reply (the `isRunning` gate prevents it),
+  (e) the "Clear chat history" button empties both the chat and
+  the storage. The TypeScript build + the rubber-duck-vetted race
+  mitigations cover the code paths; this smoke confirms the
+  UX end-to-end on real Azure traffic.
 
 ### Parked
 
@@ -522,8 +583,11 @@ history" button.
 - ✅ Token usage shows up in `LOG_CHANNEL_ID` (Phase 6.1 — merged).
 - ✅ Forcing a tool error shows a friendly message in the web chat
   (Phase 6.2 — merged).
-- All previous-phase acceptance tests still pass (regression sweep —
-  Phase 6.4).
+- ✅ All previous-phase acceptance tests still pass (regression sweep —
+  Phase 6.4 — merged; manual Playwright + Telegram smokes
+  **deferred** to pre-deployment).
+- ✅ Page reload restores the last conversation's text (Phase 6.5 —
+  merged; manual reload smoke **deferred** to pre-deployment).
 
 ---
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,8 @@ import { useDeadlineCountdownAction } from './components/DeadlineCountdown';
 import { useCurrentTeamAction } from './components/CurrentTeamCard';
 import { useLiveScoreBreakdownAction } from './components/LiveScoreBreakdown';
 import { useLiveScoreLeaderboardAction } from './components/LiveScoreLeaderboard';
+import { HistoryRestorer } from './components/HistoryRestorer';
+import { ClearHistoryButton } from './components/ClearHistoryButton';
 
 const RUNTIME_URL =
   (import.meta.env.VITE_AGENT_API_URL as string | undefined) ??
@@ -37,12 +39,25 @@ function AgentActions() {
 export default function App() {
   return (
     <div className="app-shell">
-      <h1 className="app-header">F1 Fantasy Agent</h1>
-      <p className="app-subheader">
-        Ask about upcoming races or your best teams. The Telegram bot is unaffected.
-      </p>
       <CopilotKit runtimeUrl={RUNTIME_URL}>
+        <HistoryRestorer />
         <AgentActions />
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+            gap: 16,
+          }}
+        >
+          <div>
+            <h1 className="app-header">F1 Fantasy Agent</h1>
+            <p className="app-subheader">
+              Ask about upcoming races or your best teams. The Telegram bot is unaffected.
+            </p>
+          </div>
+          <ClearHistoryButton />
+        </div>
         <div className="chat-wrapper">
           <CopilotChat
             instructions="You are an assistant for an F1 Fantasy player. Use the registered tools to answer questions; the user will see rich UI components automatically when you call them."

--- a/web/src/components/ClearHistoryButton.tsx
+++ b/web/src/components/ClearHistoryButton.tsx
@@ -1,0 +1,38 @@
+// Phase 6.5 — clear chat history button.
+//
+// Small button rendered in the page header. On click:
+//   1. Wipe the localStorage key (`clear()`).
+//   2. Call `agent.setMessages([])` to immediately reset the
+//      in-memory chat — no reload required.
+
+import { useAgent } from '@copilotkit/react-core/v2';
+import { clear } from '../lib/chatHistoryStore';
+
+export function ClearHistoryButton() {
+  const { agent } = useAgent({ agentId: 'default' });
+
+  const onClick = (): void => {
+    clear();
+    agent?.setMessages([]);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        padding: '6px 12px',
+        fontSize: 12,
+        fontWeight: 600,
+        color: '#37404f',
+        background: '#f1f3f7',
+        border: '1px solid #d8dde6',
+        borderRadius: 6,
+        cursor: 'pointer',
+      }}
+      aria-label="Clear chat history"
+    >
+      Clear chat history
+    </button>
+  );
+}

--- a/web/src/components/HistoryRestorer.tsx
+++ b/web/src/components/HistoryRestorer.tsx
@@ -1,0 +1,109 @@
+// Phase 6.5 — chat history restore + auto-save.
+//
+// Mounted INSIDE <CopilotKit>. Uses `useAgent` to grab the live
+// AbstractAgent instance, then:
+//
+//   1. On first mount with a real agent: load persisted history
+//      from localStorage and `agent.setMessages()` it. This is
+//      gated by `restoredAgentRef` so we re-run if CopilotKit
+//      swaps the agent instance (stub → real) but never restore
+//      twice on the same instance.
+//
+//   2. After hydration: subscribe to message / run-status changes
+//      via the `useAgent({ updates: [...] })` config, debounce
+//      500 ms, and persist the current messages — but ONLY when
+//      `agent.isRunning === false`. Mid-stream saves would persist
+//      half-formed assistant replies that the user would see on
+//      reload as truncated text. The `OnRunStatusChanged` update
+//      guarantees this effect re-runs (and saves) the moment the
+//      stream completes.
+//
+// The hook returns `null` — it's a side-effect-only mount.
+//
+// See `src/lib/chatHistoryStore.ts` for the persistence contract.
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  UseAgentUpdate,
+  useAgent,
+} from '@copilotkit/react-core/v2';
+import type { AbstractAgent } from '@ag-ui/client';
+import type { Message } from '@ag-ui/core';
+import {
+  load,
+  save,
+  toStoredMessages,
+  toAgUiMessages,
+} from '../lib/chatHistoryStore';
+
+// Cheap fingerprint over the message array so React re-runs the
+// save effect when something visible actually changes. `length`
+// catches new messages; the trailing id + content-length tail
+// catches the streaming-delta case. Using deep equality / the raw
+// array reference would either miss in-place mutations or churn
+// every render.
+function fingerprint(messages: Message[] | undefined): string {
+  if (!messages || messages.length === 0) return '';
+  const last = messages[messages.length - 1];
+  const content = (last as { content?: unknown }).content;
+  let tail: string;
+  if (typeof content === 'string') {
+    tail = String(content.length);
+  } else if (Array.isArray(content)) {
+    tail = `block:${content.length}`;
+  } else {
+    tail = '0';
+  }
+  return `${messages.length}:${last.id ?? ''}:${tail}`;
+}
+
+export function HistoryRestorer(): null {
+  const { agent } = useAgent({
+    agentId: 'default',
+    updates: [
+      UseAgentUpdate.OnMessagesChanged,
+      UseAgentUpdate.OnRunStatusChanged,
+    ],
+  });
+
+  const restoredAgentRef = useRef<AbstractAgent | null>(null);
+  const [hydrated, setHydrated] = useState(false);
+  const saveTimer = useRef<number | undefined>(undefined);
+
+  // 1) ONE-SHOT restore per agent instance.
+  useEffect(() => {
+    if (!agent || restoredAgentRef.current === agent) return;
+    const stored = load();
+    if (stored.length > 0) {
+      agent.setMessages(toAgUiMessages(stored));
+    }
+    restoredAgentRef.current = agent;
+    // Defer flipping `hydrated` so the restored messages settle
+    // (and OnMessagesChanged fires for them) before the save effect
+    // arms. Without this microtask, the very first OnMessagesChanged
+    // could observe the pre-restore empty array and persist [].
+    queueMicrotask(() => setHydrated(true));
+  }, [agent]);
+
+  // 2) Debounced auto-save, gated on `hydrated` AND `!isRunning`.
+  const fp = fingerprint(agent?.messages);
+  const isRunning = agent?.isRunning ?? false;
+
+  useEffect(() => {
+    if (!hydrated || !agent) return;
+    if (isRunning) return;
+    if (saveTimer.current !== undefined) {
+      window.clearTimeout(saveTimer.current);
+    }
+    saveTimer.current = window.setTimeout(() => {
+      save(toStoredMessages(agent.messages));
+    }, 500);
+    return () => {
+      if (saveTimer.current !== undefined) {
+        window.clearTimeout(saveTimer.current);
+      }
+    };
+  }, [hydrated, agent, fp, isRunning]);
+
+  return null;
+}

--- a/web/src/lib/chatHistoryStore.ts
+++ b/web/src/lib/chatHistoryStore.ts
@@ -1,0 +1,198 @@
+// Browser-only chat history persistence for the F1 Fantasy web-chat
+// agent.
+//
+// Persists ONLY the last N user-or-assistant text messages of the
+// current conversation in `localStorage`. Phase 6.5.
+//
+// Why text-only:
+// - Tool calls / tool results / large blobs (`availableTeams`,
+//   leaderboard rows, live-score breakdowns) are NEVER persisted.
+//   Reloading must not let stale data re-enter the LLM context and
+//   must not bloat localStorage past the per-origin quota.
+// - The 12 React tool-render components do NOT reappear after a
+//   reload — only the user's question + the assistant's final text
+//   reply. This is the intentional v1 behavior. The persistence
+//   layer is for VISUAL CONTINUITY, not for context-passing
+//   efficiency.
+//
+// Failure modes handled:
+// - Missing key, corrupt JSON, version mismatch, non-array messages,
+//   or any item failing per-field validation → whole payload
+//   discarded, `load()` returns `[]`.
+// - `QuotaExceededError` (or any other `setItem` throw) → `clear()` +
+//   swallow. The chat keeps working with no history.
+// - `getItem` throws (private-browsing mode in some browsers,
+//   restricted iframe contexts) → treat as missing key.
+// - Duplicate ids inside the stored payload → de-duplicated on load
+//   to avoid React-key collisions.
+
+import type { Message } from '@ag-ui/core';
+
+const STORAGE_KEY = 'f1-fantasy-agent-history';
+const SCHEMA_VERSION = 1;
+const MAX_MESSAGES = 20;
+const MAX_BYTES = 100 * 1024;
+// Per-message content cap. Defends against a single pathological
+// message blowing the byte budget.
+const MAX_CONTENT_LEN = 8 * 1024;
+
+export type StoredMessage = {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+};
+
+type StoredPayload = {
+  version: number;
+  savedAt: string;
+  messages: StoredMessage[];
+};
+
+function isValidStoredMessage(value: unknown): value is StoredMessage {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.id !== 'string' || v.id.length === 0) return false;
+  if (v.role !== 'user' && v.role !== 'assistant') return false;
+  if (typeof v.content !== 'string') return false;
+  if (v.content.length > MAX_CONTENT_LEN) return false;
+  return true;
+}
+
+function dedupeById(messages: StoredMessage[]): StoredMessage[] {
+  const seen = new Set<string>();
+  const out: StoredMessage[] = [];
+  for (const m of messages) {
+    if (seen.has(m.id)) continue;
+    seen.add(m.id);
+    out.push(m);
+  }
+  return out;
+}
+
+export function load(): StoredMessage[] {
+  let raw: string | null;
+  try {
+    raw = window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    // Private mode / restricted context — treat as no history.
+    return [];
+  }
+  if (!raw) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!parsed || typeof parsed !== 'object') return [];
+
+  const payload = parsed as Record<string, unknown>;
+  if (payload.version !== SCHEMA_VERSION) return [];
+  if (!Array.isArray(payload.messages)) return [];
+
+  const validated: StoredMessage[] = [];
+  for (const item of payload.messages) {
+    if (!isValidStoredMessage(item)) {
+      // Whole-payload reject: safer to start fresh than to splice
+      // in a partially-valid history that confuses React keys.
+      return [];
+    }
+    validated.push(item);
+  }
+
+  return dedupeById(validated);
+}
+
+function trimToBudget(messages: StoredMessage[]): StoredMessage[] {
+  let trimmed = messages;
+  if (trimmed.length > MAX_MESSAGES) {
+    trimmed = trimmed.slice(-MAX_MESSAGES);
+  }
+  // Byte cap: drop oldest until the serialized payload fits.
+  while (trimmed.length > 0) {
+    const payload: StoredPayload = {
+      version: SCHEMA_VERSION,
+      savedAt: new Date().toISOString(),
+      messages: trimmed,
+    };
+    if (JSON.stringify(payload).length <= MAX_BYTES) break;
+    trimmed = trimmed.slice(1);
+  }
+  return trimmed;
+}
+
+export function save(messages: StoredMessage[]): void {
+  const trimmed = trimToBudget(messages);
+  const payload: StoredPayload = {
+    version: SCHEMA_VERSION,
+    savedAt: new Date().toISOString(),
+    messages: trimmed,
+  };
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    // Quota exceeded or any other storage failure — clear and move
+    // on. Better to lose history than to leak the failure into the
+    // chat experience.
+    clear();
+  }
+}
+
+export function clear(): void {
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Nothing to do — storage isn't writeable in this context.
+  }
+}
+
+// Flatten the AG-UI `Message.content` into a plain string. Strict
+// allowlist: only blocks with `type === 'text'` and a string `.text`
+// survive. Image / audio / tool-content blocks are dropped entirely.
+function flattenContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  const out: string[] = [];
+  for (const block of content) {
+    if (
+      block &&
+      typeof block === 'object' &&
+      (block as { type?: unknown }).type === 'text' &&
+      typeof (block as { text?: unknown }).text === 'string'
+    ) {
+      out.push((block as { text: string }).text);
+    }
+  }
+  return out.join('');
+}
+
+// Convert the live `agent.messages` array into the persistence shape.
+// Drops `tool` + `developer` rows. Drops user/assistant rows whose
+// flattened content is empty or exceeds the per-message cap. Drops
+// rows without an id (defensive — AG-UI always sets one, but TS
+// allows undefined fields on union narrowing).
+export function toStoredMessages(messages: Message[]): StoredMessage[] {
+  const out: StoredMessage[] = [];
+  for (const msg of messages) {
+    if (msg.role !== 'user' && msg.role !== 'assistant') continue;
+    if (typeof msg.id !== 'string' || msg.id.length === 0) continue;
+    const content = flattenContent((msg as { content?: unknown }).content);
+    if (content.length === 0 || content.length > MAX_CONTENT_LEN) continue;
+    out.push({ id: msg.id, role: msg.role, content });
+  }
+  return out;
+}
+
+// Convert the persistence shape back into AG-UI `Message`s with the
+// right discriminated-union narrowing. Explicit construction avoids
+// the `as unknown as Message[]` cast that would hide future shape
+// drift.
+export function toAgUiMessages(stored: StoredMessage[]): Message[] {
+  return stored.map((m): Message => {
+    if (m.role === 'user') {
+      return { id: m.id, role: 'user', content: m.content };
+    }
+    return { id: m.id, role: 'assistant', content: m.content };
+  });
+}


### PR DESCRIPTION
## Phase 6.5 — Chat history persistence

Last Phase 6 slice. After this lands, **Phase 6 is fully shipped** and the only remaining work is frontend deployment + CORS hardening (both parked).

### What
After a page reload, the last 20 user-or-assistant **text** messages reappear in the chat. Tool calls, tool results, and large blobs (`availableTeams`, leaderboard rows, live-score payloads) are **NEVER persisted** — reloads cannot re-introduce stale data into the LLM context or bloat localStorage past the per-origin quota.

The 12 rich tool-render components do NOT reappear after reload — only the user's question + the assistant's final text reply. **This is intentional v1 behavior.** Persistence is for visual continuity, not for context-passing efficiency.

### API correction (worth flagging for future contributors)
The earlier rubber-duck pass assumed `useCopilotMessagesContext()` was the right hook. **That hook does NOT exist** in the installed CopilotKit version. The real hooks live at `@copilotkit/react-core/v2` (subpath import — `useAgent` and `UseAgentUpdate` are NOT in the root). Future contributors: always check `node_modules/@copilotkit/react-core/dist/v2/...d.cts` when looking for the v2 hooks.

### How
```
page load
   ↓
<HistoryRestorer /> mounts inside <CopilotKit>
   ↓
useAgent({ agentId: 'default', updates: [OnMessagesChanged, OnRunStatusChanged] })
   ↓
1. Per-agent-instance restore (restoredAgentRef === agent guard)
       load() → toAgUiMessages(stored) → agent.setMessages(restored)
       queueMicrotask(() => setHydrated(true))
   ↓
       OnMessagesChanged + OnRunStatusChanged re-trigger the effect
       so the save fires the moment a stream completes
```

### Rubber-duck-vetted (second pass)
Three blockers + six important findings from the rubber-duck pass — all addressed:

| # | Finding | Fix |
|---|---|---|
| 🛑 1 | Restore overwritten by an early empty save | `hydrated` state gate (queueMicrotask flip) |
| 🛑 2 | Agent stub→real swap could lose restoration | `restoredAgentRef.current === agent` per-instance tracking |
| 🛑 3 | Mid-stream partial saves persist half-formed replies | Save gated on `agent.isRunning === false` + OnRunStatusChanged dep |
| ⚠️ 4 | `as unknown as Message[]` hides shape drift | Explicit `toAgUiMessages()` converter |
| ⚠️ 5 | Corrupt localStorage could inject bad data | `load()` validates every item; whole-payload reject |
| ⚠️ 6 | `[agent, agent.messages]` deps fragile if AG-UI mutates in place | Cheap fingerprint `length:lastId:lastContentLen` as the dep |
| ⚠️ 7 | ContentBlock flattening risk | Strict allowlist — only `type === 'text'` blocks survive |
| ⚠️ 9 | Reused-id collisions on load | `dedupeById` in `load()` |
| ⚠️ 10 | `localStorage` can throw on read too (private mode) | try/catch on getItem AND setItem |

### Files
| File | Change |
|---|---|
| `web/src/lib/chatHistoryStore.ts` | **NEW** — `load` / `save` / `clear` / `toStoredMessages` / `toAgUiMessages`. Schema-versioned `{ version: 1, savedAt, messages }`. Caps: 20 messages OR 100 KB total. Strict per-item validation. Quota-safe. |
| `web/src/components/HistoryRestorer.tsx` | **NEW** — restore + debounced save with all three blocker mitigations baked in |
| `web/src/components/ClearHistoryButton.tsx` | **NEW** — header button; `clear()` + `agent?.setMessages([])` |
| `web/src/App.tsx` | Single `<CopilotKit>` wrapping everything (so all three hooks share the same agent instance); `<HistoryRestorer />` + `<ClearHistoryButton />` mounted inside; header restructured to two-column flex |
| `docs/agent-rollout-plan.md` | Marks 6.5 MERGED; flips "Current state" to "Phase 6 ALL shipped; only remaining work is deployment + CORS, both parked" (bundled per 2026-05-18 policy) |

### Verification (all green)
- **`npm test`** — 850/850 passing (backend untouched)
- **`cd web && npm run build`** — clean (TS catches converter shape drift — no unsafe casts)
- **`npm run lint`** — only 4 pre-existing warnings, 0 errors
- **Smoke** — manual reload-after-conversation in dev frontend pending; the design is type-safe + rubber-duck-vetted on all the race conditions

### No new unit tests for the store
The `web/` package has no test harness (no `jest` / `vitest` / `test` script in `web/package.json`). Per repo policy we don't add infra for one module. Matches the pattern for all 12 existing React components — type-safety + build gate + manual reload smoke is the established gate.

### Risk
Low. The persistence layer is purely additive — happy-path behavior of every existing tool is identical. The shipped code addresses all the race conditions the rubber-duck flagged. The unique-id check + version-schema gate provide forward compat for shape changes.

### What ships when this merges
- ✅ Phase 6.1 — Token-usage logging
- ✅ Phase 6.2 — Tool-error UX
- ✅ Phase 6.3 — Docs refresh
- ✅ Phase 6.4 — Regression sweep
- ✅ Phase 6.5 — History persistence ← **this PR**
- ⏸ Frontend deployment + CORS — parked

🤖 Generated with [GitHub Copilot CLI](https://github.com/github/copilot-cli)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>