### PR TITLE
feat(web-auth): protect the test slot — Google sign-in + admin-only filter

### DIFF
--- a/.github/workflows/pr_test_f1-fantazy-agent-web.yml
+++ b/.github/workflows/pr_test_f1-fantazy-agent-web.yml
@@ -67,20 +67,19 @@ jobs:
           VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
         run: npm run build
 
-      - name: Deploy to Azure Static Web Apps (staging environment)
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          action: 'upload'
-          app_location: 'web/dist'
-          api_location: ''
-          output_location: ''
-          skip_app_build: true
-          skip_api_build: true
-          # `deployment_environment: staging` forces the SWA action to
-          # publish to the fixed-name `staging` environment regardless
-          # of PR context. Without this input, the action defaults to a
-          # per-PR preview environment, which is exactly what we no
-          # longer want.
-          deployment_environment: 'staging'
+      - name: Deploy to Azure Static Web Apps (staging environment, via SWA CLI)
+        # We deliberately use the SWA CLI here instead of
+        # `Azure/static-web-apps-deploy@v1`. On `pull_request` events
+        # the action silently overrides the `deployment_environment`
+        # input and creates a per-PR-numbered preview environment —
+        # exactly the behavior this rewrite was supposed to eliminate.
+        # The SWA CLI honours `--env staging` regardless of trigger
+        # context, which is what we need so the test slot's
+        # GOOGLE_CLIENT_ID gate + CORS allowlist actually match the
+        # URL the user lands on. The CLI is the same tool we used to
+        # materialize the staging env in the first place.
+        run: |
+          npx -y @azure/static-web-apps-cli@latest deploy web/dist \
+            --env staging \
+            --deployment-token "${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}" \
+            --no-use-keychain

--- a/.github/workflows/pr_test_f1-fantazy-agent-web.yml
+++ b/.github/workflows/pr_test_f1-fantazy-agent-web.yml
@@ -1,32 +1,31 @@
 # PR preview deploy for the f1-fantazy-agent-web Static Web App.
-# Each PR gets a unique preview URL automatically (per-PR staging
-# environments). The preview frontend points at the agent's TEST slot
-# so backend changes in the same PR get exercised end-to-end.
 #
-# CORS strategy: SWA preview hostnames are predictable from the prod
-# hostname + PR number:
-#   `https://<SWA_HOSTNAME_PREFIX>-<PR>.<REGION>.<INFRA_ID>.azurestaticapps.net`
-# So this workflow adds the exact per-PR preview origin to the test
-# slot's CORS allowlist BEFORE the SWA deploy, and removes it on PR
-# close. That keeps the test slot's CORS tight (no `*` wildcard) while
-# letting per-PR previews actually talk to the test slot.
+# Every PR build is published to the SAME `staging` environment of the
+# SWA (https://calm-beach-055be4603-staging.westeurope.7.azurestaticapps.net).
+# We deliberately do NOT use per-PR preview environments any more —
+# Google's OAuth Web client requires every Authorized JavaScript origin
+# to be a fixed URL (no wildcards), so per-PR hostnames cannot be auth-
+# gated without manual GCP Console churn. Collapsing to one staging
+# environment keeps the test slot fully behind Google sign-in (and the
+# AGENT_REQUIRE_ADMIN=true filter — admins only on test).
 #
-# Caveat: an infra redeploy (deploy-infra-agent-func.yml) resets the
-# test slot CORS allowlist to the ARM template's baseline (just the SWA
-# prod origin). Open PRs lose their preview origin from the allowlist
-# until the next PR-workflow trigger re-adds it. Re-triggering a PR
-# workflow is a no-op push or a `gh run rerun` against this workflow.
+# Trade-off: only one PR can be visually tested at a time, since
+# subsequent pushes from any PR overwrite the staging deploy. For a
+# small dev team this is acceptable; communicate on the PR if you need
+# the staging slot.
 #
-# On PR close (merged or not), the staging environment is torn down
-# AND the cors origin is removed from the allowlist.
+# CORS: the test slot's allowlist is statically pinned to the single
+# staging URL (see infra/agent-func/apply-settings.sh and the
+# `testAllowedOrigins` parameter in infra/agent-func/azuredeploy.parameters.json).
+# No per-PR `az functionapp cors add/remove` plumbing is needed.
 
-name: Build and deploy web frontend to Azure Static Web App - f1-fantazy-agent-web (PR preview)
+name: Build and deploy web frontend to Azure Static Web App - f1-fantazy-agent-web (staging environment, PR validation)
 
 on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
     paths:
       - 'web/**'
       - '.github/workflows/pr_test_f1-fantazy-agent-web.yml'
@@ -34,62 +33,16 @@ on:
 env:
   NODE_VERSION: '22.x'
   AGENT_TEST_API_URL: 'https://f1-fantazy-agent-func-test.azurewebsites.net/api/agent/copilotkit'
-  # SWA preview hostname formula: `https://<PREFIX>-<PR_NUMBER>.<REGION>.<INFRA_ID>.azurestaticapps.net`
-  # The PREFIX and INFRA_ID are assigned by Azure when the SWA is created and
-  # are constants for the lifetime of the resource. If the SWA is recreated,
-  # update these three values + `prodAllowedOrigins` in infra/agent-func/azuredeploy.parameters.json.
-  SWA_HOSTNAME_PREFIX: 'calm-beach-055be4603'
-  SWA_REGION: 'westeurope'
-  SWA_INFRA_ID: '7'
-  AGENT_FUNC_NAME: 'f1-fantazy-agent-func'
-  AGENT_FUNC_RG: 'f1-fantazy-bot'
 
 jobs:
   build_and_deploy:
-    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Compute SWA preview origin
-        id: preview_origin
-        run: |
-          ORIGIN="https://${{ env.SWA_HOSTNAME_PREFIX }}-${{ github.event.pull_request.number }}.${{ env.SWA_REGION }}.${{ env.SWA_INFRA_ID }}.azurestaticapps.net"
-          echo "origin=$ORIGIN" >> "$GITHUB_OUTPUT"
-          echo "Preview origin for this PR: $ORIGIN"
-
-      - name: Azure login (to manage test slot CORS allowlist)
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZUREAPPSERVICE_CLIENTID_A26EA2FA0FAC46F99530B8845D983E85 }}
-          tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_8FDB1A8936224E90A898EAC192094784 }}
-          subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_00873174CBBD48D3871911006820901C }}
-
-      - name: Add preview origin to test-slot CORS allowlist (idempotent)
-        run: |
-          ORIGIN='${{ steps.preview_origin.outputs.origin }}'
-          EXISTING=$(az functionapp cors show \
-            --name ${{ env.AGENT_FUNC_NAME }} \
-            --slot test \
-            --resource-group ${{ env.AGENT_FUNC_RG }} \
-            --query "allowedOrigins[?@=='$ORIGIN'] | length(@)" \
-            -o tsv)
-          if [ "$EXISTING" = "0" ]; then
-            az functionapp cors add \
-              --name ${{ env.AGENT_FUNC_NAME }} \
-              --slot test \
-              --resource-group ${{ env.AGENT_FUNC_RG }} \
-              --allowed-origins "$ORIGIN" \
-              -o none
-            echo "Added $ORIGIN to test slot CORS allowlist."
-          else
-            echo "$ORIGIN already in test slot CORS allowlist — skipping."
-          fi
 
       - name: Setup Node ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v3
@@ -100,13 +53,21 @@ jobs:
         working-directory: web
         run: npm ci
 
