### PR TITLE
fix(ci): remove duplicate "Extract commit title" step in agent func deploy workflow

### DIFF
--- a/.github/workflows/main_f1-fantazy-agent-func.yml
+++ b/.github/workflows/main_f1-fantazy-agent-func.yml
@@ -120,7 +120,6 @@ jobs:
           subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_00873174CBBD48D3871911006820901C }}
 
       - name: Extract commit title
-      - name: Extract commit title
         id: extract_commit_title
         # See note on the matching step in the `build` job for why `$COMMIT_MESSAGE`
         # is used instead of `${{ env.COMMIT_MESSAGE }}`.


### PR DESCRIPTION
Follow-up to PR #195. My edit to `main_f1-fantazy-agent-func.yml`'s deploy job left two consecutive `- name: Extract commit title` lines — the original step's name line plus my new step's name line.

Python's `yaml.safe_load` is lenient about steps with only a `name` field (no `run` or `uses`), so my local validation passed. But GitHub's stricter Actions schema validation rejects steps with no action, which is why the agent func deploy run on PR #195's merge showed up as:

```
.github/workflows/main_f1-fantazy-agent-func.yml — failure 0s
```

(GitHub uses the file path instead of the workflow `name:` when parsing fails) and `gh run view --log-failed` returned "log not found" — the workflow never started.

## Fix

One-line deletion: remove the orphan `- name: Extract commit title` line that had no `run`/`uses` body.

## Verification

- ✅ `python3 -c "import yaml; yaml.safe_load(...)"` still passes (unchanged — was passing before too).
- ✅ Added a stricter custom validator (every step has either `run` or `uses` alongside `name`) — now passes.
- ✅ Scanned all other workflows for the same duplicate-step pattern: none found.
- ✅ `npm test` → 870/870 still passing.

## Acceptance

On merge, the agent func deploy workflow will fire (this PR touches that workflow file, which is in its `paths:` filter) and should reach the deploy step successfully. The agent function app stays Stopped per the manual disable; the deploy just updates `WEBSITE_RUN_FROM_PACKAGE` on the prod slot (which restart-on-resume would pick up).