### PR TITLE
fix(ci): three post-merge workflow failures (bash interpolation, OIDC RBAC perm, telegram message length)

### DIFF
--- a/.github/workflows/commit_to_main_telegram-notifier.yml
+++ b/.github/workflows/commit_to_main_telegram-notifier.yml
@@ -8,6 +8,17 @@ jobs:
   notifyTelegram:
     runs-on: ubuntu-latest
     steps:
+      - name: Extract commit title (avoid Telegram's 4096-char limit)
+        id: title
+        env:
+          FULL_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          # Only the first line of the commit message — the subject — so the
+          # full multi-line body (which can blow past Telegram's 4096-char cap)
+          # never gets passed to the action.
+          TITLE=$(printf '%s\n' "$FULL_COMMIT_MESSAGE" | head -n 1)
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+
       - name: send custom message
         uses: appleboy/telegram-action@master
         with:
@@ -16,5 +27,5 @@ jobs:
           message: |
             A push was made to the main branch in ${{ github.repository }}
             By: ${{ github.actor }}
-            Commit message: ${{ github.event.head_commit.message }}
+            Commit: ${{ steps.title.outputs.title }}
             Commit link: [GitHub Commit](https://github.com/${{ github.repository }}/commit/${{ github.sha }})

--- a/.github/workflows/main_f1-fantazy-agent-func.yml
+++ b/.github/workflows/main_f1-fantazy-agent-func.yml
@@ -38,8 +38,13 @@ jobs:
 
       - name: Extract commit title
         id: extract_commit_title
+        # `$COMMIT_MESSAGE` (shell env var, populated from the workflow-level `env:` block)
+        # is used instead of `${{ env.COMMIT_MESSAGE }}` (Actions string-interpolation into
+        # the script). The latter substitutes the raw multi-line commit body BEFORE bash
+        # parses the script — special chars like `)` or backticks in commit bodies break
+        # the parser. Shell-var form keeps the body in a real variable.
         run: |
-          title=$(printf '%s\n' "${{ env.COMMIT_MESSAGE }}" | head -n 1)
+          title=$(printf '%s\n' "$COMMIT_MESSAGE" | head -n 1)
           echo "COMMIT_MESSAGE=$title" >> "$GITHUB_ENV"
           printf 'commit_message=%s\n' "$title" >> "$GITHUB_OUTPUT"
 
@@ -115,9 +120,12 @@ jobs:
           subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_00873174CBBD48D3871911006820901C }}
 
       - name: Extract commit title
+      - name: Extract commit title
         id: extract_commit_title
+        # See note on the matching step in the `build` job for why `$COMMIT_MESSAGE`
+        # is used instead of `${{ env.COMMIT_MESSAGE }}`.
         run: |
-          title=$(printf '%s\n' "${{ env.COMMIT_MESSAGE }}" | head -n 1)
+          title=$(printf '%s\n' "$COMMIT_MESSAGE" | head -n 1)
           printf 'commit_message=%s\n' "$title" >> "$GITHUB_OUTPUT"
 
       - name: 'Run Azure Functions Action'

--- a/.github/workflows/main_f1-fantazy-bot-func.yml
+++ b/.github/workflows/main_f1-fantazy-bot-func.yml
@@ -28,8 +28,13 @@ jobs:
 
       - name: Extract commit title
         id: extract_commit_title
+        # `$COMMIT_MESSAGE` (shell env var, populated from the workflow-level `env:` block)
+        # is used instead of `${{ env.COMMIT_MESSAGE }}` (Actions string-interpolation into
+        # the script). The latter substitutes the raw multi-line commit body BEFORE bash
+        # parses the script — special chars like `)` or backticks in commit bodies break
+        # the parser. Shell-var form keeps the body in a real variable.
         run: |
-          title=$(printf '%s\n' "${{ env.COMMIT_MESSAGE }}" | head -n 1)
+          title=$(printf '%s\n' "$COMMIT_MESSAGE" | head -n 1)
           echo "COMMIT_MESSAGE=$title" >> "$GITHUB_ENV"
           printf 'commit_message=%s\n' "$title" >> "$GITHUB_OUTPUT"
 
@@ -89,8 +94,10 @@ jobs:
 
       - name: Extract commit title
         id: extract_commit_title