-      - name: Build web (VITE_AGENT_API_URL → test slot)
+      - name: Build web (VITE_AGENT_API_URL → test slot, VITE_GOOGLE_CLIENT_ID baked in)
         working-directory: web
         env:
           VITE_AGENT_API_URL: ${{ env.AGENT_TEST_API_URL }}
+          # Must be set for the staging build, otherwise the frontend
+          # renders without a login screen and the backend's GOOGLE_CLIENT_ID
+          # gate returns 401 to every call — confusing UX. The secret is
+          # shared with the prod build workflow (main_f1-fantazy-agent-web.yml).
+          # The client ID itself is NOT a secret per AGENTS.md — the
+          # GH-Actions `secrets.` indirection is just to keep the value
+          # out of the workflow file.
+          VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
         run: npm run build
 
-      - name: Deploy preview to Azure Static Web Apps
+      - name: Deploy to Azure Static Web Apps (staging environment)
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
@@ -117,45 +78,9 @@ jobs:
           output_location: ''
           skip_app_build: true
           skip_api_build: true
-
-  close_preview:
-    if: github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      id-token: write
-    steps:
-      - name: Compute SWA preview origin
-        id: preview_origin
-        run: |
-          ORIGIN="https://${{ env.SWA_HOSTNAME_PREFIX }}-${{ github.event.pull_request.number }}.${{ env.SWA_REGION }}.${{ env.SWA_INFRA_ID }}.azurestaticapps.net"
-          echo "origin=$ORIGIN" >> "$GITHUB_OUTPUT"
-
-      - name: Azure login (to clean up test slot CORS allowlist)
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZUREAPPSERVICE_CLIENTID_A26EA2FA0FAC46F99530B8845D983E85 }}
-          tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_8FDB1A8936224E90A898EAC192094784 }}
-          subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_00873174CBBD48D3871911006820901C }}
-
-      - name: Remove preview origin from test-slot CORS allowlist (tolerate absent)
-        run: |
-          ORIGIN='${{ steps.preview_origin.outputs.origin }}'
-          # Tolerate not-present: the workflow may never have added it
-          # (e.g. PR was closed before first deploy) or an infra redeploy
-          # already cleared it. We do not want a failed cleanup to fail
-          # the close_preview job.
-          az functionapp cors remove \
-            --name ${{ env.AGENT_FUNC_NAME }} \
-            --slot test \
-            --resource-group ${{ env.AGENT_FUNC_RG }} \
-            --allowed-origins "$ORIGIN" \
-            -o none \
-            || echo "Removal failed (likely already absent) — continuing."
-
-      - name: Close PR preview environment
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
-          action: 'close'
+          # `deployment_environment: staging` forces the SWA action to
+          # publish to the fixed-name `staging` environment regardless
+          # of PR context. Without this input, the action defaults to a
+          # per-PR preview environment, which is exactly what we no
+          # longer want.
+          deployment_environment: 'staging'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1010,17 +1010,25 @@ documented at the top of `.github/workflows/pr_test_f1-fantazy-agent-web.yml`.
 
 **Test slot operational notes:**
 
-- The slot is typically `Stopped` to save consumption-plan invocations.
-  PR-workflow deploys upload the package via
-  `Azure/functions-action@v1` even when the slot is stopped (the
-  `WEBSITE_RUN_FROM_PACKAGE` setting updates; only the Sync Trigger
-  step fails cosmetically — see the `continue-on-error` comment in
-  `pr_test_f1-fantazy-agent-func.yml`). The code loads automatically
-  on the next `az functionapp start --slot test`.
+- The slot stays **Running** by default. Pre-auth it used to be
+  kept Stopped as a security workaround (anyone with the URL could
+  drive the agent as the owner); with Google sign-in +
+  `AGENT_REQUIRE_ADMIN=true` in place, that workaround is no longer
+  needed. The App Service Plan is Y1 Consumption — pay-per-execution
+  — so an idle Running slot costs effectively $0, and PR validation
+  becomes a single deploy → test loop with no manual `az functionapp
+  start` round-trip.
+- The PR workflow (`pr_test_f1-fantazy-agent-func.yml`) still
+  tolerates the slot being Stopped during deploy via
+  `continue-on-error: ${{ steps.state_check.outputs.state == 'Stopped' }}`
+  — kept as a safety net if someone stops it manually. The
+  `WEBSITE_RUN_FROM_PACKAGE` setting + the package upload succeed
+  even when stopped; only Sync Trigger fails cosmetically. The latest
+  code loads automatically on the next `az functionapp start --slot test`.
 - A stopped slot returns Azure's "Web App stopped" `HTTP 403` page
-  to all callers before reaching our code. This is strictly stronger
-  than the 401 the auth gate would return, and is the default-safe
-  state between PR validation runs.
+  to all callers before reaching our code — strictly stronger than
+  the 401 the auth gate would return. Either state is safe; Running
+  is just more ergonomic.
 
 **Rollout sequence (executed 2026-05-22; documented for the record):**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Both surfaces share the same business logic via **pure cores** in `src/cores/`. 
 - **Internationalization:** `src/i18n.js` and `src/translations.js` provide language support (English/Hebrew) used throughout handlers.
 - **AI Assist:** `src/prompts.js` defines system prompts. `/ask`-style natural language queries are handled by `src/commandsHandler/askHandler.js`, which leverages Azure OpenAI to map free-text requests into command sequences.
 - **Logic Cores:** `src/cores/` holds **pure** business-logic functions that take inputs and return structured JSON. They do not depend on `bot`, `t()`, or `sendMessage`. Each Telegram handler is being progressively refactored into `(pure core in src/cores/) + (thin Telegram adapter)`. The same core is consumed by the web-chat agent's tools — so a question like "best teams with VER but no ALO" runs through the same calculator as the `/best_teams` command. **Refactor rule:** existing handler tests must keep passing unchanged after the extraction; if they don't, fix the refactor, not the test. Cores extracted so far: `nextRacesCore`, `bestTeamsCore`, `userTeamsCore`, `followedTeamsCore`, `leaderboardCore`, `bestTeamScenariosCore`, `nextRaceInfoCore`, `raceWeatherCore`, `deadlineCore`, `currentTeamCore`, `liveScoreCore`. Cores that need side effects (e.g. weather fetch logging) accept optional `onFetch`/`onError` callbacks — the Telegram adapter wires them to bot-side helpers; the agent path omits them. Pure scoring helpers shared between a handler and its core live in `src/utils/` (e.g. `src/utils/liveScoreCalc.js` for `mapLockedTeamForScoring` / `calculateLiveScoreBreakdown` / `deriveLiveScoreOptions`) so the core never depends on the adapter.
