### PR TITLE
feat(web-auth): gate the web-chat agent behind Google sign-in + allowlist

### DIFF
--- a/.github/workflows/main_f1-fantazy-agent-web.yml
+++ b/.github/workflows/main_f1-fantazy-agent-web.yml
@@ -37,10 +37,15 @@ jobs:
         working-directory: web
         run: npm ci
 
-      - name: Build web (VITE_AGENT_API_URL baked in)
+      - name: Build web (VITE_AGENT_API_URL + VITE_GOOGLE_CLIENT_ID baked in)
         working-directory: web
         env:
           VITE_AGENT_API_URL: ${{ env.AGENT_API_URL }}
+          # When this secret is not configured the build still ships;
+          # the frontend then renders the chat without an auth gate
+          # (and the backend must also bypass — see infra/agent-func/
+          # apply-settings.sh). Set the secret to roll out Google auth.
+          VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
         run: npm run build
 
       - name: Deploy to Azure Static Web Apps (production)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Both surfaces share the same business logic via **pure cores** in `src/cores/`. 
 - **Internationalization:** `src/i18n.js` and `src/translations.js` provide language support (English/Hebrew) used throughout handlers.
 - **AI Assist:** `src/prompts.js` defines system prompts. `/ask`-style natural language queries are handled by `src/commandsHandler/askHandler.js`, which leverages Azure OpenAI to map free-text requests into command sequences.
 - **Logic Cores:** `src/cores/` holds **pure** business-logic functions that take inputs and return structured JSON. They do not depend on `bot`, `t()`, or `sendMessage`. Each Telegram handler is being progressively refactored into `(pure core in src/cores/) + (thin Telegram adapter)`. The same core is consumed by the web-chat agent's tools — so a question like "best teams with VER but no ALO" runs through the same calculator as the `/best_teams` command. **Refactor rule:** existing handler tests must keep passing unchanged after the extraction; if they don't, fix the refactor, not the test. Cores extracted so far: `nextRacesCore`, `bestTeamsCore`, `userTeamsCore`, `followedTeamsCore`, `leaderboardCore`, `bestTeamScenariosCore`, `nextRaceInfoCore`, `raceWeatherCore`, `deadlineCore`, `currentTeamCore`, `liveScoreCore`. Cores that need side effects (e.g. weather fetch logging) accept optional `onFetch`/`onError` callbacks — the Telegram adapter wires them to bot-side helpers; the agent path omits them. Pure scoring helpers shared between a handler and its core live in `src/utils/` (e.g. `src/utils/liveScoreCalc.js` for `mapLockedTeamForScoring` / `calculateLiveScoreBreakdown` / `deriveLiveScoreOptions`) so the core never depends on the adapter.