+        # See note on the matching step in the `build` job for why `$COMMIT_MESSAGE`
+        # is used instead of `${{ env.COMMIT_MESSAGE }}`.
         run: |
-          title=$(printf '%s\n' "${{ env.COMMIT_MESSAGE }}" | head -n 1)
+          title=$(printf '%s\n' "$COMMIT_MESSAGE" | head -n 1)
           printf 'commit_message=%s\n' "$title" >> "$GITHUB_OUTPUT"
 
       - name: 'Run Azure Functions Action'


### PR DESCRIPTION
PR #194's merge to main triggered all the deploy workflows for the first time with this commit body, which surfaced three independent bugs. None caused production impact (the failures were all at the very first step of each workflow, before any deploy ran), but they need fixing so future merges to main aren't broken.

## Failures

| Workflow | Failure | Root cause |
|---|---|---|
| `main_f1-fantazy-bot-func.yml` (build) | `bash: syntax error near unexpected token \`(\`` | `${{ env.COMMIT_MESSAGE }}` is interpolated **literally** into the script; the `)` in my commit body broke the parser. **PRE-EXISTING** latent bug — only triggered by commit bodies with shell-special chars. |
| `main_f1-fantazy-agent-func.yml` (build) | Same | Same bug, NEW — copied from the bot workflow into the agent workflow. |
| `deploy-infra-agent-func.yml` (deploy) | `Authorization failed ... Microsoft.Authorization/roleAssignments/write` | The OIDC UAMI (`f1-fantazy-bot-f-id-bb39`) has `Key Vault Secrets User` but no write permission on role assignments. Re-applying the ARM template tried to (idempotently) re-PUT the existing role assignments, which still requires write perms. |
| `commit_to_main_telegram-notifier.yml` | `Bad Request: message is too long` | Workflow passed the full multi-line commit body into `telegram-action`'s `message:` (~70 lines / ~3KB); Telegram caps at 4096 chars. |

## Fixes

1. **Bash syntax** — Use the shell variable form (`$COMMIT_MESSAGE`, populated from the workflow-level `env:` block) instead of the Actions interpolation form. Bash now only sees a variable reference, never the raw body. Applied to both `main_*` function-app workflows (2 occurrences each = 4 edits total). Inline comment in the steps explains the rationale.

2. **UAMI RBAC permission** — Granted `Role Based Access Control Administrator` to the UAMI scoped to `f1-fantasy-kv` ONLY (least-privilege; managing role assignments on that single KV is the only thing the ARM template needs to do). Granted out-of-band:
   ```bash
   az role assignment create \
     --assignee-object-id 2284b287-2269-4797-9cc4-0089b6e50c09 \
     --assignee-principal-type ServicePrincipal \
     --role "Role Based Access Control Administrator" \
     --scope "/subscriptions/<sub>/resourceGroups/f1-fantazy-bot/providers/Microsoft.KeyVault/vaults/f1-fantasy-kv"
   ```
   Documented in the commit body for future contributors.

3. **Telegram notifier message length** — Added a step that extracts just the first line (commit subject) via `head -n 1` and writes it to `$GITHUB_OUTPUT`; the `telegram-action` now references that output instead of the full `github.event.head_commit.message`.

## Verification

- ✅ `npm test` → 870/870 still passing.
- ✅ `python3 -c "import yaml; yaml.safe_load(...)"` clean on all 3 touched workflow files.
- ✅ Telegram bot prod confirmed unaffected by yesterday's failed deploys: still serving `COMMIT_ID=18b6edd` (PR #193).
- ✅ Agent function app unchanged (still Stopped per manual disable).

## Acceptance (on merge to main)

All push-to-main workflows should go green:
- `main_f1-fantazy-bot-func.yml` (bash fix → build passes → telegram bot redeploys to prod)
- `main_f1-fantazy-agent-func.yml` (bash fix → build passes → agent code re-deploys to prod slot; slot stays Stopped though)
- `deploy-infra-agent-func.yml` (UAMI permission grant → ARM re-apply succeeds)
- `deploy-infra-agent-web.yml` (was already green)
- `main_f1-fantazy-agent-web.yml` (was already green)
- `commit_to_main_telegram-notifier.yml` (truncation fix → message fits)