-- **Agent (Web Chat):** `src/agent/`, `agentWebhook/`, and `web/` together implement a second user-facing surface. **Identity is per-request**, propagated through `AsyncLocalStorage` from the agent webhook into `getAgentChatId()`. The webhook verifies the caller's Google ID token, looks the email up in the `WebUserAllowlist` Azure Table to resolve a Telegram chatId, then runs the entire CopilotKit invocation inside that ALS scope. When `GOOGLE_CLIENT_ID` is unset (local dev + the test slot of the Function App) the auth gate is bypassed and `AGENT_HARDCODED_CHAT_ID` is used instead. See [Web auth](#web-auth) for the full pipeline and the three new Telegram admin commands (`/allow_web_user`, `/revoke_web_user`, `/list_web_users`) that manage the allowlist.
+- **Agent (Web Chat):** `src/agent/`, `agentWebhook/`, and `web/` together implement a second user-facing surface. **Identity is per-request**, propagated through `AsyncLocalStorage` from the agent webhook into `getAgentChatId()`. The webhook verifies the caller's Google ID token, looks the email up in the `WebUserAllowlist` Azure Table to resolve a Telegram chatId, then runs the entire CopilotKit invocation inside that ALS scope. When `GOOGLE_CLIENT_ID` is unset (local dev only — both production AND test slots in Azure set it) the auth gate is bypassed and `AGENT_HARDCODED_CHAT_ID` is used instead. The test slot additionally enforces an **admin-only** filter via `AGENT_REQUIRE_ADMIN=true` — see [Web auth → Test-slot admin-only gate](#test-slot-admin-only-gate). See [Web auth](#web-auth) for the full pipeline and the three new Telegram admin commands (`/allow_web_user`, `/revoke_web_user`, `/list_web_users`) that manage the allowlist.
 
 ---
 