-- **Agent (Web Chat):** `src/agent/`, `agentWebhook/`, and `web/` together implement a second user-facing surface. Identity is resolved from the `AGENT_HARDCODED_CHAT_ID` env var (v1) so all tool calls operate as that user against the same caches/blobs as the Telegram bot. See the [Agent (Web Chat)](#agent-web-chat) section for the full architecture, the cores↔tools pattern, and how to add a new tool with a matching React component.
+- **Agent (Web Chat):** `src/agent/`, `agentWebhook/`, and `web/` together implement a second user-facing surface. **Identity is per-request**, propagated through `AsyncLocalStorage` from the agent webhook into `getAgentChatId()`. The webhook verifies the caller's Google ID token, looks the email up in the `WebUserAllowlist` Azure Table to resolve a Telegram chatId, then runs the entire CopilotKit invocation inside that ALS scope. When `GOOGLE_CLIENT_ID` is unset (local dev + the test slot of the Function App) the auth gate is bypassed and `AGENT_HARDCODED_CHAT_ID` is used instead. See [Web auth](#web-auth) for the full pipeline and the three new Telegram admin commands (`/allow_web_user`, `/revoke_web_user`, `/list_web_users`) that manage the allowlist.
 
 ---
 
@@ -72,7 +72,7 @@ Both surfaces share the same business logic via **pure cores** in `src/cores/`. 
 - `/follow_league`, `/unfollow_league`, `/teams_tracker`, `/leaderboard`, `/league_graphs`, `/league_changes`
 - `/report_bug` _(reply-based — uses pending reply manager)_
 
-**Admin-only:** `/trigger_scraping`, `/trigger_api_data`, `/trigger_api_data_locked`, `/trigger_next_race_info`, `/trigger_live_score_scheduler`, `/get_botfather_commands`, `/billing_stats`, `/version`, `/list_users`, `/send_message_to_user`, `/broadcast`, `/set_nickname`, `/live_score`, `/upload_drivers_photo`, `/upload_constructors_photo`
+**Admin-only:** `/trigger_scraping`, `/trigger_api_data`, `/trigger_api_data_locked`, `/trigger_next_race_info`, `/trigger_live_score_scheduler`, `/get_botfather_commands`, `/billing_stats`, `/version`, `/list_users`, `/send_message_to_user`, `/broadcast`, `/set_nickname`, `/live_score`, `/upload_drivers_photo`, `/upload_constructors_photo`, `/allow_web_user`, `/revoke_web_user`, `/list_web_users`
 
 ### Announcements file (`/whats_new`)
 
@@ -840,17 +840,148 @@ wrapToolExecute(name, fn) catches → generates 8-char errorId (slice of randomU
 | `AZURE_OPENAI_ENDPOINT` | Agent | Azure OpenAI host (works for both `*.openai.azure.com` and `*.services.ai.azure.com`). |
 | `AZURE_OPENAI_API_KEY` | Agent | Azure OpenAI auth. |
 | `AZURE_OPEN_AI_MODEL` | Agent + Telegram `/ask` | Deployment name (used by `azure.chat(deployment)`). |
-| `AGENT_HARDCODED_CHAT_ID` | Agent | v1 single-user identity. The LLM never sees it. Defaults to `KILZI_CHAT_ID` in `scripts/dev-agent-server.js` if absent. |
+| `AGENT_HARDCODED_CHAT_ID` | Agent | Fallback identity used when no per-request context is active (local dev + test slot + cache bootstrap). The LLM never sees it. Defaults to `KILZI_CHAT_ID` in `scripts/dev-agent-server.js` if absent. |
+| `GOOGLE_CLIENT_ID` | Agent (optional) | OAuth 2.0 Web client ID. NOT a secret — safe in app settings. When set, the agent webhook enforces Google sign-in + allowlist lookup on every POST. When unset (local dev, test slot), auth is bypassed and `AGENT_HARDCODED_CHAT_ID` is used instead. |
+| `VITE_GOOGLE_CLIENT_ID` | SWA build env (optional) | Same value as `GOOGLE_CLIENT_ID`, baked into the bundle by the production SWA build (NOT PR previews). Unset = login screen is skipped (matches the backend bypass). |
 | `TELEGRAM_BOT_TOKEN` | Agent (optional) | If set, the agent's notifier bot sends token-usage + tool-error logs to the same Telegram channels the main bot uses. If unset, logs stay on stdout — local dev without Telegram still works. |
 | `LOG_CHANNEL_ID` | Telegram bot | Token-usage logs land here from BOTH processes when their notifier bots have a Telegram token. Set in `src/constants.js`. |
 | `ERRORS_CHANNEL_ID` | Telegram bot | Tool errors with `errorId` land here. Set in `src/constants.js`. |
 | `<other Azure Storage creds>` | Agent + Telegram | Cache init reads (and occasionally writes) league rosters from Azure Storage — same creds the bot uses. |
 
-### Identity model (v1)
+### Identity model
 
-- `AGENT_HARDCODED_CHAT_ID` env var is the only identity. `src/agent/identity.js` reads it once and exposes `getAgentChatId()`.
-- The LLM **never** sees or controls this value. Tool handlers receive it from the runtime context, not from LLM-controlled arguments — this avoids prompt-injection escalating to "act as another user".
-- Future phases will replace this with proper auth (token / bot login).
+The agent acts as a **per-request chatId** propagated through Node's
+`AsyncLocalStorage`. Resolution order inside `getAgentChatId()`
+(`src/agent/identity.js`):
+
+1. **Request context** set by `runWithRequestContext({ chatId, email,
+   sub }, fn)` (`src/agent/requestContext.js`). The agent webhook
+   verifies the caller's Google ID token (see [Web auth](#web-auth)),
+   looks the email up in the `WebUserAllowlist` Azure Table, then
+   wraps the entire CopilotKit runtime invocation in that scope. Every
+   tool's `execute(args)` reads from `getRequestContext()` indirectly
+   via `getAgentChatId()` — the LLM never sees `chatId` or `email` in
+   its `args`.
+2. **`AGENT_HARDCODED_CHAT_ID` env var** — used by local dev
+   (`scripts/dev-agent-server.js`), the test slot of the agent
+   Function App (auth gate intentionally bypassed for PR validation),
+   and background paths that run outside an HTTP request (e.g.
+   `cacheBootstrap`).
+3. **Throw** — neither available; tools cannot proceed without an
+   identity.
+
+The LLM **never** sees or controls the resolved chatId/email — those
+are derived from a token the LLM cannot manufacture. This blocks
+prompt injection from escalating to "act as another user".
+
+### Web auth
+
+The web chat at `https://f1.kilzid.com` is gated by **Google Sign-In**
+(via `@react-oauth/google` on the frontend and `google-auth-library`
+on the backend). Anonymous visitors see only the login screen — no
+chat UI is mounted.
+
+**Flow:**
+
+```
+browser
+  │  <GoogleLogin /> → ID token (JWT)
+  │  AuthContext caches token in sessionStorage (NOT localStorage —
+  │  closes tab = sign out)
+  │  <CopilotKit headers={() => ({ Authorization: `Bearer …` })}>
+  │  useAuthFetchInterceptor watches window.fetch for 401s from
+  │  RUNTIME_URL → on 401 calls setRejection() + signOut()
+  ▼
+agentWebhook/index.js
+  │  authenticateRequest(req, { lookupAllowedUser })
+  │    ├── extracts Bearer
+  │    ├── verifies via google-auth-library (aud, iss, email_verified)
+  │    └── looks up the lowercased email in `WebUserAllowlist`
+  │  status → HTTP:
+  │    OK         → runWithRequestContext({ chatId, email, sub }, …)
+  │    BYPASSED   → falls through (GOOGLE_CLIENT_ID unset)
+  │    UNAUTHORIZED → 401 + JSON { error, reason }
+  │    FORBIDDEN  → 401 + JSON { error, reason, email }
+  ▼
+CopilotKit → BuiltInAgent → tool execute()
+  ▼
+getAgentChatId() reads ALS context → the right user's data
+```
+
+**Backend bypass:** when `GOOGLE_CLIENT_ID` is unset on the Function
+App, `authenticateRequest` returns `BYPASSED` and the webhook falls
+through to the legacy hardcoded-chatId path. Local dev, the test
+slot, and the initial production deploy all start in bypassed mode;
+enabling the gate is a one-line app-setting change. The frontend
+mirrors the bypass: when `VITE_GOOGLE_CLIENT_ID` is empty at build
+time, the login screen is skipped entirely (no Google client to
+authenticate against).
+
+**Allowlist storage (`src/webUserAllowlistService.js`):** Azure Table
+`WebUserAllowlist`, single partition `'WebUser'`. RowKey is the
+**lowercased email** (case-insensitive lookups). Schema:
+
+| Field          | Notes                                                       |
+| -------------- | ----------------------------------------------------------- |
+| `partitionKey` | always `'WebUser'`                                          |
+| `rowKey`       | lowercased Google email                                     |
+| `chatId`       | mapped Telegram chatId (required for v1; optional later)    |
+| `addedBy`      | admin chatId that added the entry                           |
+| `addedAt`      | ISO timestamp                                               |
+
+Until the agent has its own write actions, every allowlisted email
+MUST map to an existing Telegram `chatId` so the agent can serve that
+user's existing Telegram-side data (teams, leagues, live score, …).
+Once write actions land, this `chatId` field becomes optional and
+the email alone becomes the agent's identity.
+
+**Admin tooling (Telegram bot):** three new admin commands manage the
+allowlist via the existing Pending Reply Manager:
+
+- **`/allow_web_user`** — two-step flow:
+  1. Admin enters the Google email (validated by basic regex shape).
+  2. Admin enters the target chat ID (validated against `UserRegistry`).
+  3. Bot writes the allowlist row and confirms with
+     `{nickname || chatName} ({chatId})`.
+- **`/revoke_web_user`** — single-step: admin enters the email, bot
+  deletes the row. No-op (with friendly message) when the email
+  isn't on the allowlist.
+- **`/list_web_users`** — no reply; bot renders the full allowlist as
+  Markdown, joined against `UserRegistry` so admins see the linked
+  nickname/chatName for each row.
+
+**Environment variables (auth-specific):**
+
+| Var                     | Where               | Notes                                                                                                                                       |
+| ----------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GOOGLE_CLIENT_ID`      | Agent Function App  | OAuth 2.0 Web client ID. NOT a secret — safe in app settings. Unset = bypass mode.                                                          |
+| `VITE_GOOGLE_CLIENT_ID` | SWA build env       | Same value, baked into the bundle at build time (only on prod workflow, NOT PR previews). Unset at build time = chat renders without auth gate. |
+
+**Google Cloud Console setup (one-time):** create an OAuth 2.0 Web
+client. Authorized JavaScript origins must include the production
+SWA host (`https://f1.kilzid.com` + the SWA default hostname).
+Wildcards aren't supported by Google for authorized origins, so
+PR-preview hostnames intentionally don't get auth-gated; instead they
+use the test slot which also has `GOOGLE_CLIENT_ID` unset.
+
+**Rollout sequence (do NOT skip steps):**
+
+1. Backend ships with `GOOGLE_CLIENT_ID` unset on the prod slot —
+   `authenticateRequest` returns `BYPASSED`, nothing changes.
+2. Provision the Google OAuth Web client; copy the client ID.
+3. Set `VITE_GOOGLE_CLIENT_ID` in GitHub Actions secrets; redeploy
+   the SWA via the prod workflow. Users now see the login screen but
+   the backend still bypasses (so any signed-in user can chat).
+4. Set `GOOGLE_CLIENT_ID` on the prod slot of the agent Function App
+   (via `infra/agent-func/apply-settings.sh` with the env var set).
+   Auth gate is now live end-to-end.
+5. Allowlist yourself first via `/allow_web_user` (your Google email
+   → your Telegram chatId), soak, then widen the allowlist.
+
+**Token observability:** the Phase 6.1 token-usage middleware reads
+`getRequestContext()?.email` and appends `, email: <user>` to every
+per-step log line, so on-call can correlate Telegram log spikes to a
+specific user.
 
 ### Cores ↔ Telegram-adapter pattern
 

--- a/agentWebhook/index.js
+++ b/agentWebhook/index.js
@@ -10,9 +10,22 @@
 // SWA preview environments need regex-based origin matching, which
 // siteConfig.cors.allowedOrigins doesn't support. See src/agent/corsAllowList.js
 // and the AGENT_CORS_* env vars wired up in infra/agent-func/azuredeploy.json.
+//
+// Auth: every POST is gated by `authenticateRequest` (src/agent/auth.js).
+// When `GOOGLE_CLIENT_ID` is unset the gate falls through to the legacy
+// hardcoded-chatId path (used by local dev + the test slot). When it is
+// set, the gate verifies the caller's Google ID token, looks the email
+// up in the web allowlist, and runs the downstream handler inside an
+// AsyncLocalStorage scope that carries the resolved chatId — every
+// agent tool reads it via `getAgentChatId()`.
 
 const { getCopilotRuntimeHandler } = require('../src/agent/runtime');
 const { buildCorsHeadersFromEnv } = require('../src/agent/corsAllowList');
+const { authenticateRequest, STATUS } = require('../src/agent/auth');
+const { runWithRequestContext } = require('../src/agent/requestContext');
+const {
+  getAllowedUserByEmail,
+} = require('../src/webUserAllowlistService');
 
 function getOriginHeader(req) {
   const headers = req.headers || {};
@@ -100,6 +113,48 @@ async function toAzureResponse(webResponse, req) {
   };
 }
 
+function buildUnauthorizedResponse(req, authResult) {
+  const headers = {
+    ...buildResponseCorsHeaders(req),
+    'Content-Type': 'application/json',
+  };
+  // Surface a stable machine-readable reason for the frontend (which
+  // distinguishes "session expired → re-prompt sign-in" from "this
+  // account is not allowed → show a permanent error"). We deliberately
+  // do NOT echo back the verifier's free-form `detail` string because
+  // it can contain Google library error text that doesn't add value
+  // to the user.
+  const body = {
+    error: 'unauthorized',
+    reason: authResult.reason || 'unauthorized',
+  };
+  if (authResult.status === STATUS.FORBIDDEN && authResult.email) {
+    body.email = authResult.email;
+  }
+
+  return {
+    status: 401,
+    headers,
+    body: JSON.stringify(body),
+  };
+}
+
+async function runCopilotHandler(req) {
+  const handler = getCopilotRuntimeHandler();
+  const webRequest = buildWebRequest(req);
+  const webResponse = await handler(webRequest);
+
+  if (!webResponse) {
+    return {
+      status: 500,
+      headers: buildResponseCorsHeaders(req),
+      body: 'Agent handler returned no response',
+    };
+  }
+
+  return await toAzureResponse(webResponse, req);
+}
+
 module.exports = async function (context, req) {
   if ((req.method || '').toUpperCase() === 'OPTIONS') {
     context.res = {
@@ -111,21 +166,40 @@ module.exports = async function (context, req) {
   }
 
   try {
-    const handler = getCopilotRuntimeHandler();
-    const webRequest = buildWebRequest(req);
-    const webResponse = await handler(webRequest);
+    const authResult = await authenticateRequest(req, {
+      lookupAllowedUser: getAllowedUserByEmail,
+    });
 
-    if (!webResponse) {
-      context.res = {
-        status: 500,
-        headers: buildResponseCorsHeaders(req),
-        body: 'Agent handler returned no response',
-      };
+    if (
+      authResult.status === STATUS.UNAUTHORIZED ||
+      authResult.status === STATUS.FORBIDDEN
+    ) {
+      context.log(
+        `Agent auth rejected: status=${authResult.status} reason=${authResult.reason}` +
+          (authResult.email ? ` email=${authResult.email}` : '') +
+          (authResult.detail ? ` detail=${authResult.detail}` : ''),
+      );
+      context.res = buildUnauthorizedResponse(req, authResult);
 
       return;
     }
 
-    context.res = await toAzureResponse(webResponse, req);
+    if (authResult.status === STATUS.OK) {
+      context.res = await runWithRequestContext(
+        {
+          chatId: authResult.chatId,
+          email: authResult.email,
+          name: authResult.name,
+          sub: authResult.sub,
+        },
+        () => runCopilotHandler(req),
+      );
+
+      return;
+    }
+
+    // status: BYPASSED — fall through to the legacy hardcoded-chatId path.
+    context.res = await runCopilotHandler(req);
   } catch (err) {
     context.log('Agent webhook error:', err && err.stack ? err.stack : err);
     context.res = {

--- a/agentWebhook/index.test.js
+++ b/agentWebhook/index.test.js
@@ -1,0 +1,174 @@
+// Integration-shaped test for agentWebhook/index.js. We mock the heavy
+// dependencies (CopilotKit runtime + allowlist storage) so the test runs
+// in milliseconds, but exercise the real auth → context wiring.
+
+jest.mock('../src/agent/runtime', () => {
+  const handler = jest.fn();
+
+  return {
+    getCopilotRuntimeHandler: () => handler,
+    __handler: handler,
+  };
+});
+
+jest.mock('../src/webUserAllowlistService', () => ({
+  getAllowedUserByEmail: jest.fn(),
+}));
+
+jest.mock('../src/agent/auth', () => {
+  const actual = jest.requireActual('../src/agent/auth');
+
+  return {
+    ...actual,
+    authenticateRequest: jest.fn(),
+  };
+});
+
+const { __handler: copilotHandler } = require('../src/agent/runtime');
+const { authenticateRequest, STATUS } = require('../src/agent/auth');
+const { getRequestContext } = require('../src/agent/requestContext');
+const webhook = require('./index');
+
+function makeWebResponse({ status = 200, body = 'ok', contentType = 'text/plain' } = {}) {
+  return new Response(body, {
+    status,
+    headers: { 'Content-Type': contentType },
+  });
+}
+
+function makeReq({ method = 'POST', headers = {}, body, url = '/api/agent/copilotkit' } = {}) {
+  return {
+    method,
+    url,
+    headers: { host: 'localhost:7071', ...headers },
+    rawBody: typeof body === 'string' ? body : body !== undefined ? JSON.stringify(body) : undefined,
+    body,
+  };
+}
+
+function makeCtx() {
+  const logs = [];
+
+  return {
+    logs,
+    res: undefined,
+    log: (...args) => logs.push(args.join(' ')),
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  copilotHandler.mockReset();
+  authenticateRequest.mockReset();
+});
+
+describe('agentWebhook', () => {
+  test('OPTIONS returns 204 with CORS headers and does NOT call auth', async () => {
+    const ctx = makeCtx();
+    const req = makeReq({ method: 'OPTIONS' });
+
+    await webhook(ctx, req);
+
+    expect(ctx.res.status).toBe(204);
+    expect(authenticateRequest).not.toHaveBeenCalled();
+    expect(copilotHandler).not.toHaveBeenCalled();
+  });
+
+  test('OK auth result runs copilot handler inside a request context carrying chatId/email', async () => {
+    authenticateRequest.mockResolvedValueOnce({
+      status: STATUS.OK,
+      chatId: 12345,
+      email: 'foo@example.com',
+      name: 'Foo',
+      sub: 's1',
+    });
+
+    let observedContext = null;
+    copilotHandler.mockImplementationOnce(async () => {
+      observedContext = getRequestContext();
+
+      return makeWebResponse({ status: 200, body: 'agent-ok' });
+    });
+
+    const ctx = makeCtx();
+    await webhook(ctx, makeReq({ body: { hello: 'world' } }));
+
+    expect(observedContext).toEqual({
+      chatId: 12345,
+      email: 'foo@example.com',
+      name: 'Foo',
+      sub: 's1',
+    });
+    expect(ctx.res.status).toBe(200);
+    expect(ctx.res.body).toBe('agent-ok');
+  });
+
+  test('BYPASSED auth result runs copilot handler without a request context', async () => {
+    authenticateRequest.mockResolvedValueOnce({ status: STATUS.BYPASSED });
+
+    let observedContext = 'sentinel';
+    copilotHandler.mockImplementationOnce(async () => {
+      observedContext = getRequestContext();
+
+      return makeWebResponse({ status: 200, body: 'bypassed-ok' });
+    });
+
+    const ctx = makeCtx();
+    await webhook(ctx, makeReq({ body: { hello: 'world' } }));
+
+    expect(observedContext).toBeUndefined();
+    expect(ctx.res.status).toBe(200);
+    expect(ctx.res.body).toBe('bypassed-ok');
+  });
+
+  test('UNAUTHORIZED produces 401 + JSON body and never calls the runtime', async () => {
+    authenticateRequest.mockResolvedValueOnce({
+      status: STATUS.UNAUTHORIZED,
+      reason: 'invalid_token',
+      detail: 'Token expired',
+    });
+
+    const ctx = makeCtx();
+    await webhook(ctx, makeReq({ body: { hello: 'world' } }));
+
+    expect(copilotHandler).not.toHaveBeenCalled();
+    expect(ctx.res.status).toBe(401);
+    expect(ctx.res.headers['Content-Type']).toBe('application/json');
+    const parsed = JSON.parse(ctx.res.body);
+    expect(parsed).toEqual({ error: 'unauthorized', reason: 'invalid_token' });
+    // We do NOT leak the verifier's `detail` to the wire.
+    expect(ctx.res.body).not.toContain('Token expired');
+  });
+
+  test('FORBIDDEN produces 401 + email in the body so the UI can render "not allowlisted"', async () => {
+    authenticateRequest.mockResolvedValueOnce({
+      status: STATUS.FORBIDDEN,
+      reason: 'email_not_allowlisted',
+      email: 'foo@example.com',
+    });
+
+    const ctx = makeCtx();
+    await webhook(ctx, makeReq({ body: { hello: 'world' } }));
+
+    expect(copilotHandler).not.toHaveBeenCalled();
+    expect(ctx.res.status).toBe(401);
+    const parsed = JSON.parse(ctx.res.body);
+    expect(parsed).toEqual({
+      error: 'unauthorized',
+      reason: 'email_not_allowlisted',
+      email: 'foo@example.com',
+    });
+  });
+
+  test('handler throw is caught and returned as a 500', async () => {
+    authenticateRequest.mockResolvedValueOnce({ status: STATUS.BYPASSED });
+    copilotHandler.mockImplementationOnce(async () => {
+      throw new Error('boom');
+    });
+
+    const ctx = makeCtx();
+    await webhook(ctx, makeReq({ body: { hello: 'world' } }));
+
+    expect(ctx.res.status).toBe(500);
+  });
+});

--- a/infra/agent-func/apply-settings.sh
+++ b/infra/agent-func/apply-settings.sh
@@ -27,6 +27,8 @@
 #   PROD_PREVIEW_PATTERN   (default: empty)
 #   TEST_ALLOWED_ORIGINS   (default: *)
 #   TEST_PREVIEW_PATTERN   (default: empty)
+#   GOOGLE_CLIENT_ID       (default: empty — auth gate disabled.
+#                           Set to enable Google sign-in on prod.)
 
 set -euo pipefail
 
@@ -42,6 +44,11 @@ PROD_ORIGINS="${PROD_ALLOWED_ORIGINS:-https://calm-beach-055be4603.7.azurestatic
 PROD_PATTERN="${PROD_PREVIEW_PATTERN:-}"
 TEST_ORIGINS="${TEST_ALLOWED_ORIGINS:-*}"
 TEST_PATTERN="${TEST_PREVIEW_PATTERN:-}"
+# Empty string ⇒ Google auth gate is BYPASSED (the webhook falls back to
+# AGENT_HARDCODED_CHAT_ID). Set to the OAuth 2.0 Web client ID to enable
+# the gate on the production slot. The test slot intentionally stays
+# unset so PR-preview SWA builds don't require Google credentials.
+PROD_GOOGLE_CLIENT_ID="${GOOGLE_CLIENT_ID:-}"
 
 KV_BASE="https://${KV_NAME}.vault.azure.net/secrets"
 
@@ -64,6 +71,7 @@ apply_to_slot() {
   local slot_label="$1"
   local cors_origins="$2"
   local cors_pattern="$3"
+  local google_client_id="$4"
   local slot_args=()
 
   if [[ "$slot_label" != "production" ]]; then
@@ -92,12 +100,15 @@ apply_to_slot() {
       "AGENT_HARDCODED_CHAT_ID=@Microsoft.KeyVault(SecretUri=${KV_BASE}/agent-hardcoded-chat-id/)" \
       "AGENT_CORS_ALLOWED_ORIGINS=${cors_origins}" \
       "AGENT_CORS_PREVIEW_ORIGIN_PATTERN=${cors_pattern}" \
+      "GOOGLE_CLIENT_ID=${google_client_id}" \
       "AzureWebJobsStorage=${STORAGE_CS}" \
       "APPLICATIONINSIGHTS_CONNECTION_STRING=${APPINSIGHTS_CS}" \
     --output none --only-show-errors
 }
 
-apply_to_slot "production" "$PROD_ORIGINS" "$PROD_PATTERN"
-apply_to_slot "test"       "$TEST_ORIGINS" "$TEST_PATTERN"
+apply_to_slot "production" "$PROD_ORIGINS" "$PROD_PATTERN" "$PROD_GOOGLE_CLIENT_ID"
+# Test slot deliberately leaves GOOGLE_CLIENT_ID empty — auth gate
+# bypassed so PR previews continue to use AGENT_HARDCODED_CHAT_ID.
+apply_to_slot "test"       "$TEST_ORIGINS" "$TEST_PATTERN" ""
 
 echo "Done. WEBSITE_RUN_FROM_PACKAGE and other externally-managed settings are preserved."

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@copilotkit/runtime": "^1.57.1",
         "ai": "^6.0.182",
         "dotenv": "^16.4.7",
+        "google-auth-library": "^10.6.2",
         "node-telegram-bot-api": "^0.66.0",
         "openai": "^4.93.0",
         "quickchart-js": "^3.1.3"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@copilotkit/runtime": "^1.57.1",
     "ai": "^6.0.182",
     "dotenv": "^16.4.7",
+    "google-auth-library": "^10.6.2",
     "node-telegram-bot-api": "^0.66.0",
     "openai": "^4.93.0",
     "quickchart-js": "^3.1.3"

--- a/src/agent/auth.js
+++ b/src/agent/auth.js
@@ -1,0 +1,232 @@
+// Google ID token verification + allowlist-aware request authentication
+// for the web-chat agent.
+//
+// Pipeline:
+//   1. Frontend signs in via Google Identity Services → receives an ID
+//      token (JWT). The token's `aud` claim matches GOOGLE_CLIENT_ID,
+//      `iss` is `https://accounts.google.com` (or `accounts.google.com`),
+//      `email` is the signed-in user, and `email_verified` is `true`.
+//   2. Frontend attaches `Authorization: Bearer <id_token>` to every
+//      CopilotKit POST.
+//   3. `agentWebhook/index.js` calls `authenticateRequest(req)`. We
+//      verify the token via google-auth-library, look the email up in
+//      the web allowlist, and return a status-tagged result. The
+//      webhook maps statuses to HTTP codes.
+//
+// We deliberately NEVER throw out of `authenticateRequest`. Throws
+// would either crash the function or leak a stack trace to the user;
+// instead every failure mode resolves to a status-tagged object that
+// the webhook turns into a clean 401 + JSON body.
+//
+// Bypass mode: when `GOOGLE_CLIENT_ID` is unset/empty, auth is
+// disabled. This is the local-dev path (and the test slot of the
+// Function App where `AGENT_HARDCODED_CHAT_ID` does the work).
+
+const STATUS = {
+  OK: 'ok',
+  UNAUTHORIZED: 'unauthorized',
+  FORBIDDEN: 'forbidden',
+  BYPASSED: 'bypassed',
+};
+
+const VALID_ISSUERS = new Set([
+  'https://accounts.google.com',
+  'accounts.google.com',
+]);
+
+let cachedOAuth2Client = null;
+
+function getOAuth2Client() {
+  if (cachedOAuth2Client) {
+    return cachedOAuth2Client;
+  }
+
+  // Lazy require so tests + local dev paths can run without the package
+  // installed (this module is also imported transitively from the
+  // Telegram bot's test suite via the admin commands).
+  // eslint-disable-next-line global-require
+  const { OAuth2Client } = require('google-auth-library');
+  cachedOAuth2Client = new OAuth2Client();
+
+  return cachedOAuth2Client;
+}
+
+function resetOAuth2ClientForTests() {
+  cachedOAuth2Client = null;
+}
+
+function extractBearerToken(req) {
+  const headers = (req && req.headers) || {};
+  const raw =
+    headers.authorization ||
+    headers.Authorization ||
+    headers.AUTHORIZATION ||
+    null;
+
+  if (typeof raw !== 'string') {
+    return null;
+  }
+
+  const match = raw.match(/^Bearer\s+(.+)$/i);
+  if (!match) {
+    return null;
+  }
+
+  const token = match[1].trim();
+
+  return token.length > 0 ? token : null;
+}
+
+/**
+ * Verify a Google ID token and return the relevant payload fields.
+ * Throws on any verification failure (caller catches).
+ *
+ * @param {string} token
+ * @param {string} audience - The OAuth client id (GOOGLE_CLIENT_ID).
+ * @returns {Promise<{email: string, sub: string, name?: string, picture?: string, exp?: number}>}
+ */
+async function verifyGoogleIdToken(token, audience) {
+  if (!audience) {
+    throw new Error('audience (GOOGLE_CLIENT_ID) is required');
+  }
+
+  const client = getOAuth2Client();
+  const ticket = await client.verifyIdToken({ idToken: token, audience });
+  const payload = ticket && ticket.getPayload ? ticket.getPayload() : null;
+
+  if (!payload) {
+    throw new Error('Token verification returned no payload');
+  }
+
+  if (!payload.iss || !VALID_ISSUERS.has(payload.iss)) {
+    throw new Error(`Unexpected token issuer: ${payload.iss}`);
+  }
+
+  if (!payload.email || typeof payload.email !== 'string') {
+    throw new Error('Token payload missing email claim');
+  }
+
+  if (payload.email_verified === false) {
+    throw new Error('Token email is not verified');
+  }
+
+  return {
+    email: payload.email,
+    sub: payload.sub,
+    name: payload.name,
+    picture: payload.picture,
+    exp: payload.exp,
+  };
+}
+
+/**
+ * Authenticate an incoming agent request.
+ *
+ * Returns one of:
+ *   { status: 'bypassed' } — auth disabled because GOOGLE_CLIENT_ID is
+ *     unset; webhook should fall through to the legacy hardcoded chatId
+ *     path. Used by local dev and PR-preview slots.
+ *   { status: 'ok', email, chatId, name?, sub? } — token verified and
+ *     email is in the allowlist; webhook should run with this chatId
+ *     bound to the request context.
+ *   { status: 'unauthorized', reason } — missing/malformed/invalid
+ *     bearer token. Map to 401.
+ *   { status: 'forbidden', reason, email? } — token is valid but the
+ *     email is not in the allowlist (or has no chatId mapped). Map to
+ *     401 too — we deliberately do NOT distinguish "you signed in OK
+ *     but you're not authorized" from "your token is bad" on the wire
+ *     to avoid leaking allowlist membership; only the user-facing
+ *     `reason` differs.
+ *
+ * @param {Object} req - Azure Functions request-like { headers, ... }.
+ * @param {Object} options
+ * @param {() => Promise<{email: string, chatId?: string}|null>} options.lookupAllowedUser - Async lookup by email.
+ * @param {string|undefined} [options.clientId] - Override env GOOGLE_CLIENT_ID (used by tests).
+ * @param {(token: string, audience: string) => Promise<{email: string, sub?: string, name?: string}>} [options.verifyToken] - Inject the verifier for tests.
+ * @returns {Promise<Object>}
+ */
+async function authenticateRequest(req, options) {
+  const clientId =
+    options && options.clientId !== undefined
+      ? options.clientId
+      : process.env.GOOGLE_CLIENT_ID;
+
+  if (!clientId) {
+    return { status: STATUS.BYPASSED };
+  }
+
+  const token = extractBearerToken(req);
+  if (!token) {
+    return {
+      status: STATUS.UNAUTHORIZED,
+      reason: 'missing_or_malformed_authorization_header',
+    };
+  }
+
+  const verifier =
+    (options && options.verifyToken) || verifyGoogleIdToken;
+
+  let claims;
+  try {
+    claims = await verifier(token, clientId);
+  } catch (err) {
+    return {
+      status: STATUS.UNAUTHORIZED,
+      reason: 'invalid_token',
+      detail: err && err.message ? err.message : String(err),
+    };
+  }
+
+  const lookup = options && options.lookupAllowedUser;
+  if (typeof lookup !== 'function') {
+    throw new Error('authenticateRequest requires options.lookupAllowedUser');
+  }
+
+  let row;
+  try {
+    row = await lookup(claims.email);
+  } catch (err) {
+    // Storage outage — bubble the error up via "unauthorized" so the
+    // webhook returns 401 and the frontend prompts a retry, but log
+    // the underlying detail so on-call can correlate.
+    return {
+      status: STATUS.UNAUTHORIZED,
+      reason: 'allowlist_lookup_failed',
+      detail: err && err.message ? err.message : String(err),
+    };
+  }
+
+  if (!row) {
+    return {
+      status: STATUS.FORBIDDEN,
+      reason: 'email_not_allowlisted',
+      email: claims.email,
+    };
+  }
+
+  const chatIdRaw = row.chatId;
+  const chatIdNum = Number.parseInt(chatIdRaw, 10);
+  if (!Number.isFinite(chatIdNum)) {
+    return {
+      status: STATUS.FORBIDDEN,
+      reason: 'allowlist_entry_missing_chat_id',
+      email: claims.email,
+    };
+  }
+
+  return {
+    status: STATUS.OK,
+    email: claims.email,
+    chatId: chatIdNum,
+    name: claims.name,
+    sub: claims.sub,
+  };
+}
+
+module.exports = {
+  STATUS,
+  extractBearerToken,
+  verifyGoogleIdToken,
+  authenticateRequest,
+  resetOAuth2ClientForTests,
+};

--- a/src/agent/auth.test.js
+++ b/src/agent/auth.test.js
@@ -1,0 +1,271 @@
+// We mock google-auth-library so the test never reaches the real
+// library — and so the suite still passes when the dependency isn't
+// installed in CI yet.
+jest.mock('google-auth-library', () => {
+  const verifyIdToken = jest.fn();
+
+  return {
+    OAuth2Client: jest.fn(() => ({ verifyIdToken })),
+    __verifyIdToken: verifyIdToken,
+  };
+});
+
+const googleAuth = require('google-auth-library');
+const {
+  STATUS,
+  extractBearerToken,
+  verifyGoogleIdToken,
+  authenticateRequest,
+  resetOAuth2ClientForTests,
+} = require('./auth');
+
+const ORIGINAL_ENV = process.env;
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  resetOAuth2ClientForTests();
+  googleAuth.__verifyIdToken.mockReset();
+});
+
+afterEach(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe('extractBearerToken', () => {
+  test('returns the token from a well-formed header', () => {
+    expect(
+      extractBearerToken({ headers: { authorization: 'Bearer abc.def.ghi' } }),
+    ).toBe('abc.def.ghi');
+  });
+
+  test('handles Authorization (capitalised) and extra whitespace', () => {
+    expect(
+      extractBearerToken({ headers: { Authorization: 'Bearer   foo' } }),
+    ).toBe('foo');
+  });
+
+  test('returns null on missing header', () => {
+    expect(extractBearerToken({ headers: {} })).toBeNull();
+    expect(extractBearerToken({})).toBeNull();
+    expect(extractBearerToken(null)).toBeNull();
+  });
+
+  test('returns null on non-Bearer scheme', () => {
+    expect(
+      extractBearerToken({ headers: { authorization: 'Basic abc' } }),
+    ).toBeNull();
+  });
+
+  test('returns null on empty token', () => {
+    expect(
+      extractBearerToken({ headers: { authorization: 'Bearer  ' } }),
+    ).toBeNull();
+  });
+
+  test('returns null on non-string header value', () => {
+    expect(
+      extractBearerToken({ headers: { authorization: ['Bearer x'] } }),
+    ).toBeNull();
+  });
+});
+
+describe('verifyGoogleIdToken', () => {
+  test('returns email + sub + name on success', async () => {
+    googleAuth.__verifyIdToken.mockResolvedValueOnce({
+      getPayload: () => ({
+        iss: 'https://accounts.google.com',
+        email: 'foo@example.com',
+        email_verified: true,
+        sub: '109876',
+        name: 'Foo Bar',
+        picture: 'https://...',
+        exp: 1234567890,
+      }),
+    });
+
+    const result = await verifyGoogleIdToken('token', 'client-id');
+    expect(result).toEqual({
+      email: 'foo@example.com',
+      sub: '109876',
+      name: 'Foo Bar',
+      picture: 'https://...',
+      exp: 1234567890,
+    });
+    expect(googleAuth.__verifyIdToken).toHaveBeenCalledWith({
+      idToken: 'token',
+      audience: 'client-id',
+    });
+  });
+
+  test('throws when audience is missing', async () => {
+    await expect(verifyGoogleIdToken('token', '')).rejects.toThrow(
+      /GOOGLE_CLIENT_ID/,
+    );
+  });
+
+  test('throws on unexpected issuer', async () => {
+    googleAuth.__verifyIdToken.mockResolvedValueOnce({
+      getPayload: () => ({
+        iss: 'https://evil.example.com',
+        email: 'foo@example.com',
+        email_verified: true,
+        sub: '1',
+      }),
+    });
+
+    await expect(verifyGoogleIdToken('t', 'c')).rejects.toThrow(/issuer/);
+  });
+
+  test('throws when email is missing', async () => {
+    googleAuth.__verifyIdToken.mockResolvedValueOnce({
+      getPayload: () => ({
+        iss: 'accounts.google.com',
+        email_verified: true,
+        sub: '1',
+      }),
+    });
+
+    await expect(verifyGoogleIdToken('t', 'c')).rejects.toThrow(/email/);
+  });
+
+  test('throws when email is not verified', async () => {
+    googleAuth.__verifyIdToken.mockResolvedValueOnce({
+      getPayload: () => ({
+        iss: 'accounts.google.com',
+        email: 'foo@example.com',
+        email_verified: false,
+        sub: '1',
+      }),
+    });
+
+    await expect(verifyGoogleIdToken('t', 'c')).rejects.toThrow(/not verified/);
+  });
+
+  test('propagates library throw (expired token, etc.)', async () => {
+    googleAuth.__verifyIdToken.mockRejectedValueOnce(new Error('Token expired'));
+    await expect(verifyGoogleIdToken('t', 'c')).rejects.toThrow(/expired/);
+  });
+});
+
+describe('authenticateRequest', () => {
+  function reqWithToken(token) {
+    return { headers: { authorization: `Bearer ${token}` } };
+  }
+
+  test('returns bypassed when GOOGLE_CLIENT_ID is unset', async () => {
+    delete process.env.GOOGLE_CLIENT_ID;
+
+    const result = await authenticateRequest(reqWithToken('x'), {
+      lookupAllowedUser: jest.fn(),
+    });
+
+    expect(result).toEqual({ status: STATUS.BYPASSED });
+  });
+
+  test('returns unauthorized when bearer is missing', async () => {
+    process.env.GOOGLE_CLIENT_ID = 'client-id';
+
+    const result = await authenticateRequest(
+      { headers: {} },
+      { lookupAllowedUser: jest.fn() },
+    );
+
+    expect(result.status).toBe(STATUS.UNAUTHORIZED);
+    expect(result.reason).toBe('missing_or_malformed_authorization_header');
+  });
+
+  test('returns unauthorized when token verification throws', async () => {
+    process.env.GOOGLE_CLIENT_ID = 'client-id';
+
+    const result = await authenticateRequest(reqWithToken('bad'), {
+      lookupAllowedUser: jest.fn(),
+      verifyToken: jest.fn().mockRejectedValueOnce(new Error('Token expired')),
+    });
+
+    expect(result.status).toBe(STATUS.UNAUTHORIZED);
+    expect(result.reason).toBe('invalid_token');
+    expect(result.detail).toBe('Token expired');
+  });
+
+  test('returns forbidden when email is not allowlisted', async () => {
+    process.env.GOOGLE_CLIENT_ID = 'client-id';
+
+    const result = await authenticateRequest(reqWithToken('good'), {
+      verifyToken: jest
+        .fn()
+        .mockResolvedValueOnce({ email: 'foo@example.com', sub: '1' }),
+      lookupAllowedUser: jest.fn().mockResolvedValueOnce(null),
+    });
+
+    expect(result.status).toBe(STATUS.FORBIDDEN);
+    expect(result.reason).toBe('email_not_allowlisted');
+    expect(result.email).toBe('foo@example.com');
+  });
+
+  test('returns forbidden when allowlist row has non-numeric chatId', async () => {
+    process.env.GOOGLE_CLIENT_ID = 'client-id';
+
+    const result = await authenticateRequest(reqWithToken('good'), {
+      verifyToken: jest
+        .fn()
+        .mockResolvedValueOnce({ email: 'foo@example.com', sub: '1' }),
+      lookupAllowedUser: jest
+        .fn()
+        .mockResolvedValueOnce({ email: 'foo@example.com' }),
+    });
+
+    expect(result.status).toBe(STATUS.FORBIDDEN);
+    expect(result.reason).toBe('allowlist_entry_missing_chat_id');
+  });
+
+  test('returns ok with numeric chatId and propagates claims', async () => {
+    process.env.GOOGLE_CLIENT_ID = 'client-id';
+
+    const result = await authenticateRequest(reqWithToken('good'), {
+      verifyToken: jest.fn().mockResolvedValueOnce({
+        email: 'foo@example.com',
+        sub: '109876',
+        name: 'Foo Bar',
+      }),
+      lookupAllowedUser: jest.fn().mockResolvedValueOnce({
+        email: 'foo@example.com',
+        chatId: '454873194',
+      }),
+    });
+
+    expect(result).toEqual({
+      status: STATUS.OK,
+      email: 'foo@example.com',
+      chatId: 454873194,
+      name: 'Foo Bar',
+      sub: '109876',
+    });
+  });
+
+  test('returns unauthorized when allowlist lookup throws (storage outage)', async () => {
+    process.env.GOOGLE_CLIENT_ID = 'client-id';
+
+    const result = await authenticateRequest(reqWithToken('good'), {
+      verifyToken: jest
+        .fn()
+        .mockResolvedValueOnce({ email: 'foo@example.com', sub: '1' }),
+      lookupAllowedUser: jest.fn().mockRejectedValueOnce(new Error('Azure unreachable')),
+    });
+
+    expect(result.status).toBe(STATUS.UNAUTHORIZED);
+    expect(result.reason).toBe('allowlist_lookup_failed');
+    expect(result.detail).toBe('Azure unreachable');
+  });
+
+  test('requires options.lookupAllowedUser', async () => {
+    process.env.GOOGLE_CLIENT_ID = 'client-id';
+
+    await expect(
+      authenticateRequest(reqWithToken('good'), {
+        verifyToken: jest
+          .fn()
+          .mockResolvedValueOnce({ email: 'foo@example.com', sub: '1' }),
+      }),
+    ).rejects.toThrow(/lookupAllowedUser/);
+  });
+});

--- a/src/agent/identity.js
+++ b/src/agent/identity.js
@@ -1,13 +1,29 @@
 // Resolves the user identity the agent operates as.
 //
-// Phase 1 (v1): a single hardcoded chatId is provided via the
-// AGENT_HARDCODED_CHAT_ID env var. The LLM never sees or controls
-// this — it is read from the environment by tool handlers when they
-// need it to look up the user's teams/caches/leagues.
+// Resolution order:
+//   1. The request-scoped chatId set by `runWithRequestContext` (used
+//      by the web agent webhook after verifying the caller's Google ID
+//      token and resolving it through the web allowlist). The LLM
+//      never sees or controls this — it is set by the webhook before
+//      handing the request off to CopilotKit.
+//   2. The `AGENT_HARDCODED_CHAT_ID` env var. Used by:
+//        - local dev (`scripts/dev-agent-server.js`),
+//        - the test slot of the agent Function App (where Google auth
+//          is intentionally bypassed for PR validation),
+//        - any process running outside an HTTP request scope
+//          (e.g. background cache bootstrap).
 //
-// Future phases will replace this with proper auth (token / bot login).
+// If neither is available we throw — tools cannot proceed without an
+// identity.
+
+const { getRequestContext } = require('./requestContext');
 
 function getAgentChatId() {
+  const ctx = getRequestContext();
+  if (ctx && typeof ctx.chatId === 'number' && Number.isFinite(ctx.chatId)) {
+    return ctx.chatId;
+  }
+
   const raw = process.env.AGENT_HARDCODED_CHAT_ID;
   if (!raw) {
     throw new Error(

--- a/src/agent/identity.test.js
+++ b/src/agent/identity.test.js
@@ -1,0 +1,48 @@
+const { runWithRequestContext } = require('./requestContext');
+const { getAgentChatId } = require('./identity');
+
+describe('getAgentChatId', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  test('returns the chatId from the active request context', async () => {
+    process.env.AGENT_HARDCODED_CHAT_ID = '999';
+
+    await runWithRequestContext({ chatId: 42, email: 'a@b.com' }, async () => {
+      expect(getAgentChatId()).toBe(42);
+    });
+  });
+
+  test('falls back to AGENT_HARDCODED_CHAT_ID when no context is active', () => {
+    process.env.AGENT_HARDCODED_CHAT_ID = '7654321';
+
+    expect(getAgentChatId()).toBe(7654321);
+  });
+
+  test('ignores context.chatId that is not a finite number', async () => {
+    process.env.AGENT_HARDCODED_CHAT_ID = '7654321';
+
+    await runWithRequestContext({ chatId: 'not-a-number' }, async () => {
+      expect(getAgentChatId()).toBe(7654321);
+    });
+  });
+
+  test('throws when neither context nor env is available', () => {
+    delete process.env.AGENT_HARDCODED_CHAT_ID;
+
+    expect(() => getAgentChatId()).toThrow(/AGENT_HARDCODED_CHAT_ID/);
+  });
+
+  test('throws when AGENT_HARDCODED_CHAT_ID is non-numeric and no context', () => {
+    process.env.AGENT_HARDCODED_CHAT_ID = 'nope';
+
+    expect(() => getAgentChatId()).toThrow(/must be numeric/);
+  });
+});

--- a/src/agent/requestContext.js
+++ b/src/agent/requestContext.js
@@ -1,0 +1,46 @@
+// Per-request execution context for the web-chat agent.
+//
+// Tools run inside CopilotKit's `BuiltInAgent.execute()` callback, which
+// is invoked SOMEWHERE deep inside the AI SDK's tool-dispatch loop. The
+// runtime gives us no first-class way to thread per-request state down
+// to a tool — `defineTool({ execute })` only receives the LLM-controlled
+// `args` argument. That's intentional: the LLM must not be able to spoof
+// identity.
+//
+// AsyncLocalStorage is the canonical Node solution. We wrap each incoming
+// HTTP request in `runWithRequestContext({ chatId, email, sub }, fn)`;
+// every async/Promise callback that descends from `fn` automatically
+// inherits the same store. `getRequestContext()` reads it back inside
+// tools.
+//
+// When no store is active (Telegram bot, cache bootstrap, tests, local
+// dev with auth bypassed) `getRequestContext()` returns `undefined` —
+// callers fall back to env (`AGENT_HARDCODED_CHAT_ID`).
+
+const { AsyncLocalStorage } = require('node:async_hooks');
+
+const storage = new AsyncLocalStorage();
+
+/**
+ * Run `fn` with the given request context attached. All async work
+ * descending from `fn` sees the same context via `getRequestContext()`.
+ *
+ * @param {{ chatId: number, email?: string, sub?: string, name?: string }} ctx
+ * @param {() => Promise<any>} fn
+ * @returns {Promise<any>}
+ */
+function runWithRequestContext(ctx, fn) {
+  return storage.run(ctx, fn);
+}
+
+/**
+ * Read the active request context, or `undefined` if no
+ * `runWithRequestContext` is on the stack.
+ *
+ * @returns {{ chatId: number, email?: string, sub?: string, name?: string }|undefined}
+ */
+function getRequestContext() {
+  return storage.getStore();
+}
+
+module.exports = { runWithRequestContext, getRequestContext };

--- a/src/agent/requestContext.test.js
+++ b/src/agent/requestContext.test.js
@@ -1,0 +1,62 @@
+const {
+  runWithRequestContext,
+  getRequestContext,
+} = require('./requestContext');
+
+describe('requestContext', () => {
+  test('getRequestContext returns undefined when no context is active', () => {
+    expect(getRequestContext()).toBeUndefined();
+  });
+
+  test('runWithRequestContext exposes the same store to synchronous descendants', async () => {
+    await runWithRequestContext({ chatId: 42 }, async () => {
+      expect(getRequestContext()).toEqual({ chatId: 42 });
+    });
+  });
+
+  test('store is preserved across awaits', async () => {
+    await runWithRequestContext({ chatId: 1, email: 'a@example.com' }, async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      expect(getRequestContext()).toEqual({
+        chatId: 1,
+        email: 'a@example.com',
+      });
+    });
+  });
+
+  test('concurrent contexts do not bleed into each other', async () => {
+    const seen = [];
+
+    async function captureAfterDelay(label, ms) {
+      await new Promise((r) => setTimeout(r, ms));
+      seen.push({ label, ctx: getRequestContext() });
+    }
+
+    await Promise.all([
+      runWithRequestContext({ chatId: 1 }, () => captureAfterDelay('a', 20)),
+      runWithRequestContext({ chatId: 2 }, () => captureAfterDelay('b', 10)),
+      runWithRequestContext({ chatId: 3 }, () => captureAfterDelay('c', 30)),
+    ]);
+
+    const byLabel = Object.fromEntries(seen.map((e) => [e.label, e.ctx]));
+    expect(byLabel.a).toEqual({ chatId: 1 });
+    expect(byLabel.b).toEqual({ chatId: 2 });
+    expect(byLabel.c).toEqual({ chatId: 3 });
+  });
+
+  test('store is gone after the callback resolves', async () => {
+    await runWithRequestContext({ chatId: 99 }, async () => {
+      expect(getRequestContext()).toEqual({ chatId: 99 });
+    });
+    expect(getRequestContext()).toBeUndefined();
+  });
+
+  test('throws from callback do not leak the context outwards', async () => {
+    await expect(
+      runWithRequestContext({ chatId: 7 }, async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+    expect(getRequestContext()).toBeUndefined();
+  });
+});

--- a/src/agent/tokenUsageMiddleware.js
+++ b/src/agent/tokenUsageMiddleware.js
@@ -23,6 +23,7 @@
 // CopilotKit runtime is piping back to the browser.
 
 const { sendLogMessage } = require('../utils/utils');
+const { getRequestContext } = require('./requestContext');
 
 function safeTotal(field) {
   if (!field || typeof field !== 'object') {return 0;}
@@ -31,8 +32,10 @@ function safeTotal(field) {
   return Number.isFinite(value) ? value : 0;
 }
 
-function formatLine({ modelId, step, prompt, completion, total }) {
-  return `Agent step usage — model: ${modelId}, step: ${step}, prompt: ${prompt}, completion: ${completion}, total: ${total}`;
+function formatLine({ modelId, step, prompt, completion, total, email }) {
+  const tail = email ? `, email: ${email}` : '';
+
+  return `Agent step usage — model: ${modelId}, step: ${step}, prompt: ${prompt}, completion: ${completion}, total: ${total}${tail}`;
 }
 
 // `bot` is supplied by the runtime when the middleware is constructed so
@@ -54,12 +57,14 @@ function createTokenUsageMiddleware({ bot }) {
               chunk.usage && chunk.usage.outputTokens,
             );
             const total = prompt + completion;
+            const email = (getRequestContext() || {}).email;
             const line = formatLine({
               modelId,
               step: stepIndex,
               prompt,
               completion,
               total,
+              email,
             });
 
             // Fire-and-forget. We deliberately do NOT await here — the

--- a/src/agent/tokenUsageMiddleware.test.js
+++ b/src/agent/tokenUsageMiddleware.test.js
@@ -77,6 +77,20 @@ describe('formatLine', () => {
       'Agent step usage — model: gpt-4o, step: 2, prompt: 100, completion: 50, total: 150',
     );
   });
+
+  test('appends email when provided', () => {
+    const line = formatLine({
+      modelId: 'gpt-4o',
+      step: 1,
+      prompt: 10,
+      completion: 5,
+      total: 15,
+      email: 'foo@example.com',
+    });
+    expect(line).toBe(
+      'Agent step usage — model: gpt-4o, step: 1, prompt: 10, completion: 5, total: 15, email: foo@example.com',
+    );
+  });
 });
 
 describe('createTokenUsageMiddleware', () => {
@@ -265,6 +279,41 @@ describe('createTokenUsageMiddleware', () => {
 
     expect(result.request).toEqual({ body: { x: 1 } });
     expect(result.response).toEqual({ headers: { 'x-foo': 'bar' } });
+  });
+
+  test('includes the request-scoped email in the log line when one is set', async () => {
+    const bot = makeBot();
+    const middleware = createTokenUsageMiddleware({ bot });
+    const { runWithRequestContext } = require('./requestContext');
+
+    const upstream = makeReadable([
+      {
+        type: 'finish',
+        finishReason: 'stop',
+        usage: {
+          inputTokens: { total: 1 },
+          outputTokens: { total: 2 },
+        },
+      },
+    ]);
+
+    await runWithRequestContext(
+      { chatId: 42, email: 'me@example.com' },
+      async () => {
+        const result = await middleware.wrapStream({
+          doStream: async () => ({ stream: upstream }),
+          doGenerate: async () => {
+            throw new Error('not used');
+          },
+          params: {},
+          model: FAKE_MODEL,
+        });
+        await collectStream(result.stream);
+        await new Promise((r) => setImmediate(r));
+      },
+    );
+
+    expect(bot.calls[0].line).toContain('email: me@example.com');
   });
 
   test('handles missing modelId gracefully', async () => {

--- a/src/commandsHandler/allowWebUserHandler.js
+++ b/src/commandsHandler/allowWebUserHandler.js
@@ -1,0 +1,45 @@
+const { t } = require('../i18n');
+const { isAdminMessage } = require('../utils/utils');
+const { registerPendingReply } = require('../pendingReplyManager');
+
+/**
+ * Handle the /allow_web_user admin command.
+ * Two-step pending-reply flow:
+ *   Step 1: collect the Google email address.
+ *   Step 2: collect the chat ID and write `{ email → chatId }` to the
+ *           web user allowlist.
+ *
+ * @param {Object} bot - The Telegram bot instance
+ * @param {Object} msg - The Telegram message object
+ */
+async function handleAllowWebUserCommand(bot, msg) {
+  const chatId = msg.chat.id;
+
+  if (!isAdminMessage(msg)) {
+    await bot.sendMessage(
+      chatId,
+      t('Sorry, only admins can use this command.', chatId),
+    );
+
+    return;
+  }
+
+  const prompt = `${t(
+    'Please enter the Google email to allow on the web agent:',
+    chatId,
+  )}\n\n${t('💡 Send /cancel at any time to abort.', chatId)}`;
+
+  await registerPendingReply(chatId, 'allow_web_user', {
+    step: 'collect_email',
+  });
+
+  await bot
+    .sendMessage(chatId, prompt, {
+      reply_markup: { force_reply: true },
+    })
+    .catch((err) =>
+      console.error('Error sending allow web user prompt:', err),
+    );
+}
+
+module.exports = { handleAllowWebUserCommand };

--- a/src/commandsHandler/allowWebUserHandler.test.js
+++ b/src/commandsHandler/allowWebUserHandler.test.js
@@ -1,0 +1,56 @@
+const { handleAllowWebUserCommand } = require('./allowWebUserHandler');
+
+jest.mock('../i18n', () => ({
+  t: jest.fn((key) => key),
+}));
+
+jest.mock('../utils/utils', () => ({
+  isAdminMessage: jest.fn(),
+}));
+
+jest.mock('../pendingReplyManager', () => ({
+  registerPendingReply: jest.fn().mockResolvedValue(),
+}));
+
+const { isAdminMessage } = require('../utils/utils');
+const { registerPendingReply } = require('../pendingReplyManager');
+
+describe('allowWebUserHandler', () => {
+  let botMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    botMock = { sendMessage: jest.fn().mockResolvedValue() };
+  });
+
+  it('rejects non-admin users', async () => {
+    isAdminMessage.mockReturnValue(false);
+
+    await handleAllowWebUserCommand(botMock, { chat: { id: 999 } });
+
+    expect(botMock.sendMessage).toHaveBeenCalledWith(
+      999,
+      'Sorry, only admins can use this command.',
+    );
+    expect(registerPendingReply).not.toHaveBeenCalled();
+  });
+
+  it('registers a pending reply with step=collect_email and prompts the admin', async () => {
+    isAdminMessage.mockReturnValue(true);
+
+    await handleAllowWebUserCommand(botMock, { chat: { id: 123 } });
+
+    expect(registerPendingReply).toHaveBeenCalledWith(
+      123,
+      'allow_web_user',
+      { step: 'collect_email' },
+    );
+    expect(botMock.sendMessage).toHaveBeenCalledWith(
+      123,
+      expect.stringContaining(
+        'Please enter the Google email to allow on the web agent:',
+      ),
+      { reply_markup: { force_reply: true } },
+    );
+  });
+});

--- a/src/commandsHandler/commandHandlers.js
+++ b/src/commandsHandler/commandHandlers.js
@@ -45,6 +45,9 @@ const {
   COMMAND_LEAGUE_GRAPHS,
   COMMAND_LEAGUE_CHANGES,
   COMMAND_WHATS_NEW,
+  COMMAND_ALLOW_WEB_USER,
+  COMMAND_REVOKE_WEB_USER,
+  COMMAND_LIST_WEB_USERS,
 } = require('../constants');
 
 const { handleBestTeamsMessage } = require('./bestTeamsHandler');
@@ -106,6 +109,9 @@ const {
   handleLeagueChangesCommand,
 } = require('./leagueChangesHandler');
 const { handleWhatsNewCommand } = require('./whatsNewHandler');
+const { handleAllowWebUserCommand } = require('./allowWebUserHandler');
+const { handleRevokeWebUserCommand } = require('./revokeWebUserHandler');
+const { handleListWebUsersCommand } = require('./listWebUsersHandler');
 
 // Mapping of command constants to their handler functions
 const COMMAND_HANDLERS = {
@@ -156,6 +162,9 @@ const COMMAND_HANDLERS = {
   [COMMAND_LEAGUE_GRAPHS]: handleLeagueGraphsCommand,
   [COMMAND_LEAGUE_CHANGES]: handleLeagueChangesCommand,
   [COMMAND_WHATS_NEW]: handleWhatsNewCommand,
+  [COMMAND_ALLOW_WEB_USER]: handleAllowWebUserCommand,
+  [COMMAND_REVOKE_WEB_USER]: handleRevokeWebUserCommand,
+  [COMMAND_LIST_WEB_USERS]: handleListWebUsersCommand,
 };
 
 async function executeCommand(bot, msg, command) {

--- a/src/commandsHandler/index.js
+++ b/src/commandsHandler/index.js
@@ -61,6 +61,15 @@ const {
   handleLeagueChangesCommand,
 } = require('./leagueChangesHandler');
 const { handleWhatsNewCommand } = require('./whatsNewHandler');
+const {
+  handleAllowWebUserCommand,
+} = require('./allowWebUserHandler');
+const {
+  handleRevokeWebUserCommand,
+} = require('./revokeWebUserHandler');
+const {
+  handleListWebUsersCommand,
+} = require('./listWebUsersHandler');
 
 module.exports = {
   handleBestTeamsMessage,
@@ -111,4 +120,7 @@ module.exports = {
   handleLeagueGraphsCommand,
   handleLeagueChangesCommand,
   handleWhatsNewCommand,
+  handleAllowWebUserCommand,
+  handleRevokeWebUserCommand,
+  handleListWebUsersCommand,
 };

--- a/src/commandsHandler/listWebUsersHandler.js
+++ b/src/commandsHandler/listWebUsersHandler.js
@@ -1,0 +1,112 @@
+const { listAllowedUsers } = require('../webUserAllowlistService');
+const { listAllUsers } = require('../userRegistryService');
+const {
+  sendErrorMessage,
+  isAdminMessage,
+  formatDateTime,
+} = require('../utils/utils');
+const { t } = require('../i18n');
+
+/**
+ * Handle the /list_web_users admin command. Renders the web allowlist
+ * as a Markdown table with the linked Telegram nickname/chatName so
+ * the admin can verify the mappings at a glance.
+ *
+ * @param {Object} bot - The Telegram bot instance
+ * @param {Object} msg - The Telegram message object
+ */
+async function handleListWebUsersCommand(bot, msg) {
+  const chatId = msg.chat.id;
+
+  if (!isAdminMessage(msg)) {
+    await bot.sendMessage(
+      chatId,
+      t('Sorry, only admins can use this command.', chatId),
+    );
+
+    return;
+  }
+
+  try {
+    const [allowed, users] = await Promise.all([
+      listAllowedUsers(),
+      listAllUsers().catch((err) => {
+        console.error('Error fetching users for list_web_users:', err);
+
+        return [];
+      }),
+    ]);
+
+    if (allowed.length === 0) {
+      await bot
+        .sendMessage(chatId, t('No web users allowlisted yet.', chatId))
+        .catch((err) =>
+          console.error('Error sending empty list_web_users message:', err),
+        );
+
+      return;
+    }
+
+    const usersByChatId = new Map();
+    for (const u of users) {
+      usersByChatId.set(String(u.chatId), u);
+    }
+
+    const sorted = [...allowed].sort((a, b) => {
+      const aTime = Date.parse(a.addedAt || '');
+      const bTime = Date.parse(b.addedAt || '');
+      if (Number.isNaN(aTime) && Number.isNaN(bTime)) {return 0;}
+      if (Number.isNaN(aTime)) {return 1;}
+      if (Number.isNaN(bTime)) {return -1;}
+
+      return bTime - aTime;
+    });
+
+    let message = `*${t('Web Allowlist', chatId)}* (${sorted.length})\n\n`;
+
+    sorted.forEach((row, index) => {
+      const linkedUser = row.chatId
+        ? usersByChatId.get(String(row.chatId))
+        : null;
+      const linkedDisplay = linkedUser
+        ? linkedUser.nickname || linkedUser.chatName || row.chatId
+        : t('(unknown)', chatId);
+
+      message += `*${index + 1}. ${row.email}*\n`;
+      message += `🆔 ${t('Chat ID', chatId)}: \`${row.chatId || '-'}\` — ${linkedDisplay}\n`;
+      if (row.addedAt) {
+        const addedAtDate = new Date(row.addedAt);
+        if (!Number.isNaN(addedAtDate.getTime())) {
+          const formatted = formatDateTime(addedAtDate, chatId);
+          message += `📅 ${t('Added', chatId)}: ${formatted.dateStr}, ${formatted.timeStr}\n`;
+        }
+      }
+      if (row.addedBy) {
+        message += `👤 ${t('Added by', chatId)}: \`${row.addedBy}\`\n`;
+      }
+      message += '\n';
+    });
+
+    await bot
+      .sendMessage(chatId, message, { parse_mode: 'Markdown' })
+      .catch((err) =>
+        console.error('Error sending list_web_users message:', err),
+      );
+  } catch (error) {
+    console.error('Error in handleListWebUsersCommand:', error);
+    await sendErrorMessage(bot, `Error listing web users: ${error.message}`);
+
+    await bot
+      .sendMessage(
+        chatId,
+        t('❌ Error fetching web allowlist: {ERROR}', chatId, {
+          ERROR: error.message,
+        }),
+      )
+      .catch((err) =>
+        console.error('Error sending list_web_users error message:', err),
+      );
+  }
+}
+
+module.exports = { handleListWebUsersCommand };

--- a/src/commandsHandler/listWebUsersHandler.test.js
+++ b/src/commandsHandler/listWebUsersHandler.test.js
@@ -1,0 +1,126 @@
+jest.mock('../webUserAllowlistService', () => ({
+  listAllowedUsers: jest.fn(),
+}));
+
+jest.mock('../userRegistryService', () => ({
+  listAllUsers: jest.fn(),
+}));
+
+jest.mock('../i18n', () => ({
+  t: jest.fn((key, _chatId, vars) => {
+    if (!vars) {return key;}
+
+    return Object.entries(vars).reduce(
+      (acc, [k, v]) => acc.replace(new RegExp(`{${k}}`, 'g'), String(v)),
+      key,
+    );
+  }),
+}));
+
+jest.mock('../utils/utils', () => ({
+  isAdminMessage: jest.fn(),
+  sendErrorMessage: jest.fn().mockResolvedValue(),
+  formatDateTime: jest.fn(() => ({ dateStr: '2026-05-21', timeStr: '12:00' })),
+}));
+
+const { listAllowedUsers } = require('../webUserAllowlistService');
+const { listAllUsers } = require('../userRegistryService');
+const { isAdminMessage, sendErrorMessage } = require('../utils/utils');
+const { handleListWebUsersCommand } = require('./listWebUsersHandler');
+
+describe('listWebUsersHandler', () => {
+  let botMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    botMock = { sendMessage: jest.fn().mockResolvedValue() };
+  });
+
+  it('rejects non-admin users', async () => {
+    isAdminMessage.mockReturnValue(false);
+
+    await handleListWebUsersCommand(botMock, { chat: { id: 999 } });
+
+    expect(botMock.sendMessage).toHaveBeenCalledWith(
+      999,
+      'Sorry, only admins can use this command.',
+    );
+    expect(listAllowedUsers).not.toHaveBeenCalled();
+  });
+
+  it('shows "no users" when the allowlist is empty', async () => {
+    isAdminMessage.mockReturnValue(true);
+    listAllowedUsers.mockResolvedValueOnce([]);
+    listAllUsers.mockResolvedValueOnce([]);
+
+    await handleListWebUsersCommand(botMock, { chat: { id: 123 } });
+
+    expect(botMock.sendMessage).toHaveBeenCalledWith(
+      123,
+      'No web users allowlisted yet.',
+    );
+  });
+
+  it('renders allowlist rows joined with user registry for display names', async () => {
+    isAdminMessage.mockReturnValue(true);
+    listAllowedUsers.mockResolvedValueOnce([
+      {
+        email: 'foo@example.com',
+        chatId: '12345',
+        addedBy: '454873194',
+        addedAt: '2026-05-21T12:00:00.000Z',
+      },
+    ]);
+    listAllUsers.mockResolvedValueOnce([
+      { chatId: '12345', chatName: 'Foo User', nickname: 'TheFoo' },
+    ]);
+
+    await handleListWebUsersCommand(botMock, { chat: { id: 123 } });
+
+    expect(botMock.sendMessage).toHaveBeenCalledTimes(1);
+    const [target, body, options] = botMock.sendMessage.mock.calls[0];
+    expect(target).toBe(123);
+    expect(options).toEqual({ parse_mode: 'Markdown' });
+    expect(body).toContain('Web Allowlist');
+    expect(body).toContain('foo@example.com');
+    expect(body).toContain('12345');
+    expect(body).toContain('TheFoo');
+    expect(body).toContain('Added: 2026-05-21, 12:00');
+    expect(body).toContain('Added by');
+  });
+
+  it('falls back to chatName when no nickname is set, and (unknown) when user not in registry', async () => {
+    isAdminMessage.mockReturnValue(true);
+    listAllowedUsers.mockResolvedValueOnce([
+      { email: 'a@e.com', chatId: '1' },
+      { email: 'b@e.com', chatId: '9999' },
+    ]);
+    listAllUsers.mockResolvedValueOnce([
+      { chatId: '1', chatName: 'Just Name' },
+    ]);
+
+    await handleListWebUsersCommand(botMock, { chat: { id: 123 } });
+
+    const [, body] = botMock.sendMessage.mock.calls[0];
+    expect(body).toContain('Just Name');
+    expect(body).toContain('(unknown)');
+  });
+
+  it('reports failures via sendErrorMessage and user-facing text', async () => {
+    isAdminMessage.mockReturnValue(true);
+    listAllowedUsers.mockRejectedValueOnce(new Error('storage down'));
+    listAllUsers.mockResolvedValueOnce([]);
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await handleListWebUsersCommand(botMock, { chat: { id: 123 } });
+
+    expect(sendErrorMessage).toHaveBeenCalledWith(
+      botMock,
+      expect.stringContaining('storage down'),
+    );
+    expect(botMock.sendMessage).toHaveBeenCalledWith(
+      123,
+      '❌ Error fetching web allowlist: storage down',
+    );
+  });
+});

--- a/src/commandsHandler/revokeWebUserHandler.js
+++ b/src/commandsHandler/revokeWebUserHandler.js
@@ -1,0 +1,40 @@
+const { t } = require('../i18n');
+const { isAdminMessage } = require('../utils/utils');
+const { registerPendingReply } = require('../pendingReplyManager');
+
+/**
+ * Handle the /revoke_web_user admin command. Single-step pending-reply:
+ * admin types the email, the handler deletes the allowlist row.
+ *
+ * @param {Object} bot - The Telegram bot instance
+ * @param {Object} msg - The Telegram message object
+ */
+async function handleRevokeWebUserCommand(bot, msg) {
+  const chatId = msg.chat.id;
+
+  if (!isAdminMessage(msg)) {
+    await bot.sendMessage(
+      chatId,
+      t('Sorry, only admins can use this command.', chatId),
+    );
+
+    return;
+  }
+
+  const prompt = `${t(
+    'Please enter the Google email to revoke from the web agent:',
+    chatId,
+  )}\n\n${t('💡 Send /cancel at any time to abort.', chatId)}`;
+
+  await registerPendingReply(chatId, 'revoke_web_user');
+
+  await bot
+    .sendMessage(chatId, prompt, {
+      reply_markup: { force_reply: true },
+    })
+    .catch((err) =>
+      console.error('Error sending revoke web user prompt:', err),
+    );
+}
+
+module.exports = { handleRevokeWebUserCommand };

--- a/src/commandsHandler/revokeWebUserHandler.test.js
+++ b/src/commandsHandler/revokeWebUserHandler.test.js
@@ -1,0 +1,52 @@
+const { handleRevokeWebUserCommand } = require('./revokeWebUserHandler');
+
+jest.mock('../i18n', () => ({
+  t: jest.fn((key) => key),
+}));
+
+jest.mock('../utils/utils', () => ({
+  isAdminMessage: jest.fn(),
+}));
+
+jest.mock('../pendingReplyManager', () => ({
+  registerPendingReply: jest.fn().mockResolvedValue(),
+}));
+
+const { isAdminMessage } = require('../utils/utils');
+const { registerPendingReply } = require('../pendingReplyManager');
+
+describe('revokeWebUserHandler', () => {
+  let botMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    botMock = { sendMessage: jest.fn().mockResolvedValue() };
+  });
+
+  it('rejects non-admin users', async () => {
+    isAdminMessage.mockReturnValue(false);
+
+    await handleRevokeWebUserCommand(botMock, { chat: { id: 999 } });
+
+    expect(botMock.sendMessage).toHaveBeenCalledWith(
+      999,
+      'Sorry, only admins can use this command.',
+    );
+    expect(registerPendingReply).not.toHaveBeenCalled();
+  });
+
+  it('registers a single-step pending reply for admins and prompts them', async () => {
+    isAdminMessage.mockReturnValue(true);
+
+    await handleRevokeWebUserCommand(botMock, { chat: { id: 123 } });
+
+    expect(registerPendingReply).toHaveBeenCalledWith(123, 'revoke_web_user');
+    expect(botMock.sendMessage).toHaveBeenCalledWith(
+      123,
+      expect.stringContaining(
+        'Please enter the Google email to revoke from the web agent:',
+      ),
+      { reply_markup: { force_reply: true } },
+    );
+  });
+});

--- a/src/constants.js
+++ b/src/constants.js
@@ -127,6 +127,9 @@ exports.COMMAND_TEAMS_TRACKER = '/teams_tracker';
 exports.COMMAND_LEAGUE_GRAPHS = '/league_graphs';
 exports.COMMAND_LEAGUE_CHANGES = '/league_changes';
 exports.COMMAND_WHATS_NEW = '/whats_new';
+exports.COMMAND_ALLOW_WEB_USER = '/allow_web_user';
+exports.COMMAND_REVOKE_WEB_USER = '/revoke_web_user';
+exports.COMMAND_LIST_WEB_USERS = '/list_web_users';
 
 // Menu configuration for interactive menu command
 exports.MENU_CATEGORIES = {
@@ -321,6 +324,22 @@ exports.MENU_CATEGORIES = {
         constant: exports.COMMAND_UPLOAD_CONSTRUCTORS_PHOTO,
         title: '📤 Upload Constructors Photo',
         description: 'Upload a constructors screenshot for cache extraction',
+      },
+      {
+        constant: exports.COMMAND_ALLOW_WEB_USER,
+        title: '🔐 Allow Web User',
+        description:
+          'Allow a Google email to sign in to the web agent (maps email → chat ID)',
+      },
+      {
+        constant: exports.COMMAND_REVOKE_WEB_USER,
+        title: '🚫 Revoke Web User',
+        description: 'Revoke a Google email from the web agent allowlist',
+      },
+      {
+        constant: exports.COMMAND_LIST_WEB_USERS,
+        title: '📜 List Web Users',
+        description: 'List Google emails currently allowed on the web agent',
       },
     ],
   },

--- a/src/pendingReplyRegistry.js
+++ b/src/pendingReplyRegistry.js
@@ -13,9 +13,23 @@ const {
   getChatName,
   getDisplayName,
   sendMessageToAdmins,
+  sendLogMessage,
 } = require('./utils/utils');
 const { getUserById, listAllUsers, updateUserAttributes } = require('./userRegistryService');
+const {
+  getAllowedUserByEmail,
+  addAllowedUser,
+  removeAllowedUser,
+} = require('./webUserAllowlistService');
 const { userCache } = require('./cache');
+
+// Basic RFC 5322 "looks-like-an-email" gate. Deliberately loose — Google's
+// identity provider is the real validator. We only want to catch obvious
+// typos before persisting to Azure Table Storage.
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+function looksLikeEmail(text) {
+  return typeof text === 'string' && EMAIL_REGEX.test(text.trim());
+}
 
 /**
  * Each entry provides builder functions that reconstruct the handler, validator,
@@ -599,6 +613,209 @@ const PENDING_REPLY_REGISTRY = {
         'We support only text. Please enter the league code:',
         chatId,
       ),
+  },
+  allow_web_user: {
+    buildHandler: (chatId, data) => {
+      const { registerPendingReply } = require('./pendingReplyManager');
+
+      return async (replyBot, replyMsg) => {
+        if (!data || data.step === 'collect_email') {
+          const email = replyMsg.text.trim().toLowerCase();
+
+          await registerPendingReply(chatId, 'allow_web_user', {
+            step: 'collect_chat_id',
+            email,
+          });
+
+          const prompt = `${t(
+            'Got it: {EMAIL}. Now please enter the chat ID to map this email to:',
+            chatId,
+            { EMAIL: email },
+          )}\n\n${t('💡 Send /cancel at any time to abort.', chatId)}`;
+
+          await replyBot
+            .sendMessage(chatId, prompt, {
+              reply_markup: { force_reply: true },
+            })
+            .catch((err) =>
+              console.error('Error sending allow_web_user step-2 prompt:', err),
+            );
+
+          return;
+        }
+
+        if (data.step === 'collect_chat_id') {
+          const targetChatId = replyMsg.text.trim();
+
+          let user;
+          try {
+            user = await getUserById(targetChatId);
+          } catch (err) {
+            console.error('Error fetching user in allow_web_user handler:', err);
+            await replyBot
+              .sendMessage(
+                chatId,
+                t('❌ Error fetching user: {ERROR}', chatId, {
+                  ERROR: err.message,
+                }),
+              )
+              .catch((sendErr) =>
+                console.error('Error sending allow_web_user error:', sendErr),
+              );
+
+            return;
+          }
+
+          try {
+            await addAllowedUser(data.email, targetChatId, chatId);
+          } catch (err) {
+            console.error('Error writing web allowlist:', err);
+            await replyBot
+              .sendMessage(
+                chatId,
+                t('❌ Error allowlisting user: {ERROR}', chatId, {
+                  ERROR: err.message,
+                }),
+              )
+              .catch((sendErr) =>
+                console.error(
+                  'Error sending allow_web_user write-error message:',
+                  sendErr,
+                ),
+              );
+
+            return;
+          }
+
+          const linkedName = user.nickname || user.chatName || targetChatId;
+          await replyBot
+            .sendMessage(
+              chatId,
+              t(
+                '✅ Allowed {EMAIL} on the web agent, mapped to {NAME} ({ID}).',
+                chatId,
+                { EMAIL: data.email, NAME: linkedName, ID: targetChatId },
+              ),
+            )
+            .catch((err) =>
+              console.error('Error sending allow_web_user confirmation:', err),
+            );
+
+          await sendLogMessage(
+            replyBot,
+            `Allowed web user ${data.email} → chatId ${targetChatId} (added by ${chatId})`,
+          ).catch(() => {});
+        }
+      };
+    },
+    buildValidate: (chatId, data) => {
+      if (!data || data.step === 'collect_email') {
+        return (replyMsg) => looksLikeEmail(replyMsg.text);
+      }
+
+      // Step 2: chat ID must exist in the user registry.
+      return async (replyMsg) => {
+        if (!replyMsg.text) {
+          return false;
+        }
+
+        try {
+          const user = await getUserById(replyMsg.text.trim());
+
+          return user !== null;
+        } catch (err) {
+          console.error('Error validating chat ID for allow_web_user:', err);
+
+          return false;
+        }
+      };
+    },
+    buildResendPrompt: (chatId, data) => {
+      if (!data || data.step === 'collect_email') {
+        return t('Please enter a valid Google email address.', chatId);
+      }
+
+      return t(
+        'Chat ID not found in the registry. Please enter a valid chat ID:',
+        chatId,
+      );
+    },
+  },
+  revoke_web_user: {
+    buildHandler: (chatId) => async (replyBot, replyMsg) => {
+      const email = replyMsg.text.trim().toLowerCase();
+
+      let existing;
+      try {
+        existing = await getAllowedUserByEmail(email);
+      } catch (err) {
+        console.error('Error looking up web user for revoke:', err);
+        await replyBot
+          .sendMessage(
+            chatId,
+            t('❌ Error looking up web user: {ERROR}', chatId, {
+              ERROR: err.message,
+            }),
+          )
+          .catch((sendErr) =>
+            console.error('Error sending revoke lookup error:', sendErr),
+          );
+
+        return;
+      }
+
+      if (!existing) {
+        await replyBot
+          .sendMessage(
+            chatId,
+            t('{EMAIL} was not on the web allowlist — nothing to do.', chatId, {
+              EMAIL: email,
+            }),
+          )
+          .catch((err) =>
+            console.error('Error sending revoke not-found message:', err),
+          );
+
+        return;
+      }
+
+      try {
+        await removeAllowedUser(email);
+      } catch (err) {
+        console.error('Error removing web allowlist row:', err);
+        await replyBot
+          .sendMessage(
+            chatId,
+            t('❌ Error revoking web user: {ERROR}', chatId, {
+              ERROR: err.message,
+            }),
+          )
+          .catch((sendErr) =>
+            console.error('Error sending revoke delete error:', sendErr),
+          );
+
+        return;
+      }
+
+      await replyBot
+        .sendMessage(
+          chatId,
+          t('🚫 Revoked {EMAIL} from the web agent allowlist.', chatId, {
+            EMAIL: email,
+          }),
+        )
+        .catch((err) =>
+          console.error('Error sending revoke confirmation:', err),
+        );
+
+      await sendLogMessage(
+        replyBot,
+        `Revoked web user ${email} (revoked by ${chatId})`,
+      ).catch(() => {});
+    },
+    buildValidate: () => (replyMsg) => looksLikeEmail(replyMsg.text),
+    buildResendPrompt: (chatId) =>
+      t('Please enter a valid Google email address.', chatId),
   },
 };
 

--- a/src/pendingReplyRegistry.test.js
+++ b/src/pendingReplyRegistry.test.js
@@ -36,6 +36,12 @@ jest.mock('./leagueRegistryService', () => ({
   addUserLeague: jest.fn().mockResolvedValue(),
 }));
 
+jest.mock('./webUserAllowlistService', () => ({
+  getAllowedUserByEmail: jest.fn(),
+  addAllowedUser: jest.fn().mockResolvedValue(),
+  removeAllowedUser: jest.fn().mockResolvedValue(),
+}));
+
 const {
   PENDING_REPLY_REGISTRY,
   resolveCommand,
@@ -934,6 +940,161 @@ describe('pendingReplyRegistry', () => {
         const resolved = resolveCommand('follow_league', 1);
         expect(resolved.validate({})).toBe(false);
       });
+    });
+  });
+
+  describe('allow_web_user', () => {
+    const {
+      addAllowedUser,
+    } = require('./webUserAllowlistService');
+
+    beforeEach(() => {
+      addAllowedUser.mockReset().mockResolvedValue();
+      registerPendingReply.mockClear();
+      getUserById.mockReset();
+    });
+
+    describe('step 1 (collect_email)', () => {
+      it('validate rejects non-emails', () => {
+        const resolved = resolveCommand('allow_web_user', 1);
+        expect(resolved.validate({ text: 'not-an-email' })).toBe(false);
+        expect(resolved.validate({ text: 'foo bar@x.com' })).toBe(false);
+      });
+
+      it('validate accepts something that looks like an email', () => {
+        const resolved = resolveCommand('allow_web_user', 1);
+        expect(resolved.validate({ text: 'foo@example.com' })).toBe(true);
+      });
+
+      it('handler registers step-2 with the lowercased email', async () => {
+        const botMock = { sendMessage: jest.fn().mockResolvedValue() };
+        const resolved = resolveCommand('allow_web_user', 7);
+        await resolved.handler(botMock, { text: 'Foo@Example.COM' });
+
+        expect(registerPendingReply).toHaveBeenCalledWith(
+          7,
+          'allow_web_user',
+          { step: 'collect_chat_id', email: 'foo@example.com' },
+        );
+      });
+    });
+
+    describe('step 2 (collect_chat_id)', () => {
+      it('validate rejects chat IDs missing from the registry', async () => {
+        getUserById.mockResolvedValueOnce(null);
+        const resolved = resolveCommand('allow_web_user', 1, {
+          step: 'collect_chat_id',
+          email: 'foo@example.com',
+        });
+        expect(await resolved.validate({ text: '999' })).toBe(false);
+      });
+
+      it('validate accepts chat IDs that exist in the registry', async () => {
+        getUserById.mockResolvedValueOnce({ chatName: 'X' });
+        const resolved = resolveCommand('allow_web_user', 1, {
+          step: 'collect_chat_id',
+          email: 'foo@example.com',
+        });
+        expect(await resolved.validate({ text: '12345' })).toBe(true);
+      });
+
+      it('handler writes the allowlist row and confirms', async () => {
+        getUserById.mockResolvedValueOnce({
+          chatName: 'Foo User',
+          nickname: 'TheFoo',
+        });
+        const botMock = { sendMessage: jest.fn().mockResolvedValue() };
+
+        const resolved = resolveCommand('allow_web_user', 7, {
+          step: 'collect_chat_id',
+          email: 'foo@example.com',
+        });
+        await resolved.handler(botMock, { text: '12345' });
+
+        expect(addAllowedUser).toHaveBeenCalledWith(
+          'foo@example.com',
+          '12345',
+          7,
+        );
+        expect(t).toHaveBeenCalledWith(
+          '✅ Allowed {EMAIL} on the web agent, mapped to {NAME} ({ID}).',
+          7,
+          { EMAIL: 'foo@example.com', NAME: 'TheFoo', ID: '12345' },
+        );
+        expect(botMock.sendMessage).toHaveBeenCalled();
+      });
+
+      it('handler reports addAllowedUser errors without throwing', async () => {
+        getUserById.mockResolvedValueOnce({ chatName: 'Foo' });
+        addAllowedUser.mockRejectedValueOnce(new Error('table down'));
+        const botMock = { sendMessage: jest.fn().mockResolvedValue() };
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const resolved = resolveCommand('allow_web_user', 7, {
+          step: 'collect_chat_id',
+          email: 'foo@example.com',
+        });
+        await resolved.handler(botMock, { text: '12345' });
+
+        expect(t).toHaveBeenCalledWith(
+          '❌ Error allowlisting user: {ERROR}',
+          7,
+          { ERROR: 'table down' },
+        );
+      });
+    });
+  });
+
+  describe('revoke_web_user', () => {
+    const {
+      getAllowedUserByEmail,
+      removeAllowedUser,
+    } = require('./webUserAllowlistService');
+
+    beforeEach(() => {
+      getAllowedUserByEmail.mockReset();
+      removeAllowedUser.mockReset().mockResolvedValue();
+    });
+
+    it('validate rejects non-emails', () => {
+      const resolved = resolveCommand('revoke_web_user', 1);
+      expect(resolved.validate({ text: 'nope' })).toBe(false);
+    });
+
+    it('validate accepts email-like text', () => {
+      const resolved = resolveCommand('revoke_web_user', 1);
+      expect(resolved.validate({ text: 'a@b.com' })).toBe(true);
+    });
+
+    it('handler deletes the allowlist row when present', async () => {
+      getAllowedUserByEmail.mockResolvedValueOnce({ email: 'foo@example.com' });
+      const botMock = { sendMessage: jest.fn().mockResolvedValue() };
+
+      const resolved = resolveCommand('revoke_web_user', 7);
+      await resolved.handler(botMock, { text: 'Foo@Example.COM' });
+
+      expect(getAllowedUserByEmail).toHaveBeenCalledWith('foo@example.com');
+      expect(removeAllowedUser).toHaveBeenCalledWith('foo@example.com');
+      expect(t).toHaveBeenCalledWith(
+        '🚫 Revoked {EMAIL} from the web agent allowlist.',
+        7,
+        { EMAIL: 'foo@example.com' },
+      );
+    });
+
+    it('handler is a no-op (with friendly message) when the email is not on the allowlist', async () => {
+      getAllowedUserByEmail.mockResolvedValueOnce(null);
+      const botMock = { sendMessage: jest.fn().mockResolvedValue() };
+
+      const resolved = resolveCommand('revoke_web_user', 7);
+      await resolved.handler(botMock, { text: 'foo@example.com' });
+
+      expect(removeAllowedUser).not.toHaveBeenCalled();
+      expect(t).toHaveBeenCalledWith(
+        '{EMAIL} was not on the web allowlist — nothing to do.',
+        7,
+        { EMAIL: 'foo@example.com' },
+      );
     });
   });
 });

--- a/src/textMessageHandler.js
+++ b/src/textMessageHandler.js
@@ -48,6 +48,9 @@ const {
   handleLeagueGraphsCommand,
   handleLeagueChangesCommand,
   handleWhatsNewCommand,
+  handleAllowWebUserCommand,
+  handleRevokeWebUserCommand,
+  handleListWebUsersCommand,
 } = require('./commandsHandler');
 
 // Import constants
@@ -98,6 +101,9 @@ const {
   COMMAND_LEAGUE_GRAPHS,
   COMMAND_LEAGUE_CHANGES,
   COMMAND_WHATS_NEW,
+  COMMAND_ALLOW_WEB_USER,
+  COMMAND_REVOKE_WEB_USER,
+  COMMAND_LIST_WEB_USERS,
 } = require('./constants');
 
 exports.handleTextMessage = async function (bot, msg) {
@@ -206,6 +212,12 @@ exports.handleTextMessage = async function (bot, msg) {
       return await handleLeagueChangesCommand(bot, msg);
     case msg.text === COMMAND_WHATS_NEW:
       return await handleWhatsNewCommand(bot, msg);
+    case msg.text === COMMAND_ALLOW_WEB_USER:
+      return await handleAllowWebUserCommand(bot, msg);
+    case msg.text === COMMAND_REVOKE_WEB_USER:
+      return await handleRevokeWebUserCommand(bot, msg);
+    case msg.text === COMMAND_LIST_WEB_USERS:
+      return await handleListWebUsersCommand(bot, msg);
     default:
       try {
         const jsonData = JSON.parse(textTrimmed);

--- a/src/translations.js
+++ b/src/translations.js
@@ -611,6 +611,47 @@ const translations = {
     '💡 Send /cancel at any time to abort.':
       '💡\u200F שלח \u2066/cancel\u2069 בכל רגע כדי לבטל.',
     'Operation cancelled.': 'הפעולה בוטלה.',
+    'Please enter the Google email to allow on the web agent:':
+      'אנא הזן את כתובת ה-Google של המשתמש שברצונך לאשר באתר:',
+    'Please enter the Google email to revoke from the web agent:':
+      'אנא הזן את כתובת ה-Google של המשתמש שברצונך להסיר מהאתר:',
+    'Please enter a valid Google email address.':
+      'אנא הזן כתובת אימייל Google תקינה.',
+    'Got it: {EMAIL}. Now please enter the chat ID to map this email to:':
+      'הבנתי: {EMAIL}. כעת אנא הזן את ה-chat ID שאליו תמופה כתובת זו:',
+    'Chat ID not found in the registry. Please enter a valid chat ID:':
+      'ה-chat ID לא נמצא ברישום. אנא הזן chat ID תקין:',
+    '❌ Error fetching user: {ERROR}':
+      '❌ שגיאה באחזור המשתמש: {ERROR}',
+    '❌ Error allowlisting user: {ERROR}':
+      '❌ שגיאה בהוספה לרשימה המורשית: {ERROR}',
+    '❌ Error looking up web user: {ERROR}':
+      '❌ שגיאה בחיפוש משתמש האתר: {ERROR}',
+    '❌ Error revoking web user: {ERROR}':
+      '❌ שגיאה בהסרת משתמש האתר: {ERROR}',
+    '❌ Error fetching web allowlist: {ERROR}':
+      '❌ שגיאה באחזור רשימת המשתמשים המורשים: {ERROR}',
+    '✅ Allowed {EMAIL} on the web agent, mapped to {NAME} ({ID}).':
+      '✅ {EMAIL} אושר באתר ומקושר אל {NAME} ({ID}).',
+    '🚫 Revoked {EMAIL} from the web agent allowlist.':
+      '🚫 {EMAIL} הוסר מרשימת המשתמשים המורשים באתר.',
+    '{EMAIL} was not on the web allowlist — nothing to do.':
+      '{EMAIL} לא היה ברשימת המשתמשים המורשים — אין צורך בפעולה.',
+    'No web users allowlisted yet.':
+      'אין עדיין משתמשים מורשים באתר.',
+    'Web Allowlist': 'רשימת משתמשים מורשים באתר',
+    'Added': 'נוסף',
+    'Added by': 'נוסף על ידי',
+    '(unknown)': '(לא ידוע)',
+    '🔐 Allow Web User': '🔐 אישור משתמש לאתר',
+    '🚫 Revoke Web User': '🚫 הסרת משתמש מהאתר',
+    '📜 List Web Users': '📜 רשימת משתמשי האתר',
+    'Allow a Google email to sign in to the web agent (maps email → chat ID)':
+      'אישור כתובת Google לכניסה לסוכן האתר (ממפה אימייל → chat ID)',
+    'Revoke a Google email from the web agent allowlist':
+      'הסרת כתובת Google מרשימת המשתמשים המורשים באתר',
+    'List Google emails currently allowed on the web agent':
+      'הצגת כתובות ה-Google המורשות כעת באתר הסוכן',
     'Which league graph do you want to see?':
       'איזה גרף ליגה תרצה לראות?',
     'Which graph do you want to see?': 'איזה גרף תרצה לראות?',

--- a/src/webUserAllowlistService.js
+++ b/src/webUserAllowlistService.js
@@ -1,0 +1,170 @@
+// Web user allowlist — maps Google emails to the Telegram chatId the
+// agent should act as for that user.
+//
+// Backed by Azure Table Storage (table: `WebUserAllowlist`). Uses the
+// same `AZURE_STORAGE_CONNECTION_STRING` as the rest of the app. Single
+// partition (`'WebUser'`); rowKey is the lowercased Google email so
+// `getAllowedUserByEmail` is an O(1) point lookup.
+//
+// Until the agent has its own write actions, every allowlisted user
+// MUST have a `chatId` so the agent can serve their existing Telegram-
+// side data (teams, leagues, live score, …). When write actions land
+// the `chatId` field becomes optional — see the plan for the cutover
+// path.
+
+const { TableClient } = require('@azure/data-tables');
+
+const TABLE_NAME = 'WebUserAllowlist';
+const PARTITION_KEY = 'WebUser';
+
+const SYSTEM_FIELDS = new Set([
+  'partitionKey',
+  'rowKey',
+  'etag',
+  'timestamp',
+  'odata.etag',
+  'odata.metadata',
+]);
+
+let tableClient;
+let tableReady = false;
+
+function initializeTableClient() {
+  const connectionString = process.env.AZURE_STORAGE_CONNECTION_STRING;
+
+  if (!connectionString) {
+    throw new Error(
+      'Missing AZURE_STORAGE_CONNECTION_STRING for web user allowlist storage',
+    );
+  }
+
+  tableClient = TableClient.fromConnectionString(connectionString, TABLE_NAME);
+  tableReady = false;
+}
+
+async function ensureTable() {
+  if (!tableClient) {
+    initializeTableClient();
+  }
+
+  if (!tableReady) {
+    await tableClient.createTable().catch(() => {
+      // Table already exists — ignore
+    });
+    tableReady = true;
+  }
+}
+
+function normalizeEmail(email) {
+  if (typeof email !== 'string') {
+    throw new Error('Email must be a string');
+  }
+
+  return email.trim().toLowerCase();
+}
+
+function entityToUser(entity) {
+  const user = { email: entity.rowKey };
+
+  for (const [key, value] of Object.entries(entity)) {
+    if (!SYSTEM_FIELDS.has(key)) {
+      user[key] = value;
+    }
+  }
+
+  return user;
+}
+
+/**
+ * Look up an allowed user by their Google email (case-insensitive).
+ * @param {string} email
+ * @returns {Promise<{email: string, chatId?: string, addedBy?: string, addedAt?: string}|null>}
+ */
+async function getAllowedUserByEmail(email) {
+  await ensureTable();
+
+  const rowKey = normalizeEmail(email);
+
+  try {
+    const entity = await tableClient.getEntity(PARTITION_KEY, rowKey);
+
+    return entityToUser(entity);
+  } catch (err) {
+    if (err.statusCode === 404) {
+      return null;
+    }
+
+    throw err;
+  }
+}
+
+/**
+ * Upsert an allowlist entry. `chatId` is required for v1 (read-only
+ * agent) but stored as a string so future writers can store an
+ * email-only entry.
+ *
+ * @param {string} email
+ * @param {number|string} chatId
+ * @param {number|string} addedBy - chatId of the admin adding the entry
+ */
+async function addAllowedUser(email, chatId, addedBy) {
+  await ensureTable();
+
+  const rowKey = normalizeEmail(email);
+  const now = new Date().toISOString();
+
+  const entity = {
+    partitionKey: PARTITION_KEY,
+    rowKey,
+    chatId: String(chatId),
+    addedBy: String(addedBy),
+    addedAt: now,
+  };
+
+  await tableClient.upsertEntity(entity, 'Merge');
+}
+
+/**
+ * Delete an allowlist entry. Idempotent — missing rows are a no-op.
+ * @param {string} email
+ */
+async function removeAllowedUser(email) {
+  await ensureTable();
+
+  const rowKey = normalizeEmail(email);
+
+  try {
+    await tableClient.deleteEntity(PARTITION_KEY, rowKey);
+  } catch (err) {
+    if (err.statusCode === 404) {
+      return;
+    }
+
+    throw err;
+  }
+}
+
+/**
+ * List all allowed users.
+ * @returns {Promise<Array<{email: string, chatId?: string, addedBy?: string, addedAt?: string}>>}
+ */
+async function listAllowedUsers() {
+  await ensureTable();
+
+  const users = [];
+
+  for await (const entity of tableClient.listEntities({
+    queryOptions: { filter: `PartitionKey eq '${PARTITION_KEY}'` },
+  })) {
+    users.push(entityToUser(entity));
+  }
+
+  return users;
+}
+
+module.exports = {
+  getAllowedUserByEmail,
+  addAllowedUser,
+  removeAllowedUser,
+  listAllowedUsers,
+};

--- a/src/webUserAllowlistService.test.js
+++ b/src/webUserAllowlistService.test.js
@@ -1,0 +1,199 @@
+const mockGetEntity = jest.fn();
+const mockUpsertEntity = jest.fn();
+const mockDeleteEntity = jest.fn();
+const mockCreateTable = jest.fn().mockResolvedValue();
+const mockListEntities = jest.fn();
+
+jest.mock('@azure/data-tables', () => ({
+  TableClient: {
+    fromConnectionString: jest.fn().mockReturnValue({
+      getEntity: mockGetEntity,
+      upsertEntity: mockUpsertEntity,
+      deleteEntity: mockDeleteEntity,
+      createTable: mockCreateTable,
+      listEntities: mockListEntities,
+    }),
+  },
+}));
+
+describe('webUserAllowlistService', () => {
+  const originalEnv = process.env;
+
+  let svc;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetEntity.mockReset();
+    mockUpsertEntity.mockReset();
+    mockDeleteEntity.mockReset();
+    mockCreateTable.mockReset().mockResolvedValue();
+    mockListEntities.mockReset();
+
+    process.env = {
+      ...originalEnv,
+      AZURE_STORAGE_CONNECTION_STRING: 'mock-connection-string',
+    };
+
+    jest.isolateModules(() => {
+      svc = require('./webUserAllowlistService');
+    });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  function notFound() {
+    const err = new Error('ResourceNotFound');
+    err.statusCode = 404;
+
+    return err;
+  }
+
+  describe('getAllowedUserByEmail', () => {
+    it('returns user object on hit, normalizing email case', async () => {
+      mockGetEntity.mockResolvedValueOnce({
+        partitionKey: 'WebUser',
+        rowKey: 'foo@example.com',
+        chatId: '12345',
+        addedBy: '454873194',
+        addedAt: '2026-05-21T00:00:00.000Z',
+      });
+
+      const user = await svc.getAllowedUserByEmail('Foo@Example.COM');
+
+      expect(mockGetEntity).toHaveBeenCalledWith('WebUser', 'foo@example.com');
+      expect(user).toEqual({
+        email: 'foo@example.com',
+        chatId: '12345',
+        addedBy: '454873194',
+        addedAt: '2026-05-21T00:00:00.000Z',
+      });
+    });
+
+    it('returns null on 404', async () => {
+      mockGetEntity.mockRejectedValueOnce(notFound());
+
+      const user = await svc.getAllowedUserByEmail('missing@example.com');
+
+      expect(user).toBeNull();
+    });
+
+    it('re-throws non-404 errors', async () => {
+      mockGetEntity.mockRejectedValueOnce(new Error('boom'));
+
+      await expect(
+        svc.getAllowedUserByEmail('foo@example.com'),
+      ).rejects.toThrow('boom');
+    });
+
+    it('strips Azure system fields from the returned object', async () => {
+      mockGetEntity.mockResolvedValueOnce({
+        partitionKey: 'WebUser',
+        rowKey: 'foo@example.com',
+        etag: 'W/"datetime"',
+        timestamp: '2026-05-21T00:00:00.000Z',
+        chatId: '12345',
+      });
+
+      const user = await svc.getAllowedUserByEmail('foo@example.com');
+      expect(user).toEqual({ email: 'foo@example.com', chatId: '12345' });
+    });
+  });
+
+  describe('addAllowedUser', () => {
+    it('writes the entity with Merge mode and stringifies chatId', async () => {
+      mockUpsertEntity.mockResolvedValueOnce();
+
+      await svc.addAllowedUser('Bar@Example.com', 67890, 454873194);
+
+      expect(mockUpsertEntity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          partitionKey: 'WebUser',
+          rowKey: 'bar@example.com',
+          chatId: '67890',
+          addedBy: '454873194',
+          addedAt: expect.any(String),
+        }),
+        'Merge',
+      );
+    });
+  });
+
+  describe('removeAllowedUser', () => {
+    it('deletes the row', async () => {
+      mockDeleteEntity.mockResolvedValueOnce();
+
+      await svc.removeAllowedUser('foo@example.com');
+
+      expect(mockDeleteEntity).toHaveBeenCalledWith(
+        'WebUser',
+        'foo@example.com',
+      );
+    });
+
+    it('treats missing row as a no-op (404)', async () => {
+      mockDeleteEntity.mockRejectedValueOnce(notFound());
+
+      await expect(
+        svc.removeAllowedUser('missing@example.com'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('re-throws on non-404 errors', async () => {
+      mockDeleteEntity.mockRejectedValueOnce(new Error('boom'));
+
+      await expect(svc.removeAllowedUser('foo@example.com')).rejects.toThrow(
+        'boom',
+      );
+    });
+  });
+
+  describe('listAllowedUsers', () => {
+    it('returns all entries with email + non-system fields', async () => {
+      mockListEntities.mockReturnValueOnce({
+        async *[Symbol.asyncIterator]() {
+          yield {
+            partitionKey: 'WebUser',
+            rowKey: 'a@example.com',
+            etag: 'x',
+            chatId: '1',
+            addedBy: '100',
+            addedAt: '2026-05-01T00:00:00.000Z',
+          };
+          yield {
+            partitionKey: 'WebUser',
+            rowKey: 'b@example.com',
+            chatId: '2',
+          };
+        },
+      });
+
+      const users = await svc.listAllowedUsers();
+
+      expect(users).toEqual([
+        {
+          email: 'a@example.com',
+          chatId: '1',
+          addedBy: '100',
+          addedAt: '2026-05-01T00:00:00.000Z',
+        },
+        { email: 'b@example.com', chatId: '2' },
+      ]);
+    });
+  });
+
+  describe('initialization', () => {
+    it('throws when AZURE_STORAGE_CONNECTION_STRING is missing', async () => {
+      delete process.env.AZURE_STORAGE_CONNECTION_STRING;
+
+      jest.isolateModules(() => {
+        svc = require('./webUserAllowlistService');
+      });
+
+      await expect(
+        svc.getAllowedUserByEmail('foo@example.com'),
+      ).rejects.toThrow(/AZURE_STORAGE_CONNECTION_STRING/);
+    });
+  });
+});

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@copilotkit/react-core": "^1.57.1",
         "@copilotkit/react-ui": "^1.57.1",
+        "@react-oauth/google": "^0.13.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -2106,6 +2107,16 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
+    },
+    "node_modules/@react-oauth/google": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.13.5.tgz",
+      "integrity": "sha512-xQWri2s/3nNekZJ4uuov2aAfQYu83bN3864KcFqw2pK1nNbFurQIjPFDXhWaKH3IjYJ2r/9yyIIpsn5lMqrheQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
     },
     "node_modules/@react-types/shared": {
       "version": "3.34.0",

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@copilotkit/react-core": "^1.57.1",
     "@copilotkit/react-ui": "^1.57.1",
+    "@react-oauth/google": "^0.13.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,13 @@
+import { useEffect } from 'react';
 import { CopilotKit } from '@copilotkit/react-core';
 import { CopilotChat } from '@copilotkit/react-ui';
 import '@copilotkit/react-ui/styles.css';
+import { GoogleOAuthProvider } from '@react-oauth/google';
+import { AuthProvider, useAuth } from './auth/AuthContext';
+import { useAuthFetchInterceptor } from './auth/useAuthFetchInterceptor';
+import { LoginScreen } from './components/LoginScreen';
+import { SignedInBadge } from './components/SignedInBadge';
+import { setHistoryScope } from './lib/chatHistoryStore';
 import { useNextRacesAction } from './components/NextRacesTable';
 import { useBestTeamsAction } from './components/BestTeamsTable';
 import { useBestTeamScenariosAction } from './components/BestTeamScenariosMatrix';
@@ -20,6 +27,9 @@ const RUNTIME_URL =
   (import.meta.env.VITE_AGENT_API_URL as string | undefined) ??
   'http://localhost:7071/api/agent/copilotkit';
 
+const GOOGLE_CLIENT_ID =
+  (import.meta.env.VITE_GOOGLE_CLIENT_ID as string | undefined) ?? '';
+
 function AgentActions() {
   useNextRacesAction();
   useUserTeamsAction();
@@ -36,39 +46,117 @@ function AgentActions() {
   return null;
 }
 
-export default function App() {
+function AuthedAgent() {
+  const { session } = useAuth();
+  useAuthFetchInterceptor(RUNTIME_URL);
+
+  // Keep the chat-history scope in sync with the active user so two
+  // users on the same browser don't see each other's chat. Side-effect
+  // is set BEFORE the chat tree renders so the very first HistoryRestorer
+  // read targets the right key.
+  useEffect(() => {
+    setHistoryScope(session ? session.claims.sub : null);
+  }, [session]);
+
+  if (!session) {
+    return <LoginScreen />;
+  }
+
   return (
-    <div className="app-shell">
-      <CopilotKit runtimeUrl={RUNTIME_URL}>
-        <HistoryRestorer />
-        <AgentActions />
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'flex-start',
-            gap: 16,
-          }}
-        >
-          <div>
-            <h1 className="app-header">F1 Fantasy Agent</h1>
-            <p className="app-subheader">
-              Ask about upcoming races or your best teams. The Telegram bot is unaffected.
-            </p>
-          </div>
+    <CopilotKit
+      runtimeUrl={RUNTIME_URL}
+      headers={() => ({ Authorization: `Bearer ${session.idToken}` })}
+    >
+      <HistoryRestorer />
+      <AgentActions />
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          gap: 16,
+        }}
+      >
+        <div>
+          <h1 className="app-header">F1 Fantasy Agent</h1>
+          <p className="app-subheader">
+            Ask about upcoming races or your best teams. The Telegram bot is unaffected.
+          </p>
+        </div>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+          <SignedInBadge />
           <ClearHistoryButton />
         </div>
-        <div className="chat-wrapper">
-          <CopilotChat
-            instructions="You are an assistant for an F1 Fantasy player. Use the registered tools to answer questions; the user will see rich UI components automatically when you call them."
-            labels={{
-              title: 'F1 Fantasy Agent',
-              initial:
-                'Hi! Try: "best teams for kilzid3 with Verstappen but no Alonso".',
-            }}
-          />
+      </div>
+      <div className="chat-wrapper">
+        <CopilotChat
+          instructions="You are an assistant for an F1 Fantasy player. Use the registered tools to answer questions; the user will see rich UI components automatically when you call them."
+          labels={{
+            title: 'F1 Fantasy Agent',
+            initial:
+              'Hi! Try: "best teams for kilzid3 with Verstappen but no Alonso".',
+          }}
+        />
+      </div>
+    </CopilotKit>
+  );
+}
+
+// When VITE_GOOGLE_CLIENT_ID is unset (local dev or PR-preview build),
+// we render the chat directly without any auth gate — backend bypasses
+// auth in that mode too (when GOOGLE_CLIENT_ID is unset on the
+// Function App). This keeps `npm run dev` frictionless.
+function UnauthedAgent() {
+  return (
+    <CopilotKit runtimeUrl={RUNTIME_URL}>
+      <HistoryRestorer />
+      <AgentActions />
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          gap: 16,
+        }}
+      >
+        <div>
+          <h1 className="app-header">F1 Fantasy Agent</h1>
+          <p className="app-subheader">
+            Ask about upcoming races or your best teams. The Telegram bot is unaffected.
+          </p>
         </div>
-      </CopilotKit>
-    </div>
+        <ClearHistoryButton />
+      </div>
+      <div className="chat-wrapper">
+        <CopilotChat
+          instructions="You are an assistant for an F1 Fantasy player. Use the registered tools to answer questions; the user will see rich UI components automatically when you call them."
+          labels={{
+            title: 'F1 Fantasy Agent',
+            initial:
+              'Hi! Try: "best teams for kilzid3 with Verstappen but no Alonso".',
+          }}
+        />
+      </div>
+    </CopilotKit>
+  );
+}
+
+export default function App() {
+  if (!GOOGLE_CLIENT_ID) {
+    return (
+      <div className="app-shell">
+        <UnauthedAgent />
+      </div>
+    );
+  }
+
+  return (
+    <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID}>
+      <AuthProvider>
+        <div className="app-shell">
+          <AuthedAgent />
+        </div>
+      </AuthProvider>
+    </GoogleOAuthProvider>
   );
 }

--- a/web/src/auth/AuthContext.tsx
+++ b/web/src/auth/AuthContext.tsx
@@ -48,13 +48,17 @@ type AuthContextValue = {
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
+// Minimal JWT payload decoder. We do NOT verify the signature here —
+// the backend does that. Decoding is only for UI display (email,
+// name, etc.) and for scoping localStorage keys by `sub`. If the
+// token is malformed we treat it as "not signed in".
+//
+// `atob` is a browser builtin in every environment Vite targets, so
+// no Node `Buffer` fallback is needed.
 function base64UrlDecode(input: string): string {
   const padding = '='.repeat((4 - (input.length % 4)) % 4);
   const base64 = (input + padding).replace(/-/g, '+').replace(/_/g, '/');
-  if (typeof atob === 'function') {
-    return atob(base64);
-  }
-  return Buffer.from(base64, 'base64').toString('binary');
+  return atob(base64);
 }
 
 export function decodeIdTokenClaims(token: string): IdTokenClaims | null {

--- a/web/src/auth/AuthContext.tsx
+++ b/web/src/auth/AuthContext.tsx
@@ -1,0 +1,164 @@
+// Google sign-in state for the F1 Fantasy web-chat agent.
+//
+// Holds the ID token returned by Google Identity Services (via
+// @react-oauth/google's <GoogleLogin /> button) plus the decoded
+// `email`, `name`, `picture`, and `sub` claims for UI display. The
+// token is cached in `sessionStorage` (NOT `localStorage`) so closing
+// the tab logs the user out — a low-cost mitigation for shared
+// browsers.
+//
+// The token is read by `<CopilotKit>` via a custom transport that
+// adds `Authorization: Bearer ${idToken}` to every backend request.
+// The backend verifies the token + allowlists the email on EVERY
+// request; the frontend treats the token as opaque (we only decode
+// it for display) and bounces to the login screen on any 401.
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+const STORAGE_KEY = 'f1-fantasy-agent-id-token';
+
+type IdTokenClaims = {
+  email: string;
+  name?: string;
+  picture?: string;
+  sub: string;
+  exp: number;
+};
+
+type AuthSession = {
+  idToken: string;
+  claims: IdTokenClaims;
+};
+
+type AuthContextValue = {
+  session: AuthSession | null;
+  signIn: (idToken: string) => void;
+  signOut: () => void;
+  rejection: { reason: string; email?: string } | null;
+  setRejection: (rejection: { reason: string; email?: string } | null) => void;
+};
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+function base64UrlDecode(input: string): string {
+  const padding = '='.repeat((4 - (input.length % 4)) % 4);
+  const base64 = (input + padding).replace(/-/g, '+').replace(/_/g, '/');
+  if (typeof atob === 'function') {
+    return atob(base64);
+  }
+  return Buffer.from(base64, 'base64').toString('binary');
+}
+
+export function decodeIdTokenClaims(token: string): IdTokenClaims | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+    const payload = JSON.parse(base64UrlDecode(parts[1]));
+    if (typeof payload.email !== 'string') return null;
+    if (typeof payload.sub !== 'string') return null;
+    return {
+      email: payload.email,
+      name: typeof payload.name === 'string' ? payload.name : undefined,
+      picture:
+        typeof payload.picture === 'string' ? payload.picture : undefined,
+      sub: payload.sub,
+      exp: typeof payload.exp === 'number' ? payload.exp : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function readStoredToken(): AuthSession | null {
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const claims = decodeIdTokenClaims(raw);
+    if (!claims) return null;
+    if (claims.exp && claims.exp * 1000 <= Date.now()) {
+      window.sessionStorage.removeItem(STORAGE_KEY);
+      return null;
+    }
+    return { idToken: raw, claims };
+  } catch {
+    return null;
+  }
+}
+
+function persistToken(token: string | null) {
+  try {
+    if (token === null) {
+      window.sessionStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.sessionStorage.setItem(STORAGE_KEY, token);
+    }
+  } catch {
+    // sessionStorage may be unavailable (private mode); ignore.
+  }
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [session, setSession] = useState<AuthSession | null>(() =>
+    readStoredToken(),
+  );
+  const [rejection, setRejection] = useState<
+    { reason: string; email?: string } | null
+  >(null);
+
+  const signIn = useCallback((idToken: string) => {
+    const claims = decodeIdTokenClaims(idToken);
+    if (!claims) {
+      setRejection({ reason: 'invalid_token' });
+      return;
+    }
+    persistToken(idToken);
+    setSession({ idToken, claims });
+    setRejection(null);
+  }, []);
+
+  const signOut = useCallback(() => {
+    persistToken(null);
+    setSession(null);
+  }, []);
+
+  useEffect(() => {
+    if (!session) return;
+    const expMs = session.claims.exp * 1000;
+    const delay = expMs - Date.now();
+    if (delay <= 0) {
+      signOut();
+      setRejection({ reason: 'session_expired' });
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      signOut();
+      setRejection({ reason: 'session_expired' });
+    }, delay);
+    return () => window.clearTimeout(timer);
+  }, [session, signOut]);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({ session, signIn, signOut, rejection, setRejection }),
+    [session, signIn, signOut, rejection],
+  );
+
+  return (
+    <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth must be used inside <AuthProvider>');
+  }
+  return ctx;
+}

--- a/web/src/auth/useAuthFetchInterceptor.ts
+++ b/web/src/auth/useAuthFetchInterceptor.ts
@@ -1,0 +1,85 @@
+// Global fetch interceptor that detects 401s from the agent webhook
+// and bounces the user back to the login screen.
+//
+// Why a fetch override (vs CopilotKit's onError):
+// - CopilotKit surfaces its own error codes (AGENT_CONNECT_FAILED, etc.)
+//   that don't expose the underlying HTTP status cleanly. We need the
+//   raw 401 + the JSON body so we can show the user "your email is not
+//   allowlisted" vs "session expired".
+// - The override is scoped to URLs that start with the agent runtime
+//   URL — every other fetch on the page passes through untouched.
+// - We only install the override ONCE; multiple <AuthBoundary>
+//   re-renders are a no-op.
+//
+// On 401:
+//   - parses the JSON body to read the server's `reason` and `email`,
+//   - sets the AuthContext rejection (so the login screen can render
+//     a meaningful error),
+//   - calls signOut() so the gated chat UI immediately unmounts.
+
+import { useEffect, useRef } from 'react';
+import { useAuth } from './AuthContext';
+
+type AuthErrorBody = {
+  error?: string;
+  reason?: string;
+  email?: string;
+};
+
+function isAgentResponse(input: RequestInfo | URL, runtimeUrl: string): boolean {
+  try {
+    const requestUrl =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    if (!requestUrl) return false;
+    return requestUrl.startsWith(runtimeUrl);
+  } catch {
+    return false;
+  }
+}
+
+export function useAuthFetchInterceptor(runtimeUrl: string): void {
+  const { signOut, setRejection } = useAuth();
+  const installedRef = useRef(false);
+
+  useEffect(() => {
+    if (installedRef.current) return;
+    installedRef.current = true;
+
+    const original = window.fetch.bind(window);
+
+    async function wrapped(
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> {
+      const response = await original(input, init);
+
+      if (response.status === 401 && isAgentResponse(input, runtimeUrl)) {
+        // Clone before reading so the consumer can still consume the body.
+        let body: AuthErrorBody = {};
+        try {
+          body = (await response.clone().json()) as AuthErrorBody;
+        } catch {
+          // Non-JSON body — fall through with empty fields.
+        }
+        setRejection({
+          reason: body.reason || 'unauthorized',
+          email: body.email,
+        });
+        signOut();
+      }
+
+      return response;
+    }
+
+    (window as unknown as { fetch: typeof window.fetch }).fetch = wrapped;
+
+    return () => {
+      (window as unknown as { fetch: typeof window.fetch }).fetch = original;
+      installedRef.current = false;
+    };
+  }, [runtimeUrl, signOut, setRejection]);
+}

--- a/web/src/components/LoginScreen.tsx
+++ b/web/src/components/LoginScreen.tsx
@@ -1,0 +1,121 @@
+// Login screen shown to anonymous visitors.
+//
+// Renders just a Google sign-in button + a one-line headline + an
+// optional banner explaining why the previous sign-in attempt was
+// rejected. NO chat UI is mounted until the user has a valid token.
+
+import { GoogleLogin } from '@react-oauth/google';
+import { useAuth } from '../auth/AuthContext';
+
+const REJECTION_MESSAGES: Record<string, string> = {
+  email_not_allowlisted:
+    'This Google account is not allowed on the F1 Fantasy Agent. Please contact the admin via Telegram if you believe this is a mistake.',
+  invalid_token:
+    'Your sign-in token could not be verified. Please sign in again.',
+  session_expired: 'Your session has expired. Please sign in again.',
+  unauthorized: 'Sign-in is required to use the F1 Fantasy Agent.',
+  allowlist_lookup_failed:
+    'A temporary problem prevented us from verifying your access. Please try again in a moment.',
+};
+
+function formatRejection(rejection: {
+  reason: string;
+  email?: string;
+}): string {
+  const base =
+    REJECTION_MESSAGES[rejection.reason] ?? REJECTION_MESSAGES.unauthorized;
+  if (rejection.email && rejection.reason === 'email_not_allowlisted') {
+    return `${rejection.email}: ${base}`;
+  }
+  return base;
+}
+
+export function LoginScreen() {
+  const { signIn, rejection, setRejection } = useAuth();
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '60vh',
+        gap: 24,
+        padding: '32px 16px',
+        textAlign: 'center',
+      }}
+    >
+      <div style={{ maxWidth: 420 }}>
+        <h1
+          style={{
+            margin: '0 0 12px',
+            fontSize: 28,
+            fontWeight: 700,
+            color: '#1a1a1a',
+          }}
+        >
+          🏎️ F1 Fantasy Agent
+        </h1>
+        <p
+          style={{
+            margin: 0,
+            fontSize: 15,
+            color: '#444',
+            lineHeight: 1.45,
+          }}
+        >
+          Sign in with Google to chat with the agent. Access is invitation
+          only — ask the admin on Telegram if you'd like to be allowlisted.
+        </p>
+      </div>
+
+      {rejection ? (
+        <div
+          role="alert"
+          style={{
+            maxWidth: 420,
+            padding: '12px 16px',
+            background: '#fff4f4',
+            border: '1px solid #f5c2c2',
+            borderRadius: 8,
+            color: '#7a1f1f',
+            fontSize: 13,
+            lineHeight: 1.45,
+          }}
+        >
+          {formatRejection(rejection)}
+        </div>
+      ) : null}
+
+      <div
+        style={{
+          padding: 24,
+          background: '#fff',
+          borderRadius: 12,
+          boxShadow: '0 2px 8px rgba(0,0,0,0.06)',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 12,
+        }}
+      >
+        <GoogleLogin
+          onSuccess={(credentialResponse) => {
+            if (credentialResponse.credential) {
+              signIn(credentialResponse.credential);
+            } else {
+              setRejection({ reason: 'invalid_token' });
+            }
+          }}
+          onError={() => {
+            setRejection({ reason: 'invalid_token' });
+          }}
+          theme="filled_blue"
+          size="large"
+          shape="rectangular"
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/SignedInBadge.tsx
+++ b/web/src/components/SignedInBadge.tsx
@@ -1,0 +1,66 @@
+// Signed-in indicator + Sign out button.
+//
+// Renders next to <ClearHistoryButton /> in the header. Shows the
+// user's name (falling back to email) plus a small avatar from the
+// Google profile picture if available. The sign-out button clears
+// both the auth session AND the chat history — shared-browser users
+// should never see each other's conversation.
+
+import { useAuth } from '../auth/AuthContext';
+import { clear as clearChatHistory } from '../lib/chatHistoryStore';
+
+export function SignedInBadge() {
+  const { session, signOut } = useAuth();
+
+  if (!session) return null;
+  const { claims } = session;
+  const display = claims.name || claims.email;
+
+  const onSignOut = () => {
+    // Wipe local history so a different user signing in on the
+    // same browser doesn't see the previous conversation.
+    clearChatHistory();
+    signOut();
+  };
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        fontSize: 13,
+        color: '#37404f',
+      }}
+    >
+      {claims.picture ? (
+        <img
+          src={claims.picture}
+          alt=""
+          width={28}
+          height={28}
+          referrerPolicy="no-referrer"
+          style={{ borderRadius: '50%' }}
+        />
+      ) : null}
+      <span title={claims.email}>{display}</span>
+      <button
+        type="button"
+        onClick={onSignOut}
+        style={{
+          padding: '6px 10px',
+          fontSize: 12,
+          fontWeight: 600,
+          color: '#37404f',
+          background: '#f1f3f7',
+          border: '1px solid #d8dde6',
+          borderRadius: 6,
+          cursor: 'pointer',
+        }}
+        aria-label="Sign out"
+      >
+        Sign out
+      </button>
+    </div>
+  );
+}

--- a/web/src/lib/chatHistoryStore.ts
+++ b/web/src/lib/chatHistoryStore.ts
@@ -28,7 +28,25 @@
 
 import type { Message } from '@ag-ui/core';
 
-const STORAGE_KEY = 'f1-fantasy-agent-history';
+// Localstorage key — scoped per-Google-sub at runtime so multiple
+// users on the same browser don't see each other's history.
+const BASE_STORAGE_KEY = 'f1-fantasy-agent-history';
+let activeScope: string | null = null;
+
+function storageKey(): string {
+  return activeScope ? `${BASE_STORAGE_KEY}::${activeScope}` : BASE_STORAGE_KEY;
+}
+
+/**
+ * Bind chat history to a per-user scope. Call with the Google `sub`
+ * after sign-in; call with `null` after sign-out to detach (so a
+ * brief render between sign-out and unmount doesn't accidentally
+ * touch the previous user's blob).
+ */
+export function setHistoryScope(scope: string | null): void {
+  activeScope = scope;
+}
+
 const SCHEMA_VERSION = 1;
 const MAX_MESSAGES = 20;
 const MAX_BYTES = 100 * 1024;
@@ -72,7 +90,7 @@ function dedupeById(messages: StoredMessage[]): StoredMessage[] {
 export function load(): StoredMessage[] {
   let raw: string | null;
   try {
-    raw = window.localStorage.getItem(STORAGE_KEY);
+    raw = window.localStorage.getItem(storageKey());
   } catch {
     // Private mode / restricted context — treat as no history.
     return [];
@@ -130,7 +148,7 @@ export function save(messages: StoredMessage[]): void {
     messages: trimmed,
   };
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    window.localStorage.setItem(storageKey(), JSON.stringify(payload));
   } catch {
     // Quota exceeded or any other storage failure — clear and move
     // on. Better to lose history than to leak the failure into the
@@ -141,7 +159,7 @@ export function save(messages: StoredMessage[]): void {
 
 export function clear(): void {
   try {
-    window.localStorage.removeItem(STORAGE_KEY);
+    window.localStorage.removeItem(storageKey());
   } catch {
     // Nothing to do — storage isn't writeable in this context.
   }


### PR DESCRIPTION
## Summary

Anonymous visitors now see a clean Google sign-in screen instead of the chat. Every backend POST is verified against a Google ID token and the caller's email is looked up in a new `WebUserAllowlist` Azure Table → mapped Telegram chatId. The agent then runs inside an `AsyncLocalStorage` scope so every existing tool sees the right user's data via `getAgentChatId()` — **zero changes to tools or cores**.

Until the agent has its own write actions, the allowlisted email also needs a Telegram chatId mapping so we can serve that user's existing Telegram-side data (teams, leagues, live score, …). Once write actions land, the chatId mapping becomes optional and email alone becomes the identity.

## What's in

### Backend
- `src/agent/requestContext.js` — `AsyncLocalStorage` request scope.
- `src/agent/auth.js` — Google ID token verifier (`google-auth-library`) + `authenticateRequest` returning `ok` / `bypassed` / `unauthorized` / `forbidden`. Bypasses entirely when `GOOGLE_CLIENT_ID` is unset.
- `src/agent/identity.js` — `getAgentChatId()` now ALS-aware, falling back to `AGENT_HARDCODED_CHAT_ID` for local dev / cache bootstrap / test slot.
- `src/webUserAllowlistService.js` — new Azure Table CRUD for the email → chatId allowlist (Merge mode, same pattern as `userRegistryService`).
- `agentWebhook/index.js` — gates POSTs, returns 401 + JSON body on failure, wraps the runtime in `runWithRequestContext` on success.
- `tokenUsageMiddleware.js` — appends `email: <user>` to per-step usage logs so spikes are correlatable to a user.

### Telegram admin tooling (three new commands)
- `/allow_web_user` — two-step: email → chatId, writes the allowlist row.
- `/revoke_web_user` — single-step: email → deletes the row.
- `/list_web_users` — renders the allowlist joined against `UserRegistry` so admins see linked nickname/chatName.

### Frontend (`web/`)
- Added `@react-oauth/google`.
- New `AuthProvider` (sessionStorage-backed; closing the tab signs out), `LoginScreen`, `SignedInBadge`.
- `useAuthFetchInterceptor` watches every fetch to the runtime URL; a 401 sets a rejection reason + signs out so the login screen distinguishes 'this account is not allowed' from 'session expired'.
- `<CopilotKit headers={() => ({ Authorization: ... })}>` adds the Bearer token to every request.
- Chat history scoped by Google `sub` so shared browsers don't leak conversations across users.
- When `VITE_GOOGLE_CLIENT_ID` is unset at build time the entire auth gate is skipped — matches the backend bypass so `npm run dev` and PR-preview SWA builds keep working unchanged.

### Infra
- `infra/agent-func/apply-settings.sh` — adds `GOOGLE_CLIENT_ID` to the prod slot only; the test slot stays unset (bypass mode for PR previews).
- `.github/workflows/main_f1-fantazy-agent-web.yml` — bakes `VITE_GOOGLE_CLIENT_ID` from a GH secret into the prod SWA build.

### Docs
- `AGENTS.md` — rewrote 'Identity model' + added a 95-line 'Web auth' section covering the full pipeline, allowlist schema, admin commands, env vars, and the rollout sequence.

## Tests
- **+73 new tests · 941 total · all passing · 0 lint errors**.
- Coverage includes ALS isolation across concurrent requests, token verifier branches (happy / bad / missing / forbidden / storage outage), webhook integration (OPTIONS, OK, BYPASSED, UNAUTHORIZED, FORBIDDEN, runtime throw), every new registry entry, and the three new admin handlers.

## Backwards compatibility
**Nothing changes on first deploy.** When `GOOGLE_CLIENT_ID` is unset, the webhook bypasses auth and the existing hardcoded-chatId behaviour is preserved. Enable the gate by setting the env var on the prod slot after the OAuth client is provisioned.

## Rollout sequence (do not skip steps)
1. Merge this PR with `GOOGLE_CLIENT_ID` **unset** on the prod slot → no behaviour change, soak.
2. Provision the Google OAuth Web client; copy the client ID.
3. Set `VITE_GOOGLE_CLIENT_ID` in GitHub Actions secrets; redeploy the SWA via the prod workflow → users now see the login screen but the backend still bypasses (so any signed-in user can chat).
4. Set `GOOGLE_CLIENT_ID` on the prod slot of the agent Function App (via `apply-settings.sh` with the env var set) → auth gate is now live end-to-end.
5. Run `/allow_web_user` for yourself first (your Google email → your chatId), soak, then widen the allowlist.

See `AGENTS.md` → 'Web auth' for the full step-by-step.