### PR TITLE
[codex] enable Google auto login

### DIFF
--- a/web/src/auth/AccessVerifier.tsx
+++ b/web/src/auth/AccessVerifier.tsx
@@ -49,7 +49,7 @@ export function AccessVerifier({
       if (result.status === 'forbidden') {
         // 401 from the backend → definitive rejection.
         setRejection({ reason: result.reason, email: result.email });
-        signOut();
+        signOut({ disableGoogleAutoSelect: true });
         // The parent will re-render with no session → LoginScreen.
         return;
       }

--- a/web/src/auth/AuthContext.test.tsx
+++ b/web/src/auth/AuthContext.test.tsx
@@ -1,0 +1,121 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { googleLogout } from '@react-oauth/google';
+import { AuthProvider, useAuth } from './AuthContext';
+
+vi.mock('@react-oauth/google', () => ({
+  googleLogout: vi.fn(),
+}));
+
+const STORAGE_KEY = 'f1-fantasy-agent-id-token';
+
+function encodeBase64Url(value: object): string {
+  return window
+    .btoa(JSON.stringify(value))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+function makeIdToken(exp: number): string {
+  return [
+    encodeBase64Url({ alg: 'none', typ: 'JWT' }),
+    encodeBase64Url({
+      email: 'driver@example.com',
+      name: 'Driver',
+      sub: 'google-sub-1',
+      exp,
+    }),
+    'signature',
+  ].join('.');
+}
+
+function renderAuthProbe() {
+  let signIn: ((idToken: string) => void) | null = null;
+  let signOut: ReturnType<typeof useAuth>['signOut'] | null = null;
+  let email: string | null = null;
+
+  function Probe() {
+    const auth = useAuth();
+    signIn = auth.signIn;
+    signOut = auth.signOut;
+    email = auth.session?.claims.email ?? null;
+    return null;
+  }
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+  });
+
+  return {
+    get signIn() {
+      if (!signIn) throw new Error('signIn was not initialized');
+      return signIn;
+    },
+    get signOut() {
+      if (!signOut) throw new Error('signOut was not initialized');
+      return signOut;
+    },
+    get email() {
+      return email;
+    },
+    cleanup() {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+afterEach(() => {
+  window.sessionStorage.clear();
+  vi.clearAllMocks();
+});
+
+describe('AuthProvider signOut', () => {
+  test('clears the local session without disabling Google auto-select by default', () => {
+    const probe = renderAuthProbe();
+    const token = makeIdToken(Math.floor(Date.now() / 1000) + 3600);
+
+    act(() => {
+      probe.signIn(token);
+    });
+    expect(probe.email).toBe('driver@example.com');
+
+    act(() => {
+      probe.signOut();
+    });
+
+    expect(googleLogout).not.toHaveBeenCalled();
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(probe.email).toBeNull();
+    probe.cleanup();
+  });
+
+  test('disables Google auto-select for explicit sign-out', () => {
+    const probe = renderAuthProbe();
+    const token = makeIdToken(Math.floor(Date.now() / 1000) + 3600);
+
+    act(() => {
+      probe.signIn(token);
+    });
+    act(() => {
+      probe.signOut({ disableGoogleAutoSelect: true });
+    });
+
+    expect(googleLogout).toHaveBeenCalledTimes(1);
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(probe.email).toBeNull();
+    probe.cleanup();
+  });
+});

--- a/web/src/auth/AuthContext.tsx
+++ b/web/src/auth/AuthContext.tsx
@@ -3,9 +3,10 @@
 // Holds the ID token returned by Google Identity Services (via
 // @react-oauth/google's <GoogleLogin /> button) plus the decoded
 // `email`, `name`, `picture`, and `sub` claims for UI display. The
-// token is cached in `sessionStorage` (NOT `localStorage`) so closing
-// the tab logs the user out — a low-cost mitigation for shared
-// browsers.
+// token is cached in `sessionStorage` (NOT `localStorage`) so stale
+// Google ID tokens are not kept beyond the browser session. The login
+// screen uses Google One Tap/auto-select to get a fresh token when the
+// browser still has an active Google session.
 //
 // The token is read by `<CopilotKit>` via a custom transport that
 // adds `Authorization: Bearer ${idToken}` to every backend request.
@@ -22,8 +23,13 @@ import {
   useState,
   type ReactNode,
 } from 'react';
+import { googleLogout } from '@react-oauth/google';
 
 const STORAGE_KEY = 'f1-fantasy-agent-id-token';
+
+type SignOutOptions = {
+  disableGoogleAutoSelect?: boolean;
+};
 
 type IdTokenClaims = {
   email: string;
@@ -41,7 +47,7 @@ type AuthSession = {
 type AuthContextValue = {
   session: AuthSession | null;
   signIn: (idToken: string) => void;
-  signOut: () => void;
+  signOut: (options?: SignOutOptions) => void;
   rejection: { reason: string; email?: string } | null;
   setRejection: (rejection: { reason: string; email?: string } | null) => void;
 };
@@ -128,7 +134,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setRejection(null);
   }, []);
 
-  const signOut = useCallback(() => {
+  const signOut = useCallback((options?: SignOutOptions) => {
+    if (options?.disableGoogleAutoSelect) {
+      googleLogout();
+    }
     persistToken(null);
     setSession(null);
   }, []);

--- a/web/src/components/LoginScreen.test.tsx
+++ b/web/src/components/LoginScreen.test.tsx
@@ -1,0 +1,59 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import type { GoogleLoginProps } from '@react-oauth/google';
+import { AuthProvider } from '../auth/AuthContext';
+import { LoginScreen } from './LoginScreen';
+
+let latestGoogleLoginProps: GoogleLoginProps | null = null;
+
+vi.mock('@react-oauth/google', () => ({
+  googleLogout: vi.fn(),
+  GoogleLogin: (props: GoogleLoginProps) => {
+    latestGoogleLoginProps = props;
+    return <button type="button">Google sign in</button>;
+  },
+}));
+
+function renderLoginScreen() {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <AuthProvider>
+        <LoginScreen />
+      </AuthProvider>,
+    );
+  });
+
+  return () => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  };
+}
+
+afterEach(() => {
+  latestGoogleLoginProps = null;
+  vi.clearAllMocks();
+});
+
+describe('LoginScreen', () => {
+  test('enables Google One Tap automatic sign-in while keeping the button fallback', () => {
+    const cleanup = renderLoginScreen();
+
+    expect(latestGoogleLoginProps).toMatchObject({
+      useOneTap: true,
+      auto_select: true,
+      theme: 'filled_blue',
+      size: 'large',
+      shape: 'rectangular',
+    });
+    expect(document.body.textContent).toContain('Google sign in');
+
+    cleanup();
+  });
+});

--- a/web/src/components/LoginScreen.tsx
+++ b/web/src/components/LoginScreen.tsx
@@ -114,6 +114,8 @@ export function LoginScreen() {
           theme="filled_blue"
           size="large"
           shape="rectangular"
+          useOneTap
+          auto_select
         />
       </div>
     </div>

--- a/web/src/components/SignedInBadge.tsx
+++ b/web/src/components/SignedInBadge.tsx
@@ -20,7 +20,7 @@ export function SignedInBadge() {
     // Wipe local history so a different user signing in on the
     // same browser doesn't see the previous conversation.
     clearChatHistory();
-    signOut();
+    signOut({ disableGoogleAutoSelect: true });
   };
 
   return (


### PR DESCRIPTION
## Summary
- Enable Google One Tap with auto-select on the web login screen so returning users can get a fresh Google ID token without clicking the sign-in button when Google allows it.
- Add explicit sign-out handling that disables Google auto-select to avoid immediately signing users back in after they choose to leave or after backend auth rejection.
- Add focused web auth tests for auto-login props and sign-out behavior.

## Why
The web app previously cached the Google ID token only in sessionStorage, so reopening the page required a manual Google sign-in. Reusing expired ID tokens is not safe because the backend verifies Google token expiry on every request, so the app now asks Google to issue a fresh credential automatically when the browser has an eligible Google session.

## Validation
- `cd web && npm test`
- `cd web && npm run build`
- Commit hook: `npm run lint` and `npm run test:coverage` (91 suites, 963 tests passed; lint warnings were pre-existing max-depth/max-params warnings)