@@ -103,7 +103,7 @@ Start the web-chat agent locally with `npm run dev` (boots both the agent dev se
 **Deployment targets:**
 - The Telegram bot is deployed as the existing Azure Function App `f1-fantazy-bot-func` via the `telegramWebhook/` function. Push to `main` → `production` slot; PR → `test` slot.
 - The web-chat agent is deployed to a **separate Azure Function App** (`f1-fantazy-agent-func`) via the `agentWebhook/` function — keeping it independent for deploy, scale, and failure-isolation reasons (an agent rollout cannot break the Telegram bot). Push to `main` → `production` slot; PR → `test` slot. The agent's deploy package EXCLUDES `telegramWebhook/` and other non-agent paths (see `.funcignore.agent` and the `Strip non-agent paths from the package` step in `.github/workflows/main_f1-fantazy-agent-func.yml`) so the isolation goal is enforced mechanically.
-- The frontend (`web/`) is deployed to an Azure Static Web App (`f1-fantazy-agent-web`, Free SKU) and served from the prod custom domain `https://f1.kilzid.com` (CNAME → the SWA's auto-generated `calm-beach-055be4603.7.azurestaticapps.net`). The custom domain is provisioned via the SWA ARM template's `customDomains` parameter. Push to `main` → `production` environment; PR → per-PR preview environment at `https://<prefix>-<PR>.<region>.<n>.azurestaticapps.net` (the SWA built-in feature, no separate resource per PR; previews use the auto hostname, not the custom domain). The preview environment's `VITE_AGENT_API_URL` points at the agent Function App's `test` slot so PR builds exercise the end-to-end stack against the slot version of the backend.
+- The frontend (`web/`) is deployed to an Azure Static Web App (`f1-fantazy-agent-web`, Free SKU) and served from the prod custom domain `https://f1.kilzid.com` (CNAME → the SWA's auto-generated `calm-beach-055be4603.7.azurestaticapps.net`). The custom domain is provisioned via the SWA ARM template's `customDomains` parameter. Push to `main` → `production` environment. PRs deploy to a **single shared `staging` environment** at `https://calm-beach-055be4603-staging.westeurope.7.azurestaticapps.net` (NOT per-PR ephemerals — Google OAuth doesn't allow wildcard origins, so we collapsed PR previews into one fixed origin so the test slot can be fully auth-gated; see [Web auth → Test-slot admin-only gate](#test-slot-admin-only-gate)). Trade-off: only one PR can be visually tested at a time. The staging environment's `VITE_AGENT_API_URL` points at the agent Function App's `test` slot so PR builds exercise the end-to-end stack against the slot version of the backend.
 - All Azure resources live in resource group `f1-fantazy-bot` in subscription `5cfc4033-…` (`westeurope`). The agent Function App reuses the existing App Service Plan `ASP-f1fantazybot-b551` (Y1 Consumption, supports slots), storage account `f1fantazybot9eca`, Key Vault `f1-fantasy-kv`, and Application Insights `f1-fantazy-bot-func`. New KV secret: `agent-hardcoded-chat-id`.
 - ARM templates: `infra/agent-func/azuredeploy.json` + `infra/agent-web/azuredeploy.json` (parameter files alongside). Run `npm run deploy:agent-func` / `npm run deploy:agent-web` to apply locally; the `deploy-infra-agent-func.yml` / `deploy-infra-agent-web.yml` workflows do the same on push to `main` when those paths change.
 - CORS is handled in `agentWebhook/index.js` (via `src/agent/corsAllowList.js`), not by Azure's `siteConfig.cors` layer, because SWA preview environments need regex matching that the Azure layer doesn't support. Env vars: `AGENT_CORS_ALLOWED_ORIGINS` (comma-separated exact origins) + `AGENT_CORS_PREVIEW_ORIGIN_PATTERN` (regex). When both are unset (local dev), the matcher returns `*` for back-compat. See `readme.md` → "Deploying the agent" for the one-time bootstrap checklist.
@@ -840,9 +840,10 @@ wrapToolExecute(name, fn) catches → generates 8-char errorId (slice of randomU
 | `AZURE_OPENAI_ENDPOINT` | Agent | Azure OpenAI host (works for both `*.openai.azure.com` and `*.services.ai.azure.com`). |
 | `AZURE_OPENAI_API_KEY` | Agent | Azure OpenAI auth. |
 | `AZURE_OPEN_AI_MODEL` | Agent + Telegram `/ask` | Deployment name (used by `azure.chat(deployment)`). |
-| `AGENT_HARDCODED_CHAT_ID` | Agent | Fallback identity used when no per-request context is active (local dev + test slot + cache bootstrap). The LLM never sees it. Defaults to `KILZI_CHAT_ID` in `scripts/dev-agent-server.js` if absent. |
-| `GOOGLE_CLIENT_ID` | Agent (optional) | OAuth 2.0 Web client ID. NOT a secret — safe in app settings. When set, the agent webhook enforces Google sign-in + allowlist lookup on every POST. When unset (local dev, test slot), auth is bypassed and `AGENT_HARDCODED_CHAT_ID` is used instead. |
-| `VITE_GOOGLE_CLIENT_ID` | SWA build env (optional) | Same value as `GOOGLE_CLIENT_ID`, baked into the bundle by the production SWA build (NOT PR previews). Unset = login screen is skipped (matches the backend bypass). |
+| `AGENT_HARDCODED_CHAT_ID` | Agent | Fallback identity used when no per-request context is active (local dev + cache bootstrap). On Azure-deployed slots both prod + test set `GOOGLE_CLIENT_ID`, so the hardcoded path is unreachable from user traffic — it survives as a local-dev fallback only. The LLM never sees it. Defaults to `KILZI_CHAT_ID` in `scripts/dev-agent-server.js` if absent. |
+| `GOOGLE_CLIENT_ID` | Agent | OAuth 2.0 Web client ID. NOT a secret — safe in app settings. Set on BOTH Azure slots (production + test). When the agent webhook sees a valid bearer it enforces Google sign-in + allowlist lookup on every POST. When unset (local dev only), auth is bypassed and `AGENT_HARDCODED_CHAT_ID` is used instead. |
+| `AGENT_REQUIRE_ADMIN` | Agent | `"true"` on the test slot only — adds an admin-only filter after the allowlist check (admins = `KILZI_CHAT_ID` / `DORSE_CHAT_ID` from `src/constants.js`). `"false"` / unset on prod. See [Web auth → Test-slot admin-only gate](#test-slot-admin-only-gate). |
+| `VITE_GOOGLE_CLIENT_ID` | SWA build env | Same client ID, baked into the bundle by both the prod SWA workflow AND the PR/staging workflow. Unset at build time = chat renders without auth gate (local dev only). |
 | `TELEGRAM_BOT_TOKEN` | Agent (optional) | If set, the agent's notifier bot sends token-usage + tool-error logs to the same Telegram channels the main bot uses. If unset, logs stay on stdout — local dev without Telegram still works. |
 | `LOG_CHANNEL_ID` | Telegram bot | Token-usage logs land here from BOTH processes when their notifier bots have a Telegram token. Set in `src/constants.js`. |
 | `ERRORS_CHANNEL_ID` | Telegram bot | Tool errors with `errorId` land here. Set in `src/constants.js`. |
@@ -863,10 +864,11 @@ The agent acts as a **per-request chatId** propagated through Node's
    via `getAgentChatId()` — the LLM never sees `chatId` or `email` in
    its `args`.
 2. **`AGENT_HARDCODED_CHAT_ID` env var** — used by local dev
-   (`scripts/dev-agent-server.js`), the test slot of the agent
-   Function App (auth gate intentionally bypassed for PR validation),
-   and background paths that run outside an HTTP request (e.g.
-   `cacheBootstrap`).
+   (`scripts/dev-agent-server.js`) and by background paths that run
+   outside an HTTP request (e.g. `cacheBootstrap`). Both Azure-deployed
+   slots (production + test) now run the Google auth gate, so the
+   hardcoded path is no longer reachable from real user traffic on
+   Azure — it survives as a local-dev fallback only.
 3. **Throw** — neither available; tools cannot proceed without an
    identity.
 
@@ -899,7 +901,7 @@ agentWebhook/index.js
   │    └── looks up the lowercased email in `WebUserAllowlist`
   │  status → HTTP:
   │    OK         → runWithRequestContext({ chatId, email, sub }, …)
-  │    BYPASSED   → falls through (GOOGLE_CLIENT_ID unset)
+  │    BYPASSED   → falls through (GOOGLE_CLIENT_ID unset; local dev only)
   │    UNAUTHORIZED → 401 + JSON { error, reason }
   │    FORBIDDEN  → 401 + JSON { error, reason, email }
   ▼
@@ -908,14 +910,14 @@ CopilotKit → BuiltInAgent → tool execute()
 getAgentChatId() reads ALS context → the right user's data
 ```
 
-**Backend bypass:** when `GOOGLE_CLIENT_ID` is unset on the Function
-App, `authenticateRequest` returns `BYPASSED` and the webhook falls
-through to the legacy hardcoded-chatId path. Local dev, the test
-slot, and the initial production deploy all start in bypassed mode;
-enabling the gate is a one-line app-setting change. The frontend
-mirrors the bypass: when `VITE_GOOGLE_CLIENT_ID` is empty at build
-time, the login screen is skipped entirely (no Google client to
-authenticate against).
+**Backend bypass (local-dev only):** when `GOOGLE_CLIENT_ID` is unset
+on the Function App, `authenticateRequest` returns `BYPASSED` and the
+webhook falls through to the legacy hardcoded-chatId path. In Azure,
+both slots now set `GOOGLE_CLIENT_ID` (production + test), so
+`BYPASSED` is only reachable from local dev (`scripts/dev-agent-server.js`,
+where the env var is intentionally absent). The frontend mirrors the
+bypass: when `VITE_GOOGLE_CLIENT_ID` is empty at build time, the
+login screen is skipped entirely (local dev only).
 
 **Allowlist storage (`src/webUserAllowlistService.js`):** Azure Table
 `WebUserAllowlist`, single partition `'WebUser'`. RowKey is the
@@ -954,29 +956,97 @@ allowlist via the existing Pending Reply Manager:
 
 | Var                     | Where               | Notes                                                                                                                                       |
 | ----------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `GOOGLE_CLIENT_ID`      | Agent Function App  | OAuth 2.0 Web client ID. NOT a secret — safe in app settings. Unset = bypass mode.                                                          |
-| `VITE_GOOGLE_CLIENT_ID` | SWA build env       | Same value, baked into the bundle at build time (only on prod workflow, NOT PR previews). Unset at build time = chat renders without auth gate. |
+| `GOOGLE_CLIENT_ID`      | Agent Function App  | OAuth 2.0 Web client ID. NOT a secret — safe in app settings. Set on BOTH slots in Azure (production + test). Unset = bypass mode (local dev only). |
+| `AGENT_REQUIRE_ADMIN`   | Agent Function App  | `"true"` on the test slot (admin-only filter — see [Test-slot admin-only gate](#test-slot-admin-only-gate)). `"false"` / unset on production. |
+| `VITE_GOOGLE_CLIENT_ID` | SWA build env       | Same client ID, baked into the bundle at build time by both the prod workflow (`main_f1-fantazy-agent-web.yml`) AND the PR/staging workflow (`pr_test_f1-fantazy-agent-web.yml`). Unset at build time = chat renders without auth gate (local dev only). |
 
 **Google Cloud Console setup (one-time):** create an OAuth 2.0 Web
 client. Authorized JavaScript origins must include the production
-SWA host (`https://f1.kilzid.com` + the SWA default hostname).
-Wildcards aren't supported by Google for authorized origins, so
-PR-preview hostnames intentionally don't get auth-gated; instead they
-use the test slot which also has `GOOGLE_CLIENT_ID` unset.
+SWA host (`https://f1.kilzid.com` + the SWA default hostname
+`https://calm-beach-055be4603.7.azurestaticapps.net`) AND the
+fixed staging-environment hostname
+`https://calm-beach-055be4603-staging.westeurope.7.azurestaticapps.net`.
+The latter is the single shared PR-preview origin — see [Test-slot
+admin-only gate](#test-slot-admin-only-gate) for why per-PR
+ephemeral origins were collapsed into one.
 
-**Rollout sequence (do NOT skip steps):**
+#### Test-slot admin-only gate
 
-1. Backend ships with `GOOGLE_CLIENT_ID` unset on the prod slot —
-   `authenticateRequest` returns `BYPASSED`, nothing changes.
-2. Provision the Google OAuth Web client; copy the client ID.
-3. Set `VITE_GOOGLE_CLIENT_ID` in GitHub Actions secrets; redeploy
-   the SWA via the prod workflow. Users now see the login screen but
-   the backend still bypasses (so any signed-in user can chat).
-4. Set `GOOGLE_CLIENT_ID` on the prod slot of the agent Function App
-   (via `infra/agent-func/apply-settings.sh` with the env var set).
-   Auth gate is now live end-to-end.
-5. Allowlist yourself first via `/allow_web_user` (your Google email
-   → your Telegram chatId), soak, then widen the allowlist.
+The test slot of the agent Function App is fully Google-gated AND
+additionally locked to admin chatIds (`KILZI_CHAT_ID`,
+`DORSE_CHAT_ID` — same set `isAdminMessage` uses). This blocks
+drive-by abuse and cost-exfiltration on the publicly-reachable
+preview URL.
+
+**How it works:**
+
+- `AGENT_REQUIRE_ADMIN=true` is set on the test slot (via
+  `infra/agent-func/apply-settings.sh`). On prod it's `"false"`.
+- `src/agent/auth.js` evaluates `process.env.AGENT_REQUIRE_ADMIN === 'true'`
+  AFTER the standard allowlist + valid-chatId checks succeed. Only
+  the literal string `"true"` enables the gate — defensive against
+  typos in app settings.
+- Non-admin allowlisted users on the test slot resolve to
+  `{ status: FORBIDDEN, reason: 'not_admin', email }` → `401` to the
+  client. The frontend's existing rejection-screen path renders this
+  the same way as `email_not_allowlisted`.
+- Admin definition lives in `src/constants.js`
+  (`KILZI_CHAT_ID = 454873194`, `DORSE_CHAT_ID = 673447790`). The
+  env var doesn't carry a chatId list — keeping one source of truth
+  for "admin" between the Telegram bot and the agent.
+- Gate ordering is intentional: the allowlist + chatId validity
+  checks run FIRST, so a non-allowlisted admin still gets the
+  generic `email_not_allowlisted` response (no info leak about admin
+  identity).
+
+**Why a single staging SWA environment instead of per-PR
+ephemerals?** Google's OAuth 2.0 Web client requires every
+Authorized JavaScript origin to be a fixed URL — wildcards are not
+supported. Maintaining a list of per-PR hostnames in GCP Console
+doesn't scale, so all PR builds publish to the same fixed `staging`
+environment of the SWA. The trade-off — only one PR can be visually
+tested at a time — is acceptable for a small dev team and is
+documented at the top of `.github/workflows/pr_test_f1-fantazy-agent-web.yml`.
+
+**Test slot operational notes:**
+
+- The slot is typically `Stopped` to save consumption-plan invocations.
+  PR-workflow deploys upload the package via
+  `Azure/functions-action@v1` even when the slot is stopped (the
+  `WEBSITE_RUN_FROM_PACKAGE` setting updates; only the Sync Trigger
+  step fails cosmetically — see the `continue-on-error` comment in
+  `pr_test_f1-fantazy-agent-func.yml`). The code loads automatically
+  on the next `az functionapp start --slot test`.
+- A stopped slot returns Azure's "Web App stopped" `HTTP 403` page
+  to all callers before reaching our code. This is strictly stronger
+  than the 401 the auth gate would return, and is the default-safe
+  state between PR validation runs.
+
+**Rollout sequence (executed 2026-05-22; documented for the record):**
+
+1. Backend code: add `AGENT_REQUIRE_ADMIN` env-var support to
+   `src/agent/auth.js` + tests in `src/agent/auth.test.js`.
+2. Frontend: no source changes needed — existing Google sign-in
+   flow works against the staging environment because the OAuth
+   client ID and the `WebUserAllowlist` Azure Table are shared with
+   prod.
+3. Provision the SWA staging environment (one-off SWA CLI deploy
+   of a placeholder to materialize the `staging` env) — yields
+   `https://calm-beach-055be4603-staging.westeurope.7.azurestaticapps.net`.
+4. Add the staging origin to the prod OAuth client's Authorized
+   JavaScript origins in Google Cloud Console.
+5. Update `infra/agent-func/apply-settings.sh` to set
+   `GOOGLE_CLIENT_ID` on the test slot (same value as prod) plus
+   `AGENT_REQUIRE_ADMIN=true`. Update `azuredeploy.parameters.json`
+   so `testAllowedOrigins` is the single staging URL.
+6. Rewrite `pr_test_f1-fantazy-agent-web.yml` to deploy to the
+   fixed `staging` environment (replacing per-PR previews). Delete
+   the dynamic `az functionapp cors add/remove` plumbing.
+7. Run `npm run deploy:agent-func` with `GOOGLE_CLIENT_ID` set to
+   apply both ARM + app-settings to Azure.
+8. Push, open a PR, let the PR workflows deploy the new agent code
+   + staging frontend. Manually start the test slot for end-to-end
+   verification, then stop it again.
 
 **Token observability:** the Phase 6.1 token-usage middleware reads
 `getRequestContext()?.email` and appends `, email: <user>` to every

--- a/infra/agent-func/apply-settings.sh
+++ b/infra/agent-func/apply-settings.sh
@@ -25,10 +25,14 @@
 #   AZURE_OPEN_AI_MODEL    (default: gpt-5.4)
 #   PROD_ALLOWED_ORIGINS   (default: https://calm-beach-055be4603.7.azurestaticapps.net)
 #   PROD_PREVIEW_PATTERN   (default: empty)
-#   TEST_ALLOWED_ORIGINS   (default: *)
+#   TEST_ALLOWED_ORIGINS   (default: https://calm-beach-055be4603-staging.westeurope.7.azurestaticapps.net)
 #   TEST_PREVIEW_PATTERN   (default: empty)
-#   GOOGLE_CLIENT_ID       (default: empty — auth gate disabled.
-#                           Set to enable Google sign-in on prod.)
+#   GOOGLE_CLIENT_ID       (default: empty — auth gate DISABLED on both
+#                           slots. Set to the OAuth 2.0 Web client ID to
+#                           enable Google sign-in on BOTH the production
+#                           AND test slots. The test slot additionally
+#                           runs an admin-only filter — see
+#                           AGENT_REQUIRE_ADMIN below.)
 
 set -euo pipefail
 
@@ -42,13 +46,18 @@ MODEL="${AZURE_OPEN_AI_MODEL:-gpt-5.4}"
 STORAGE_CONTAINER="${AZURE_STORAGE_CONTAINER_NAME:-f1-fantasy-scraper-json}"
 PROD_ORIGINS="${PROD_ALLOWED_ORIGINS:-https://calm-beach-055be4603.7.azurestaticapps.net}"
 PROD_PATTERN="${PROD_PREVIEW_PATTERN:-}"
-TEST_ORIGINS="${TEST_ALLOWED_ORIGINS:-*}"
+# The test slot frontend lives at a single fixed SWA staging hostname
+# now (no more per-PR previews) — see `pr_test_f1-fantazy-agent-web.yml`.
+# This tightens CORS without sacrificing PR-preview workflow.
+TEST_ORIGINS="${TEST_ALLOWED_ORIGINS:-https://calm-beach-055be4603-staging.westeurope.7.azurestaticapps.net}"
 TEST_PATTERN="${TEST_PREVIEW_PATTERN:-}"
-# Empty string ⇒ Google auth gate is BYPASSED (the webhook falls back to
-# AGENT_HARDCODED_CHAT_ID). Set to the OAuth 2.0 Web client ID to enable
-# the gate on the production slot. The test slot intentionally stays
-# unset so PR-preview SWA builds don't require Google credentials.
+# When set, the Google auth gate runs on BOTH slots. The test slot
+# additionally requires AGENT_REQUIRE_ADMIN=true (see below) so only
+# admin chatIds (KILZI/DORSE) can reach the agent on PR previews. When
+# empty, both slots BYPASS auth and fall back to AGENT_HARDCODED_CHAT_ID
+# — kept ONLY for local-dev parity; do not ship empty to Azure.
 PROD_GOOGLE_CLIENT_ID="${GOOGLE_CLIENT_ID:-}"
+TEST_GOOGLE_CLIENT_ID="${GOOGLE_CLIENT_ID:-}"
 
 KV_BASE="https://${KV_NAME}.vault.azure.net/secrets"
 
@@ -72,6 +81,7 @@ apply_to_slot() {
   local cors_origins="$2"
   local cors_pattern="$3"
   local google_client_id="$4"
+  local require_admin="$5"
   local slot_args=()
 
   if [[ "$slot_label" != "production" ]]; then
@@ -101,14 +111,20 @@ apply_to_slot() {
       "AGENT_CORS_ALLOWED_ORIGINS=${cors_origins}" \
       "AGENT_CORS_PREVIEW_ORIGIN_PATTERN=${cors_pattern}" \
       "GOOGLE_CLIENT_ID=${google_client_id}" \
+      "AGENT_REQUIRE_ADMIN=${require_admin}" \
       "AzureWebJobsStorage=${STORAGE_CS}" \
       "APPLICATIONINSIGHTS_CONNECTION_STRING=${APPINSIGHTS_CS}" \
     --output none --only-show-errors
 }
 
-apply_to_slot "production" "$PROD_ORIGINS" "$PROD_PATTERN" "$PROD_GOOGLE_CLIENT_ID"
-# Test slot deliberately leaves GOOGLE_CLIENT_ID empty — auth gate
-# bypassed so PR previews continue to use AGENT_HARDCODED_CHAT_ID.
-apply_to_slot "test"       "$TEST_ORIGINS" "$TEST_PATTERN" ""
+# Production: full Google sign-in + allowlist; everyone on the
+# WebUserAllowlist can chat as themselves.
+apply_to_slot "production" "$PROD_ORIGINS" "$PROD_PATTERN" "$PROD_GOOGLE_CLIENT_ID" "false"
+# Test slot: same Google client + same allowlist, BUT an additional
+# admin-only filter (AGENT_REQUIRE_ADMIN=true) — the test slot is
+# locked down to admin chatIds (KILZI/DORSE) per
+# src/agent/auth.js#isAdminChatId. Non-admin allowlisted users still
+# work on prod; the test slot returns FORBIDDEN reason=not_admin.
+apply_to_slot "test"       "$TEST_ORIGINS" "$TEST_PATTERN" "$TEST_GOOGLE_CLIENT_ID" "true"
 
 echo "Done. WEBSITE_RUN_FROM_PACKAGE and other externally-managed settings are preserved."

--- a/infra/agent-func/azuredeploy.json
+++ b/infra/agent-func/azuredeploy.json
@@ -110,7 +110,7 @@
       "type": "string",
       "defaultValue": "*",
       "metadata": {
-        "description": "Comma-separated EXACT origins allowed by CORS on the test slot. Same shape as prodAllowedOrigins. Default is `*` because SWA preview environments have unpredictable per-PR hostnames that Azure's CORS layer cannot regex-match; restricting the test slot to a tight allowlist would mean updating it per PR. `*` is acceptable on test since the slot is for short-lived PR validation."
+        "description": "Comma-separated EXACT origins allowed by CORS on the test slot. Same shape as prodAllowedOrigins. After the test slot was locked behind Google auth + admin-only filter (see GOOGLE_CLIENT_ID + AGENT_REQUIRE_ADMIN in apply-settings.sh), PR previews deploy to a single fixed SWA staging environment instead of per-PR ephemerals. The parameter file pins this to that one origin so the platform CORS layer matches exactly."
       }
     },
     "testPreviewOriginPattern": {

--- a/infra/agent-func/azuredeploy.parameters.json
+++ b/infra/agent-func/azuredeploy.parameters.json
@@ -36,7 +36,7 @@
       "value": ""
     },
     "testAllowedOrigins": {
-      "value": "https://f1.kilzid.com,https://calm-beach-055be4603.7.azurestaticapps.net"
+      "value": "https://calm-beach-055be4603-staging.westeurope.7.azurestaticapps.net"
     },
     "testPreviewOriginPattern": {
       "value": ""

--- a/src/agent/auth.js
+++ b/src/agent/auth.js
@@ -19,8 +19,20 @@
 // the webhook turns into a clean 401 + JSON body.
 //
 // Bypass mode: when `GOOGLE_CLIENT_ID` is unset/empty, auth is
-// disabled. This is the local-dev path (and the test slot of the
-// Function App where `AGENT_HARDCODED_CHAT_ID` does the work).
+// disabled. This is the local-dev path only — every Azure-deployed
+// slot (production AND test) sets GOOGLE_CLIENT_ID and runs the gate.
+//
+// Admin-only mode: when `AGENT_REQUIRE_ADMIN === 'true'`, an additional
+// post-allowlist check enforces that the resolved chatId is one of the
+// admin chatIds (KILZI / DORSE — same source `isAdminMessage` uses).
+// Non-admins resolve to `FORBIDDEN` with reason `not_admin`. This is
+// the gate that locks the PR-preview / test-slot agent down to the two
+// repo owners while keeping production open to the wider
+// WebUserAllowlist. The env var is intentionally not a CHAT_ID list:
+// the source of truth for "admin" stays in `src/constants.js` so the
+// Telegram bot and the agent stay aligned.
+
+const { KILZI_CHAT_ID, DORSE_CHAT_ID } = require('../constants');
 
 const STATUS = {
   OK: 'ok',
@@ -33,6 +45,12 @@ const VALID_ISSUERS = new Set([
   'https://accounts.google.com',
   'accounts.google.com',
 ]);
+
+const ADMIN_CHAT_IDS = new Set([KILZI_CHAT_ID, DORSE_CHAT_ID]);
+
+function isAdminChatId(chatId) {
+  return ADMIN_CHAT_IDS.has(chatId);
+}
 
 let cachedOAuth2Client = null;
 
@@ -125,23 +143,27 @@ async function verifyGoogleIdToken(token, audience) {
  * Returns one of:
  *   { status: 'bypassed' } — auth disabled because GOOGLE_CLIENT_ID is
  *     unset; webhook should fall through to the legacy hardcoded chatId
- *     path. Used by local dev and PR-preview slots.
- *   { status: 'ok', email, chatId, name?, sub? } — token verified and
- *     email is in the allowlist; webhook should run with this chatId
- *     bound to the request context.
+ *     path. Used by local dev only (no Azure-deployed slot is bypassed
+ *     anymore — both production and test set GOOGLE_CLIENT_ID).
+ *   { status: 'ok', email, chatId, name?, sub? } — token verified,
+ *     email is in the allowlist, AND (if `AGENT_REQUIRE_ADMIN === 'true'`)
+ *     the resolved chatId is one of the admin chatIds. Webhook should
+ *     run with this chatId bound to the request context.
  *   { status: 'unauthorized', reason } — missing/malformed/invalid
  *     bearer token. Map to 401.
  *   { status: 'forbidden', reason, email? } — token is valid but the
- *     email is not in the allowlist (or has no chatId mapped). Map to
- *     401 too — we deliberately do NOT distinguish "you signed in OK
- *     but you're not authorized" from "your token is bad" on the wire
- *     to avoid leaking allowlist membership; only the user-facing
- *     `reason` differs.
+ *     email is not in the allowlist, the allowlist row has no chatId,
+ *     OR (admin-only mode) the chatId is not an admin. Map to 401 too —
+ *     we deliberately do NOT distinguish "you signed in OK but you're
+ *     not authorized" from "your token is bad" on the wire to avoid
+ *     leaking allowlist membership; only the user-facing `reason`
+ *     differs.
  *
  * @param {Object} req - Azure Functions request-like { headers, ... }.
  * @param {Object} options
  * @param {() => Promise<{email: string, chatId?: string}|null>} options.lookupAllowedUser - Async lookup by email.
  * @param {string|undefined} [options.clientId] - Override env GOOGLE_CLIENT_ID (used by tests).
+ * @param {boolean|undefined} [options.requireAdmin] - Override env AGENT_REQUIRE_ADMIN (used by tests). When true, non-admin chatIds resolve to FORBIDDEN with reason `not_admin`.
  * @param {(token: string, audience: string) => Promise<{email: string, sub?: string, name?: string}>} [options.verifyToken] - Inject the verifier for tests.
  * @returns {Promise<Object>}
  */
@@ -154,6 +176,11 @@ async function authenticateRequest(req, options) {
   if (!clientId) {
     return { status: STATUS.BYPASSED };
   }
+
+  const requireAdmin =
+    options && options.requireAdmin !== undefined
+      ? Boolean(options.requireAdmin)
+      : process.env.AGENT_REQUIRE_ADMIN === 'true';
 
   const token = extractBearerToken(req);
   if (!token) {
@@ -214,6 +241,19 @@ async function authenticateRequest(req, options) {
     };
   }
 
+  // Admin-only gate (test slot / PR previews). Runs LAST so the
+  // checks above (allowlist membership, valid chat-id mapping) still
+  // run against every signed-in caller — admins included. That keeps
+  // the failure mode of "I'm an admin but my allowlist row is bad"
+  // visible and debuggable.
+  if (requireAdmin && !isAdminChatId(chatIdNum)) {
+    return {
+      status: STATUS.FORBIDDEN,
+      reason: 'not_admin',
+      email: claims.email,
+    };
+  }
+
   return {
     status: STATUS.OK,
     email: claims.email,
@@ -228,5 +268,6 @@ module.exports = {
   extractBearerToken,
   verifyGoogleIdToken,
   authenticateRequest,
+  isAdminChatId,
   resetOAuth2ClientForTests,
 };

--- a/src/agent/auth.test.js
+++ b/src/agent/auth.test.js
@@ -16,8 +16,10 @@ const {
   extractBearerToken,
   verifyGoogleIdToken,
   authenticateRequest,
+  isAdminChatId,
   resetOAuth2ClientForTests,
 } = require('./auth');
+const { KILZI_CHAT_ID, DORSE_CHAT_ID } = require('../constants');
 
 const ORIGINAL_ENV = process.env;
 
@@ -267,5 +269,227 @@ describe('authenticateRequest', () => {
           .mockResolvedValueOnce({ email: 'foo@example.com', sub: '1' }),
       }),
     ).rejects.toThrow(/lookupAllowedUser/);
+  });
+});
+
+describe('isAdminChatId', () => {
+  test('returns true for KILZI_CHAT_ID', () => {
+    expect(isAdminChatId(KILZI_CHAT_ID)).toBe(true);
+  });
+
+  test('returns true for DORSE_CHAT_ID', () => {
+    expect(isAdminChatId(DORSE_CHAT_ID)).toBe(true);
+  });
+
+  test('returns false for any other chatId', () => {
+    expect(isAdminChatId(123456)).toBe(false);
+    expect(isAdminChatId(0)).toBe(false);
+    expect(isAdminChatId(null)).toBe(false);
+    expect(isAdminChatId(undefined)).toBe(false);
+    // A non-admin chatId from src/constants.js — guards against
+    // someone accidentally promoting everyone in the constants file.
+    expect(isAdminChatId(740312192 /* YEHONATAN_CHAT_ID */)).toBe(false);
+  });
+
+  test('treats stringified admin chatId as non-admin (we only check numeric)', () => {
+    // authenticateRequest parses the allowlist chatId to a Number
+    // before calling this helper, so the helper itself only deals
+    // with numbers. Strings should NOT match — this catches a future
+    // refactor that forgets the parseInt step.
+    expect(isAdminChatId(String(KILZI_CHAT_ID))).toBe(false);
+  });
+});
+
+describe('authenticateRequest — admin-only gate (AGENT_REQUIRE_ADMIN)', () => {
+  function reqWithToken(token) {
+    return { headers: { authorization: `Bearer ${token}` } };
+  }
+
+  // Each test sets clientId via options to keep the env minimal and
+  // explicit. We toggle the admin flag via options too so we don't
+  // rely on shared process.env state across tests.
+
+  test('admin chatId passes when requireAdmin=true', async () => {
+    const result = await authenticateRequest(reqWithToken('good'), {
+      clientId: 'client-id',
+      requireAdmin: true,
+      verifyToken: jest.fn().mockResolvedValueOnce({
+        email: 'kilzi@example.com',
+        sub: '1',
+        name: 'Kilzi',
+      }),
+      lookupAllowedUser: jest.fn().mockResolvedValueOnce({
+        email: 'kilzi@example.com',
+        chatId: String(KILZI_CHAT_ID),
+      }),
+    });
+
+    expect(result).toEqual({
+      status: STATUS.OK,
+      email: 'kilzi@example.com',
+      chatId: KILZI_CHAT_ID,
+      name: 'Kilzi',
+      sub: '1',
+    });
+  });
+
+  test('DORSE chatId passes when requireAdmin=true (second admin entry)', async () => {
+    const result = await authenticateRequest(reqWithToken('good'), {
+      clientId: 'client-id',
+      requireAdmin: true,
+      verifyToken: jest
+        .fn()
+        .mockResolvedValueOnce({ email: 'dorse@example.com', sub: '2' }),
+      lookupAllowedUser: jest.fn().mockResolvedValueOnce({
+        email: 'dorse@example.com',
+        chatId: String(DORSE_CHAT_ID),
+      }),
+    });
+
+    expect(result.status).toBe(STATUS.OK);
+    expect(result.chatId).toBe(DORSE_CHAT_ID);
+  });
+
+  test('non-admin allowlisted chatId is FORBIDDEN with reason=not_admin', async () => {
+    const result = await authenticateRequest(reqWithToken('good'), {
+      clientId: 'client-id',
+      requireAdmin: true,
+      verifyToken: jest
+        .fn()
+        .mockResolvedValueOnce({ email: 'tester@example.com', sub: '3' }),
+      lookupAllowedUser: jest.fn().mockResolvedValueOnce({
+        email: 'tester@example.com',
+        // A real, on-allowlist, non-admin chatId.
+        chatId: '740312192',
+      }),
+    });
+
+    expect(result).toEqual({
+      status: STATUS.FORBIDDEN,
+      reason: 'not_admin',
+      email: 'tester@example.com',
+    });
+  });
+
+  test('non-admin allowlisted chatId is OK when requireAdmin=false (prod parity)', async () => {
+    const result = await authenticateRequest(reqWithToken('good'), {
+      clientId: 'client-id',
+      requireAdmin: false,
+      verifyToken: jest
+        .fn()
+        .mockResolvedValueOnce({ email: 'tester@example.com', sub: '3' }),
+      lookupAllowedUser: jest.fn().mockResolvedValueOnce({
+        email: 'tester@example.com',
+        chatId: '740312192',
+      }),
+    });
+
+    expect(result.status).toBe(STATUS.OK);
+    expect(result.chatId).toBe(740312192);
+  });
+
+  test('reads AGENT_REQUIRE_ADMIN=true from env when option is not provided', async () => {
+    process.env.GOOGLE_CLIENT_ID = 'client-id';
+    process.env.AGENT_REQUIRE_ADMIN = 'true';
+
+    const result = await authenticateRequest(reqWithToken('good'), {
+      verifyToken: jest
+        .fn()
+        .mockResolvedValueOnce({ email: 'tester@example.com', sub: '3' }),
+      lookupAllowedUser: jest.fn().mockResolvedValueOnce({
+        email: 'tester@example.com',
+        chatId: '740312192',
+      }),
+    });
+
+    expect(result.status).toBe(STATUS.FORBIDDEN);
+    expect(result.reason).toBe('not_admin');
+  });
+
+  test('AGENT_REQUIRE_ADMIN unset is treated as false (prod default)', async () => {
+    process.env.GOOGLE_CLIENT_ID = 'client-id';
+    delete process.env.AGENT_REQUIRE_ADMIN;
+
+    const result = await authenticateRequest(reqWithToken('good'), {
+      verifyToken: jest
+        .fn()
+        .mockResolvedValueOnce({ email: 'tester@example.com', sub: '3' }),
+      lookupAllowedUser: jest.fn().mockResolvedValueOnce({
+        email: 'tester@example.com',
+        chatId: '740312192',
+      }),
+    });
+
+    expect(result.status).toBe(STATUS.OK);
+  });
+
+  test('AGENT_REQUIRE_ADMIN="false" string is treated as false (only "true" enables)', async () => {
+    process.env.GOOGLE_CLIENT_ID = 'client-id';
+    process.env.AGENT_REQUIRE_ADMIN = 'false';
+
+    const result = await authenticateRequest(reqWithToken('good'), {
+      verifyToken: jest
+        .fn()
+        .mockResolvedValueOnce({ email: 'tester@example.com', sub: '3' }),
+      lookupAllowedUser: jest.fn().mockResolvedValueOnce({
+        email: 'tester@example.com',
+        chatId: '740312192',
+      }),
+    });
+
+    expect(result.status).toBe(STATUS.OK);
+  });
+
+  test('options.requireAdmin overrides env (true beats AGENT_REQUIRE_ADMIN=false)', async () => {
+    process.env.GOOGLE_CLIENT_ID = 'client-id';
+    process.env.AGENT_REQUIRE_ADMIN = 'false';
+
+    const result = await authenticateRequest(reqWithToken('good'), {
+      requireAdmin: true,
+      verifyToken: jest
+        .fn()
+        .mockResolvedValueOnce({ email: 'tester@example.com', sub: '3' }),
+      lookupAllowedUser: jest.fn().mockResolvedValueOnce({
+        email: 'tester@example.com',
+        chatId: '740312192',
+      }),
+    });
+
+    expect(result.status).toBe(STATUS.FORBIDDEN);
+    expect(result.reason).toBe('not_admin');
+  });
+
+  test('admin gate runs AFTER allowlist check — non-allowlisted admin still gets email_not_allowlisted', async () => {
+    // Guards the gate ordering: a chatId can't bypass the allowlist
+    // membership check just by happening to equal an admin chatId
+    // upstream of the lookup. (In practice this can't happen because
+    // the lookup is keyed on email, not chatId, but the ordering
+    // guarantee is worth pinning.)
+    const result = await authenticateRequest(reqWithToken('good'), {
+      clientId: 'client-id',
+      requireAdmin: true,
+      verifyToken: jest
+        .fn()
+        .mockResolvedValueOnce({ email: 'random@example.com', sub: '9' }),
+      lookupAllowedUser: jest.fn().mockResolvedValueOnce(null),
+    });
+
+    expect(result.status).toBe(STATUS.FORBIDDEN);
+    expect(result.reason).toBe('email_not_allowlisted');
+  });
+
+  test('admin gate does NOT run when status is BYPASSED (local dev parity)', async () => {
+    // If GOOGLE_CLIENT_ID is unset, we short-circuit to BYPASSED
+    // BEFORE the admin gate evaluates. This preserves the local-dev
+    // path even if a developer accidentally sets AGENT_REQUIRE_ADMIN
+    // locally.
+    delete process.env.GOOGLE_CLIENT_ID;
+    process.env.AGENT_REQUIRE_ADMIN = 'true';
+
+    const result = await authenticateRequest(reqWithToken('any'), {
+      lookupAllowedUser: jest.fn(),
+    });
+
+    expect(result).toEqual({ status: STATUS.BYPASSED });
   });
 });


### PR DESCRIPTION
## Why

The test slot of `f1-fantazy-agent-func` was publicly reachable and acted as the repo owner via `AGENT_HARDCODED_CHAT_ID`. Anyone who discovered the URL could drive the agent, read fantasy data, and burn Azure OpenAI quota. PRs #200 / #201 added auth on production only — this PR closes the gap on the test slot.

## How

Collapse per-PR SWA preview environments into a **single fixed `staging` environment** so Google OAuth's no-wildcards-on-origins rule can be satisfied with one Authorized JavaScript origin. The test slot now runs:

1. The same Google sign-in + `WebUserAllowlist` gate as production (`GOOGLE_CLIENT_ID` set).
2. An **additional admin-only filter** via a new `AGENT_REQUIRE_ADMIN=true` env var. Admins = `KILZI_CHAT_ID` + `DORSE_CHAT_ID` (same source `isAdminMessage` uses).

Trade-off: only one PR can be visually tested at a time on the shared staging SWA. Acceptable for a small dev team.

## Changes

| File | What |
|---|---|
| `src/agent/auth.js` | `AGENT_REQUIRE_ADMIN` honored after allowlist + valid-chatId checks; non-admin → `FORBIDDEN reason=not_admin` |
| `src/agent/auth.test.js` | 10 new tests: admin pass, non-admin reject, env-var vs option override, gate ordering, BYPASSED interaction |
| `infra/agent-func/apply-settings.sh` | Test slot now gets `GOOGLE_CLIENT_ID` (same as prod) + `AGENT_REQUIRE_ADMIN=true`. CORS default `*` → single staging origin. |
| `infra/agent-func/azuredeploy.parameters.json` | `testAllowedOrigins` → staging URL |
| `infra/agent-func/azuredeploy.json` | `testAllowedOrigins` description rewritten |
| `.github/workflows/pr_test_f1-fantazy-agent-web.yml` | Rewrite: deleted per-PR hostname computation, dynamic CORS plumbing, `close_preview` job. Single `deployment_environment: staging` deploy. `VITE_GOOGLE_CLIENT_ID` baked at build time. |
| `AGENTS.md` | Refreshed Web auth + Deployment + env-var sections. New "Test-slot admin-only gate" subsection. |

## Pre-push verification

- ARM + app settings already applied via `npm run deploy:agent-func`.
- Prod `GOOGLE_CLIENT_ID` unchanged; `AGENT_REQUIRE_ADMIN=false` on prod.
- Test slot platform CORS reduced to the staging SWA origin only.
- Anonymous POST to prod still returns `401 reason=missing_or_malformed_authorization_header` (unchanged).
- Test slot is currently `Stopped` → anonymous gets Azure's 403 stopped page until the PR-workflow start cycle.
- 102/102 `src/agent` + `agentWebhook` tests green; lint clean.

## Post-merge verification plan

1. Workflow `pr_test_f1-fantazy-agent-func.yml` deploys the new `auth.js` to the test slot.
2. Workflow `pr_test_f1-fantazy-agent-web.yml` deploys the staging frontend (with `VITE_GOOGLE_CLIENT_ID` baked).
3. Start the test slot: `az functionapp start --name f1-fantazy-agent-func --slot test`.
4. Sign in to the staging SWA as KILZI → `get_current_team` should return your own team.
5. (Optional) sign in as a non-admin allowlisted user → rejection screen with `reason=not_admin`.
6. Stop the test slot again.

🤖 Generated with [GitHub Copilot CLI](https://github.com/github/copilot-cli)