### PR TITLE
feat(agent): use AGENT: prefix for agent-process Telegram logs

### DIFF
--- a/src/agent/notifierBot.js
+++ b/src/agent/notifierBot.js
@@ -16,11 +16,18 @@
 
 const TelegramBot = require('node-telegram-bot-api');
 
+// Prefix used by `sendLogMessage` / `sendErrorMessage` /
+// `sendMessageToAdmins` in `src/utils/utils.js` to tag the log line.
+// The agent runs in its own process and must be visually distinct from
+// the original Telegram-bot path (which uses the default `BOT:` prefix).
+const AGENT_LOG_PREFIX = 'AGENT';
+
 let cachedBot = null;
 
 function makeNoopBot() {
   return {
     sendMessage: async () => undefined,
+    _logPrefix: AGENT_LOG_PREFIX,
   };
 }
 
@@ -41,6 +48,7 @@ function getNotifierBot() {
 
   try {
     cachedBot = new TelegramBot(token, { polling: false });
+    cachedBot._logPrefix = AGENT_LOG_PREFIX;
   } catch (err) {
     console.error(
       'AGENT: Failed to construct notifier TelegramBot, falling back to noop:',
@@ -56,4 +64,4 @@ function resetNotifierBotForTests() {
   cachedBot = null;
 }
 
-module.exports = { getNotifierBot, resetNotifierBotForTests };
+module.exports = { getNotifierBot, resetNotifierBotForTests, AGENT_LOG_PREFIX };

--- a/src/agent/tokenUsageMiddleware.test.js
+++ b/src/agent/tokenUsageMiddleware.test.js
@@ -31,11 +31,14 @@ function makeReadable(chunks) {
 
 // `sendLogMessage(bot, line)` calls `bot.sendMessage(LOG_CHANNEL_ID, line)`
 // internally, so faking the bot is enough to observe what was logged.
+// We tag the fake bot with `_logPrefix: 'AGENT'` to mirror the production
+// notifier bot — `sendLogMessage` reads that to choose the line prefix.
 function makeBot() {
   const calls = [];
 
   return {
     calls,
+    _logPrefix: 'AGENT',
     sendMessage: jest.fn(async (chatId, line) => {
       calls.push({ chatId, line });
     }),
@@ -131,7 +134,7 @@ describe('createTokenUsageMiddleware', () => {
     expect(bot.sendMessage).toHaveBeenCalledTimes(2);
     const firstLine = bot.calls[0].line;
     const secondLine = bot.calls[1].line;
-    expect(firstLine).toContain('BOT: Agent step usage');
+    expect(firstLine).toContain('AGENT: Agent step usage');
     expect(firstLine).toContain('model: gpt-test-1');
     expect(firstLine).toContain('step: 1');
     expect(firstLine).toContain('prompt: 120');

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -64,6 +64,18 @@ const sendMessage = async function (bot, chatId, message, options) {
   await bot.sendMessage(chatId, message, options);
 };
 
+// Resolve the log-line prefix for a given bot instance. The agent's
+// notifier bot tags itself with `_logPrefix = 'AGENT'` so its
+// Telegram-bound log lines are visually distinct from the original
+// Telegram bot path. Untagged bots fall back to `BOT`.
+const resolveLogPrefix = function (bot) {
+  if (bot && typeof bot._logPrefix === 'string' && bot._logPrefix.length > 0) {
+    return bot._logPrefix;
+  }
+
+  return 'BOT';
+};
+
 exports.sendLogMessage = async function (bot, logMessage) {
   if (!LOG_CHANNEL_ID) {
     console.error('LOG_CHANNEL_ID is not set');
@@ -78,7 +90,7 @@ exports.sendLogMessage = async function (bot, logMessage) {
     env = 'test';
   }
 
-  let log = `BOT: ${logMessage}
+  let log = `${resolveLogPrefix(bot)}: ${logMessage}
 env: ${env}`;
 
   if (
@@ -109,7 +121,7 @@ exports.sendErrorMessage = async function (bot, errorMessage) {
     env = 'test';
   }
 
-  let log = `BOT: ${errorMessage}
+  let log = `${resolveLogPrefix(bot)}: ${errorMessage}
 env: ${env}`;
 
   if (
@@ -129,7 +141,7 @@ pid: ${process.pid}`;
 
 exports.sendMessageToAdmins = async function (bot, message) {
   const adminChatIds = [KILZI_CHAT_ID, DORSE_CHAT_ID];
-  const msg = `BOT: ${message}`;
+  const msg = `${resolveLogPrefix(bot)}: ${message}`;
 
   for (const chatId of adminChatIds) {
     await sendMessage(bot, chatId, msg);

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -165,6 +165,33 @@ describe('utils', () => {
 
       consoleErrorSpy.mockRestore();
     });
+
+    it('defaults to BOT: prefix when bot has no _logPrefix tag', async () => {
+      const botMock = { sendMessage: jest.fn().mockResolvedValue() };
+
+      await sendLogMessage(botMock, 'untagged bot');
+
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        expect.any(Number),
+        expect.stringMatching(/^BOT: untagged bot/),
+        undefined,
+      );
+    });
+
+    it('uses the bot._logPrefix tag when set (agent path)', async () => {
+      const botMock = {
+        _logPrefix: 'AGENT',
+        sendMessage: jest.fn().mockResolvedValue(),
+      };
+
+      await sendLogMessage(botMock, 'tagged bot');
+
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        expect.any(Number),
+        expect.stringMatching(/^AGENT: tagged bot/),
+        undefined,
+      );
+    });
   });
 
   describe('sendErrorMessage', () => {


### PR DESCRIPTION
## Problem
`sendLogMessage` / `sendErrorMessage` / `sendMessageToAdmins` in `src/utils/utils.js` hardcoded `BOT: ` on every Telegram-bound line. The agent runs in its own process and reuses these helpers (directly from `tokenUsageMiddleware` and `wrapToolExecute`, transitively via `cacheBootstrap → initializeCaches(getNotifierBot())`), so its logs landed in the channels visually indistinguishable from the original Telegram bot path.

## Change
Tag the agent's notifier bot (`src/agent/notifierBot.js`) with `_logPrefix = 'AGENT'` and have the shared logging helpers read it (defaulting to `'BOT'` when absent). The marker rides on the bot reference, so the prefix propagates automatically to every direct and transitive caller — no per-call-site changes needed. The Telegram bot's real `TelegramBot` instance is untagged → its log lines stay `BOT:` (byte-identical behaviour).

## Files
- `src/utils/utils.js` — added `resolveLogPrefix(bot)`; replaced the 3 hardcoded `BOT:` strings.
- `src/agent/notifierBot.js` — set `_logPrefix = 'AGENT'` on both the real non-polling `TelegramBot` and the noop fallback; exported `AGENT_LOG_PREFIX`.
- `src/agent/tokenUsageMiddleware.test.js` — updated the one explicit `BOT:` assertion to `AGENT:` and tagged the fake bot.
- `src/utils/utils.test.js` — added regression tests for both paths (tagged → `AGENT:`, untagged → `BOT:`).

## Verification
- `npm test` — 872 passing.
- `npm run lint` — no new warnings (4 pre-existing in unrelated files).
- Manual sanity check on `npm run dev:agent` — stdout token-usage line starts with `AGENT:`.

## Out of scope
- No `WEB:` prefix / frontend → backend logging endpoint (frontend doesn't log to Telegram).
- Telegram-bot path keeps `BOT:` unchanged.
