### PR TITLE
[codex] Add Hebrew agent UI support

### DIFF
--- a/src/agent/systemPrompt.js
+++ b/src/agent/systemPrompt.js
@@ -179,7 +179,11 @@ Workflow rules:
     pattern as other tools.
 
 Style rules:
-- Answer in English.
+- Match the language of the user's latest message. If the user asks in
+  Hebrew, answer in Hebrew. If they ask in English, answer in English.
+  If the user explicitly asks for a specific response language, follow
+  that request. Keep F1/team/driver/constructor codes such as VER, MCL,
+  FER, and T1 unchanged.
 - Be concise. Prefer tables and lists over long paragraphs.
 - When you call a tool that has a rich UI component registered on the
   frontend, the user will see that component automatically. Do not
@@ -206,4 +210,3 @@ function getSystemPrompt() {
 }
 
 module.exports = { getSystemPrompt };
-

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,6 +22,7 @@ import { useLiveScoreBreakdownAction } from './components/LiveScoreBreakdown';
 import { useLiveScoreLeaderboardAction } from './components/LiveScoreLeaderboard';
 import { HistoryRestorer } from './components/HistoryRestorer';
 import { ClearHistoryButton } from './components/ClearHistoryButton';
+import { RtlChatSupport } from './components/RtlChatSupport';
 
 const RUNTIME_URL =
   (import.meta.env.VITE_AGENT_API_URL as string | undefined) ??
@@ -91,6 +92,7 @@ function VerifiedAgentChat() {
       headers={() => ({ Authorization: `Bearer ${session.idToken}` })}
     >
       <HistoryRestorer />
+      <RtlChatSupport />
       <AgentActions />
       <div
         style={{
@@ -113,7 +115,7 @@ function VerifiedAgentChat() {
       </div>
       <div className="chat-wrapper">
         <CopilotChat
-          instructions="You are an assistant for an F1 Fantasy player. Use the registered tools to answer questions; the user will see rich UI components automatically when you call them."
+          instructions="You are an assistant for an F1 Fantasy player. Use the registered tools to answer questions; the user will see rich UI components automatically when you call them. Match the language of the user's latest message: answer Hebrew questions in Hebrew and English questions in English, unless the user explicitly asks for a specific response language."
           labels={{
             title: 'F1 Fantasy Agent',
             initial:
@@ -133,6 +135,7 @@ function UnauthedAgent() {
   return (
     <CopilotKit runtimeUrl={RUNTIME_URL}>
       <HistoryRestorer />
+      <RtlChatSupport />
       <AgentActions />
       <div
         style={{
@@ -152,7 +155,7 @@ function UnauthedAgent() {
       </div>
       <div className="chat-wrapper">
         <CopilotChat
-          instructions="You are an assistant for an F1 Fantasy player. Use the registered tools to answer questions; the user will see rich UI components automatically when you call them."
+          instructions="You are an assistant for an F1 Fantasy player. Use the registered tools to answer questions; the user will see rich UI components automatically when you call them. Match the language of the user's latest message: answer Hebrew questions in Hebrew and English questions in English, unless the user explicitly asks for a specific response language."
           labels={{
             title: 'F1 Fantasy Agent',
             initial:

--- a/web/src/components/RtlChatSupport.tsx
+++ b/web/src/components/RtlChatSupport.tsx
@@ -1,0 +1,72 @@
+import { useEffect } from 'react';
+
+const DIRECTIONAL_TEXT_SELECTOR = [
+  '.chat-wrapper .copilotKitMessage',
+  '.chat-wrapper .copilotKitInput > textarea',
+].join(', ');
+
+const HEBREW_TEXT_RE = /[\u0590-\u05ff]/;
+
+function getElementText(element: HTMLElement): string {
+  if (element instanceof HTMLTextAreaElement) {
+    return element.value;
+  }
+
+  return element.textContent ?? '';
+}
+
+function applyElementDirection(element: HTMLElement): void {
+  element.setAttribute('dir', 'auto');
+
+  const text = getElementText(element);
+  if (!text.trim()) {
+    element.removeAttribute('data-text-direction');
+    return;
+  }
+
+  element.setAttribute(
+    'data-text-direction',
+    HEBREW_TEXT_RE.test(text) ? 'rtl' : 'ltr',
+  );
+}
+
+function applyAutomaticDirection(root: ParentNode = document): void {
+  root.querySelectorAll<HTMLElement>(DIRECTIONAL_TEXT_SELECTOR).forEach((element) => {
+    applyElementDirection(element);
+  });
+}
+
+export function RtlChatSupport(): null {
+  useEffect(() => {
+    applyAutomaticDirection();
+
+    const observer = new MutationObserver(() => {
+      applyAutomaticDirection();
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+
+    const handleInput = (event: Event) => {
+      const target = event.target;
+      if (
+        target instanceof HTMLElement &&
+        target.matches(DIRECTIONAL_TEXT_SELECTOR)
+      ) {
+        applyElementDirection(target);
+      }
+    };
+
+    document.addEventListener('input', handleInput, true);
+
+    return () => {
+      document.removeEventListener('input', handleInput, true);
+      observer.disconnect();
+    };
+  }, []);
+
+  return null;
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -53,3 +53,34 @@ body {
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 4px 16px rgba(0, 0, 0, 0.04);
   overflow: hidden;
 }
+
+.chat-wrapper .copilotKitMessage,
+.chat-wrapper .copilotKitInput > textarea {
+  text-align: start;
+  unicode-bidi: plaintext;
+}
+
+.chat-wrapper .copilotKitMessage[data-text-direction='rtl'] ul.copilotKitMarkdownElement,
+.chat-wrapper .copilotKitMessage[data-text-direction='rtl'] ol.copilotKitMarkdownElement {
+  padding-left: 0;
+  padding-right: 20px;
+}
+
+.chat-wrapper .copilotKitMessage[data-text-direction='rtl'] blockquote.copilotKitMarkdownElement {
+  border-left: 0;
+  border-right: 2px solid rgb(142, 142, 160);
+  padding-left: 0;
+  padding-right: 10px;
+}
+
+.chat-wrapper .copilotKitMessage[data-text-direction='rtl'] .copilotKitMessageControls {
+  left: auto;
+  right: 0;
+}
+
+.chat-wrapper .copilotKitCodeBlock,
+.chat-wrapper .copilotKitInlineCode {
+  direction: ltr;
+  text-align: left;
+  unicode-bidi: isolate;
+}


### PR DESCRIPTION
## Summary
- Replace the web-agent English-only system prompt rule with language matching for the latest user message.
- Mirror the same language guidance in both authenticated and unauthenticated CopilotChat instructions.
- Add RTL-aware chat UI handling for Hebrew messages and composer text via `dir="auto"`, with local styling for RTL lists, blockquotes, message controls, and LTR code snippets.

## Impact
Hebrew questions to the web-chat agent should now receive Hebrew answers and render with right-to-left text flow in the chat UI. English questions still receive English answers, and F1/team/driver codes and code blocks remain left-to-right.

## Validation
- `npm --prefix web run build`
- Commit hook: `npm run lint` and `npm run test:coverage` (91 suites, 962 tests passed; lint warnings only in pre-existing files).

## Note
I attempted to verify visually with the in-app browser, but the browser surface was unavailable in this session (`iab` not exposed).