### PR TITLE
[codex] Preserve agent Google client id during infra deploys

### DIFF
--- a/.github/workflows/deploy-infra-agent-func.yml
+++ b/.github/workflows/deploy-infra-agent-func.yml
@@ -31,4 +31,11 @@ jobs:
           subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_00873174CBBD48D3871911006820901C }}
 
       - name: Deploy agent Function App ARM template
+        env:
+          # Public OAuth client id, kept in a secret only to avoid
+          # hard-coding environment-specific config in the workflow.
+          # apply-settings.sh uses this for the backend GOOGLE_CLIENT_ID
+          # gate; without it, an infra deploy would preserve the existing
+          # value rather than clearing auth.
+          GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
         run: npm run deploy:agent-func

--- a/infra/agent-func/apply-settings.sh
+++ b/infra/agent-func/apply-settings.sh
@@ -27,12 +27,15 @@
 #   PROD_PREVIEW_PATTERN   (default: empty)
 #   TEST_ALLOWED_ORIGINS   (default: https://test.f1.kilzid.com,https://proud-sky-035c6b003.7.azurestaticapps.net)
 #   TEST_PREVIEW_PATTERN   (default: empty)
-#   GOOGLE_CLIENT_ID       (default: empty — auth gate DISABLED on both
-#                           slots. Set to the OAuth 2.0 Web client ID to
-#                           enable Google sign-in on BOTH the production
-#                           AND test slots. The test slot additionally
-#                           runs an admin-only filter — see
-#                           AGENT_REQUIRE_ADMIN below.)
+#   GOOGLE_CLIENT_ID       OAuth 2.0 Web client ID. When set, enables Google
+#                           sign-in on BOTH the production AND test slots. The
+#                           test slot additionally runs an admin-only filter —
+#                           see AGENT_REQUIRE_ADMIN below.
+#                           When unset, this script preserves any existing
+#                           GOOGLE_CLIENT_ID app setting instead of clearing it.
+#   ALLOW_EMPTY_GOOGLE_CLIENT_ID
+#                           Set to "true" only when you intentionally want to
+#                           write an empty GOOGLE_CLIENT_ID and disable auth.
 
 set -euo pipefail
 
@@ -56,11 +59,10 @@ TEST_ORIGINS="${TEST_ALLOWED_ORIGINS:-https://test.f1.kilzid.com,https://proud-s
 TEST_PATTERN="${TEST_PREVIEW_PATTERN:-}"
 # When set, the Google auth gate runs on BOTH slots. The test slot
 # additionally requires AGENT_REQUIRE_ADMIN=true (see below) so only
-# admin chatIds (KILZI/DORSE) can reach the agent on PR previews. When
-# empty, both slots BYPASS auth and fall back to AGENT_HARDCODED_CHAT_ID
-# — kept ONLY for local-dev parity; do not ship empty to Azure.
+# admin chatIds (KILZI/DORSE) can reach the agent on PR previews.
 PROD_GOOGLE_CLIENT_ID="${GOOGLE_CLIENT_ID:-}"
 TEST_GOOGLE_CLIENT_ID="${GOOGLE_CLIENT_ID:-}"
+ALLOW_EMPTY_GOOGLE_CLIENT_ID="${ALLOW_EMPTY_GOOGLE_CLIENT_ID:-false}"
 
 KV_BASE="https://${KV_NAME}.vault.azure.net/secrets"
 
@@ -91,6 +93,31 @@ apply_to_slot() {
     slot_args+=(--slot "$slot_label")
   fi
 
+  local settings=(
+    "FUNCTIONS_EXTENSION_VERSION=~4"
+    "FUNCTIONS_WORKER_RUNTIME=node"
+    "WEBSITE_NODE_DEFAULT_VERSION=~22"
+    "NODE_ENV=production"
+    "AZURE_OPEN_AI_MODEL=${MODEL}"
+    "AZURE_STORAGE_CONTAINER_NAME=${STORAGE_CONTAINER}"
+    "AZURE_OPENAI_ENDPOINT=@Microsoft.KeyVault(SecretUri=${KV_BASE}/azure-openai-endpoint/)"
+    "AZURE_OPENAI_API_KEY=@Microsoft.KeyVault(SecretUri=${KV_BASE}/azure-openai-api-key/)"
+    "AZURE_STORAGE_CONNECTION_STRING=@Microsoft.KeyVault(SecretUri=${KV_BASE}/azure-storage-connection-string/)"
+    "TELEGRAM_BOT_TOKEN=@Microsoft.KeyVault(SecretUri=${KV_BASE}/telegram-bot-token/)"
+    "AGENT_HARDCODED_CHAT_ID=@Microsoft.KeyVault(SecretUri=${KV_BASE}/agent-hardcoded-chat-id/)"
+    "AGENT_CORS_ALLOWED_ORIGINS=${cors_origins}"
+    "AGENT_CORS_PREVIEW_ORIGIN_PATTERN=${cors_pattern}"
+    "AGENT_REQUIRE_ADMIN=${require_admin}"
+    "AzureWebJobsStorage=${STORAGE_CS}"
+    "APPLICATIONINSIGHTS_CONNECTION_STRING=${APPINSIGHTS_CS}"
+  )
+
+  if [[ -n "$google_client_id" || "$ALLOW_EMPTY_GOOGLE_CLIENT_ID" == "true" ]]; then
+    settings+=("GOOGLE_CLIENT_ID=${google_client_id}")
+  else
+    echo "GOOGLE_CLIENT_ID is unset; preserving existing ${slot_label} app setting."
+  fi
+
   echo "Applying app settings to slot: ${slot_label}..."
   # Note: ${slot_args[@]+"${slot_args[@]}"} pattern is `set -u`-safe expansion
   # of a possibly-empty array (Bash treats `${empty_array[@]}` as unbound).
@@ -99,24 +126,7 @@ apply_to_slot() {
     --resource-group "$RG" \
     --subscription "$SUB" \
     ${slot_args[@]+"${slot_args[@]}"} \
-    --settings \
-      "FUNCTIONS_EXTENSION_VERSION=~4" \
-      "FUNCTIONS_WORKER_RUNTIME=node" \
-      "WEBSITE_NODE_DEFAULT_VERSION=~22" \
-      "NODE_ENV=production" \
-      "AZURE_OPEN_AI_MODEL=${MODEL}" \
-      "AZURE_STORAGE_CONTAINER_NAME=${STORAGE_CONTAINER}" \
-      "AZURE_OPENAI_ENDPOINT=@Microsoft.KeyVault(SecretUri=${KV_BASE}/azure-openai-endpoint/)" \
-      "AZURE_OPENAI_API_KEY=@Microsoft.KeyVault(SecretUri=${KV_BASE}/azure-openai-api-key/)" \
-      "AZURE_STORAGE_CONNECTION_STRING=@Microsoft.KeyVault(SecretUri=${KV_BASE}/azure-storage-connection-string/)" \
-      "TELEGRAM_BOT_TOKEN=@Microsoft.KeyVault(SecretUri=${KV_BASE}/telegram-bot-token/)" \
-      "AGENT_HARDCODED_CHAT_ID=@Microsoft.KeyVault(SecretUri=${KV_BASE}/agent-hardcoded-chat-id/)" \
-      "AGENT_CORS_ALLOWED_ORIGINS=${cors_origins}" \
-      "AGENT_CORS_PREVIEW_ORIGIN_PATTERN=${cors_pattern}" \
-      "GOOGLE_CLIENT_ID=${google_client_id}" \
-      "AGENT_REQUIRE_ADMIN=${require_admin}" \
-      "AzureWebJobsStorage=${STORAGE_CS}" \
-      "APPLICATIONINSIGHTS_CONNECTION_STRING=${APPINSIGHTS_CS}" \
+    --settings "${settings[@]}" \
     --output none --only-show-errors
 }
 

--- a/src/agent/identity.js
+++ b/src/agent/identity.js
@@ -8,8 +8,6 @@
 //      handing the request off to CopilotKit.
 //   2. The `AGENT_HARDCODED_CHAT_ID` env var. Used by:
 //        - local dev (`scripts/dev-agent-server.js`),
-//        - the test slot of the agent Function App (where Google auth
-//          is intentionally bypassed for PR validation),
 //        - any process running outside an HTTP request scope
 //          (e.g. background cache bootstrap).
 //


### PR DESCRIPTION
## Summary

Fixes the deployment path that could silently clear the agent Function App's `GOOGLE_CLIENT_ID` app setting and put the web agent back into bypass mode.

## Root Cause

`deploy-infra-agent-func.yml` runs `npm run deploy:agent-func`, which chains `infra/agent-func/apply-settings.sh`. The script always wrote `GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}`. Because the workflow did not pass `GOOGLE_CLIENT_ID`, infra deploys wrote an empty value to both slots. The agent webhook treats an empty `GOOGLE_CLIENT_ID` as local-dev bypass mode, so tools fell back to `AGENT_HARDCODED_CHAT_ID`.

## Changes

- Pass `secrets.VITE_GOOGLE_CLIENT_ID` into the agent Function App infra deploy workflow as `GOOGLE_CLIENT_ID`.
- Make `apply-settings.sh` preserve the existing `GOOGLE_CLIENT_ID` setting when the env var is absent.
- Add explicit `ALLOW_EMPTY_GOOGLE_CLIENT_ID=true` escape hatch for intentional auth disablement.
- Remove stale identity comment that said the test slot intentionally bypasses Google auth.

## Validation

- `bash -n infra/agent-func/apply-settings.sh`
- `npm test -- src/agent/auth.test.js agentWebhook/index.test.js src/agent/identity.test.js`
- Live prod/test settings were restored manually and `/api/agent/whoami` now returns `401 missing_or_malformed_authorization_header` without a bearer token instead of `200 mode=bypassed`.