### PR TITLE
[codex] add web dark theme support

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,11 +2,13 @@ import { CopilotKit } from '@copilotkit/react-core';
 import { CopilotChat } from '@copilotkit/react-ui';
 import '@copilotkit/react-ui/styles.css';
 import { GoogleOAuthProvider } from '@react-oauth/google';
+import { useLayoutEffect, useState } from 'react';
 import { AuthProvider, useAuth } from './auth/AuthContext';
 import { useAuthFetchInterceptor } from './auth/useAuthFetchInterceptor';
 import { AccessVerifier } from './auth/AccessVerifier';
 import { LoginScreen } from './components/LoginScreen';
 import { SignedInBadge } from './components/SignedInBadge';
+import { ThemeToggle } from './components/ThemeToggle';
 import { setHistoryScope } from './lib/chatHistoryStore';
 import { useNextRacesAction } from './components/NextRacesTable';
 import { useBestTeamsAction } from './components/BestTeamsTable';
@@ -23,6 +25,12 @@ import { useLiveScoreLeaderboardAction } from './components/LiveScoreLeaderboard
 import { HistoryRestorer } from './components/HistoryRestorer';
 import { ClearHistoryButton } from './components/ClearHistoryButton';
 import { RtlChatSupport } from './components/RtlChatSupport';
+import {
+  applyTheme,
+  persistTheme,
+  resolveInitialTheme,
+  type ThemeMode,
+} from './theme';
 
 const RUNTIME_URL =
   (import.meta.env.VITE_AGENT_API_URL as string | undefined) ??
@@ -47,7 +55,13 @@ function AgentActions() {
   return null;
 }
 
-function AuthedAgent() {
+function AuthedAgent({
+  theme,
+  onToggleTheme,
+}: {
+  theme: ThemeMode;
+  onToggleTheme: () => void;
+}) {
   const { session } = useAuth();
   useAuthFetchInterceptor(RUNTIME_URL);
 
@@ -56,17 +70,23 @@ function AuthedAgent() {
     // renders. Defensive — `signOut()` clearing the session triggers
     // this branch even if a different user later signs in.
     setHistoryScope(null);
-    return <LoginScreen />;
+    return <LoginScreen theme={theme} onToggleTheme={onToggleTheme} />;
   }
 
   return (
     <AccessVerifier runtimeUrl={RUNTIME_URL}>
-      <VerifiedAgentChat />
+      <VerifiedAgentChat theme={theme} onToggleTheme={onToggleTheme} />
     </AccessVerifier>
   );
 }
 
-function VerifiedAgentChat() {
+function VerifiedAgentChat({
+  theme,
+  onToggleTheme,
+}: {
+  theme: ThemeMode;
+  onToggleTheme: () => void;
+}) {
   const { session } = useAuth();
 
   // Bind the chat-history scope SYNCHRONOUSLY during render — before
@@ -94,21 +114,16 @@ function VerifiedAgentChat() {
       <HistoryRestorer />
       <RtlChatSupport />
       <AgentActions />
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
-          gap: 16,
-        }}
-      >
+      <div className="app-titlebar">
         <div>
           <h1 className="app-header">F1 Fantasy Agent</h1>
           <p className="app-subheader">
-            Ask about upcoming races or your best teams. The Telegram bot is unaffected.
+            Ask about upcoming races or your best teams. The Telegram bot is
+            unaffected.
           </p>
         </div>
-        <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+        <div className="app-actions">
+          <ThemeToggle theme={theme} onToggle={onToggleTheme} />
           <SignedInBadge />
           <ClearHistoryButton />
         </div>
@@ -131,27 +146,30 @@ function VerifiedAgentChat() {
 // we render the chat directly without any auth gate — backend bypasses
 // auth in that mode too (when GOOGLE_CLIENT_ID is unset on the
 // Function App). This keeps `npm run dev` frictionless.
-function UnauthedAgent() {
+function UnauthedAgent({
+  theme,
+  onToggleTheme,
+}: {
+  theme: ThemeMode;
+  onToggleTheme: () => void;
+}) {
   return (
     <CopilotKit runtimeUrl={RUNTIME_URL}>
       <HistoryRestorer />
       <RtlChatSupport />
       <AgentActions />
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
-          gap: 16,
-        }}
-      >
+      <div className="app-titlebar">
         <div>
           <h1 className="app-header">F1 Fantasy Agent</h1>
           <p className="app-subheader">
-            Ask about upcoming races or your best teams. The Telegram bot is unaffected.
+            Ask about upcoming races or your best teams. The Telegram bot is
+            unaffected.
           </p>
         </div>
-        <ClearHistoryButton />
+        <div className="app-actions">
+          <ThemeToggle theme={theme} onToggle={onToggleTheme} />
+          <ClearHistoryButton />
+        </div>
       </div>
       <div className="chat-wrapper">
         <CopilotChat
@@ -168,10 +186,21 @@ function UnauthedAgent() {
 }
 
 export default function App() {
+  const [theme, setTheme] = useState<ThemeMode>(() => resolveInitialTheme());
+
+  useLayoutEffect(() => {
+    applyTheme(theme);
+    persistTheme(theme);
+  }, [theme]);
+
+  const onToggleTheme = () => {
+    setTheme((current) => (current === 'dark' ? 'light' : 'dark'));
+  };
+
   if (!GOOGLE_CLIENT_ID) {
     return (
       <div className="app-shell">
-        <UnauthedAgent />
+        <UnauthedAgent theme={theme} onToggleTheme={onToggleTheme} />
       </div>
     );
   }
@@ -180,7 +209,7 @@ export default function App() {
     <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID}>
       <AuthProvider>
         <div className="app-shell">
-          <AuthedAgent />
+          <AuthedAgent theme={theme} onToggleTheme={onToggleTheme} />
         </div>
       </AuthProvider>
     </GoogleOAuthProvider>

--- a/web/src/auth/AccessVerifier.tsx
+++ b/web/src/auth/AccessVerifier.tsx
@@ -12,7 +12,13 @@
 // chat, but they also MUSTN'T be bounced into a sign-in loop on a
 // cold-start blip.
 
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
 import { useAuth } from './AuthContext';
 import { verifyAccess, type VerifyAccessOk } from './whoami';
 
@@ -88,7 +94,7 @@ function VerifyingSpinner() {
         justifyContent: 'center',
         minHeight: '60vh',
         gap: 16,
-        color: '#444',
+        color: 'var(--app-muted)',
         fontSize: 14,
       }}
     >
@@ -97,8 +103,8 @@ function VerifyingSpinner() {
         style={{
           width: 36,
           height: 36,
-          border: '3px solid #d8dde6',
-          borderTopColor: '#37404f',
+          border: '3px solid var(--app-control-border)',
+          borderTopColor: 'var(--app-control-text)',
           borderRadius: '50%',
           animation: 'f1-spin 0.8s linear infinite',
         }}
@@ -136,7 +142,14 @@ function UnavailableCard({
         <h2 style={{ margin: '0 0 8px', fontSize: 22, fontWeight: 700 }}>
           🏎️ Agent unavailable
         </h2>
-        <p style={{ margin: 0, fontSize: 14, color: '#444', lineHeight: 1.45 }}>
+        <p
+          style={{
+            margin: 0,
+            fontSize: 14,
+            color: 'var(--app-muted)',
+            lineHeight: 1.45,
+          }}
+        >
           {message}
         </p>
       </div>
@@ -147,8 +160,8 @@ function UnavailableCard({
           padding: '10px 18px',
           fontSize: 14,
           fontWeight: 600,
-          color: '#fff',
-          background: '#37404f',
+          color: 'var(--app-primary-contrast)',
+          background: 'var(--app-primary)',
           border: 'none',
           borderRadius: 8,
           cursor: 'pointer',

--- a/web/src/components/BestTeamScenariosMatrix.tsx
+++ b/web/src/components/BestTeamScenariosMatrix.tsx
@@ -16,7 +16,12 @@ type ScenarioRow = {
 };
 
 type BestTeamScenariosResult = {
-  status?: 'ok' | 'no_teams' | 'unknown_team' | 'ambiguous_team' | 'missing_cache';
+  status?:
+    | 'ok'
+    | 'no_teams'
+    | 'unknown_team'
+    | 'ambiguous_team'
+    | 'missing_cache';
   teamId?: string;
   teamName?: string;
   chip?: string | null;
@@ -45,7 +50,7 @@ function BestTeamScenariosMatrix({
 
   if (result.status === 'no_teams') {
     return (
-      <div style={{ padding: 12, color: '#7a4a00' }}>
+      <div style={{ padding: 12, color: 'var(--app-warning-text)' }}>
         You don't have any tracked teams yet.
       </div>
     );
@@ -53,7 +58,7 @@ function BestTeamScenariosMatrix({
 
   if (result.status === 'missing_cache') {
     return (
-      <div style={{ padding: 12, color: '#7a4a00' }}>
+      <div style={{ padding: 12, color: 'var(--app-warning-text)' }}>
         Missing cached data for this team. Upload current team data via the
         Telegram bot first.
       </div>
@@ -62,7 +67,7 @@ function BestTeamScenariosMatrix({
 
   if (result.status === 'unknown_team') {
     return (
-      <div style={{ padding: 12, color: '#a32020' }}>
+      <div style={{ padding: 12, color: 'var(--app-danger-text)' }}>
         Couldn't find a matching team.
       </div>
     );
@@ -70,7 +75,7 @@ function BestTeamScenariosMatrix({
 
   if (result.status === 'ambiguous_team') {
     return (
-      <div style={{ padding: 12, color: '#7a4a00' }}>
+      <div style={{ padding: 12, color: 'var(--app-warning-text)' }}>
         Multiple tracked teams — specify which one.
       </div>
     );
@@ -85,23 +90,25 @@ function BestTeamScenariosMatrix({
     <div
       style={{
         margin: '8px 0',
-        border: '1px solid #e2e6ee',
+        border: '1px solid var(--app-border)',
         borderRadius: 10,
-        background: '#fff',
+        background: 'var(--app-surface)',
         overflow: 'hidden',
       }}
     >
       <div
         style={{
           padding: '10px 14px',
-          background: '#f6f8fb',
-          borderBottom: '1px solid #e2e6ee',
+          background: 'var(--app-surface-muted)',
+          borderBottom: '1px solid var(--app-border)',
         }}
       >
-        <div style={{ fontWeight: 700, fontSize: 14, color: '#1f2937' }}>
+        <div
+          style={{ fontWeight: 700, fontSize: 14, color: 'var(--app-text)' }}
+        >
           📊 Best Team Scenarios — {result.teamName}
         </div>
-        <div style={{ color: '#7d8693', fontSize: 11, marginTop: 2 }}>
+        <div style={{ color: 'var(--app-subtle)', fontSize: 11, marginTop: 2 }}>
           Top team per ppm preset × chip combination. 🟢/🟡 indicate chip lift
           vs. no-chip baseline of the same row.
         </div>
@@ -110,18 +117,21 @@ function BestTeamScenariosMatrix({
       {scenarios.map((row) => (
         <div
           key={row.ppm}
-          style={{ borderTop: '1px solid #f0f2f6', padding: '10px 14px' }}
+          style={{
+            borderTop: '1px solid var(--app-border)',
+            padding: '10px 14px',
+          }}
         >
           <div
             style={{
               fontWeight: 600,
               fontSize: 13,
-              color: '#1f2937',
+              color: 'var(--app-text)',
               marginBottom: 6,
             }}
           >
             {row.ppmLabel}{' '}
-            <span style={{ color: '#7d8693', fontWeight: 400 }}>
+            <span style={{ color: 'var(--app-subtle)', fontWeight: 400 }}>
               ({row.ppm} pts / $M)
             </span>
           </div>
@@ -133,15 +143,25 @@ function BestTeamScenariosMatrix({
             }}
           >
             <thead>
-              <tr style={{ color: '#7d8693', textAlign: 'left' }}>
-                <th style={{ padding: '4px 8px', fontWeight: 500 }}>Scenario</th>
+              <tr style={{ color: 'var(--app-subtle)', textAlign: 'left' }}>
+                <th style={{ padding: '4px 8px', fontWeight: 500 }}>
+                  Scenario
+                </th>
                 <th
-                  style={{ padding: '4px 8px', textAlign: 'right', fontWeight: 500 }}
+                  style={{
+                    padding: '4px 8px',
+                    textAlign: 'right',
+                    fontWeight: 500,
+                  }}
                 >
                   Pts
                 </th>
                 <th
-                  style={{ padding: '4px 8px', textAlign: 'right', fontWeight: 500 }}
+                  style={{
+                    padding: '4px 8px',
+                    textAlign: 'right',
+                    fontWeight: 500,
+                  }}
                 >
                   Δ price
                 </th>
@@ -155,15 +175,18 @@ function BestTeamScenariosMatrix({
                   <tr
                     key={cell.chipLabel}
                     style={{
-                      background: isBaseline ? 'transparent' : '#fafbfd',
-                      borderTop: idx === 0 ? 'none' : '1px solid #f5f7fa',
+                      background: isBaseline
+                        ? 'transparent'
+                        : 'var(--app-surface-subtle)',
+                      borderTop:
+                        idx === 0 ? 'none' : '1px solid var(--app-border)',
                     }}
                   >
                     <td
                       style={{
                         padding: '4px 8px',
                         fontWeight: isBaseline ? 600 : 400,
-                        color: '#1f2937',
+                        color: 'var(--app-text)',
                       }}
                     >
                       {cell.chipLabel}
@@ -185,7 +208,7 @@ function BestTeamScenariosMatrix({
                       style={{
                         padding: '4px 8px',
                         textAlign: 'right',
-                        color: '#7d8693',
+                        color: 'var(--app-subtle)',
                         fontVariantNumeric: 'tabular-nums',
                       }}
                     >
@@ -212,7 +235,7 @@ export function useBestTeamScenariosAction() {
     render: ({ status, result }) => {
       if (status === 'inProgress' || status === 'executing') {
         return (
-          <div style={{ padding: 10, color: '#666' }}>
+          <div style={{ padding: 10, color: 'var(--app-muted)' }}>
             Computing scenarios…
           </div>
         );

--- a/web/src/components/BestTeamsTable.tsx
+++ b/web/src/components/BestTeamsTable.tsx
@@ -113,10 +113,10 @@ function BestTeamsError({ result }: { result: GetBestTeamsErrorResult }) {
     <div
       style={{
         padding: 12,
-        border: '1px solid #f0d5d5',
+        border: '1px solid var(--app-danger-border)',
         borderRadius: 8,
-        background: '#fff7f7',
-        color: '#7a2222',
+        background: 'var(--app-danger-surface)',
+        color: 'var(--app-danger-text)',
         fontSize: 14,
       }}
     >
@@ -156,9 +156,11 @@ function HighlightedCode({
     borderRadius: 4,
     fontSize: 12,
     fontWeight: 600,
-    border: '1px solid #d5dbe7',
-    background: isIncluded ? '#e6f4ea' : '#fafbfd',
-    color: isIncluded ? '#1e4d2b' : '#222',
+    border: '1px solid var(--app-border)',
+    background: isIncluded
+      ? 'var(--app-success-surface)'
+      : 'var(--app-surface-subtle)',
+    color: isIncluded ? 'var(--app-success-text)' : 'var(--app-text)',
   };
   return (
     <span style={style}>
@@ -175,7 +177,7 @@ function BestTeamsTable({ result }: { result?: GetBestTeamsResult }) {
   }
   if (!result.bestTeams || result.bestTeams.length === 0) {
     return (
-      <div style={{ padding: 12, color: '#555' }}>
+      <div style={{ padding: 12, color: 'var(--app-muted)' }}>
         No teams match those filters.
       </div>
     );
@@ -189,25 +191,24 @@ function BestTeamsTable({ result }: { result?: GetBestTeamsResult }) {
     <div
       style={{
         margin: '8px 0',
-        border: '1px solid #e2e6ee',
+        border: '1px solid var(--app-border)',
         borderRadius: 8,
-        background: '#fff',
+        background: 'var(--app-surface)',
         overflow: 'hidden',
       }}
     >
       <div
         style={{
           padding: '10px 14px',
-          borderBottom: '1px solid #e2e6ee',
-          background: '#f8fafc',
+          borderBottom: '1px solid var(--app-border)',
+          background: 'var(--app-surface-muted)',
           fontSize: 14,
         }}
       >
-        <div style={{ fontWeight: 600 }}>
-          Best teams — {result.teamName}
-        </div>
-        <div style={{ color: '#555', fontSize: 12, marginTop: 2 }}>
-          Ranked by {rankByLabel(result.rankBy, result.budgetChangePointsPerMillion)}
+        <div style={{ fontWeight: 600 }}>Best teams — {result.teamName}</div>
+        <div style={{ color: 'var(--app-muted)', fontSize: 12, marginTop: 2 }}>
+          Ranked by{' '}
+          {rankByLabel(result.rankBy, result.budgetChangePointsPerMillion)}
           {' · '}
           Chip: {chipLabel(result.chip)}
           {includeDrivers.size > 0
@@ -224,9 +225,16 @@ function BestTeamsTable({ result }: { result?: GetBestTeamsResult }) {
             : ''}
         </div>
       </div>
-      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
+      <table
+        style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}
+      >
         <thead>
-          <tr style={{ background: '#fafbfd', textAlign: 'left' }}>
+          <tr
+            style={{
+              background: 'var(--app-surface-subtle)',
+              textAlign: 'left',
+            }}
+          >
             <th style={cellHeader}>#</th>
             <th style={cellHeader}>Drivers</th>
             <th style={cellHeader}>Constructors</th>
@@ -239,11 +247,18 @@ function BestTeamsTable({ result }: { result?: GetBestTeamsResult }) {
         </thead>
         <tbody>
           {result.bestTeams.map((team) => (
-            <tr key={team.row} style={{ borderTop: '1px solid #f0f2f7' }}>
+            <tr
+              key={team.row}
+              style={{ borderTop: '1px solid var(--app-border)' }}
+            >
               <td style={cellBody}>
                 <strong>{team.row}</strong>
                 {team.transfersNeeded === 0 ? (
-                  <div style={{ fontSize: 11, color: '#1e4d2b' }}>current</div>
+                  <div
+                    style={{ fontSize: 11, color: 'var(--app-success-text)' }}
+                  >
+                    current
+                  </div>
                 ) : null}
               </td>
               <td style={cellBody}>
@@ -272,7 +287,9 @@ function BestTeamsTable({ result }: { result?: GetBestTeamsResult }) {
               <td style={cellBody}>
                 <strong>{team.projectedPoints.toFixed(1)}</strong>
                 {team.penalty > 0 ? (
-                  <div style={{ fontSize: 11, color: '#7a2222' }}>
+                  <div
+                    style={{ fontSize: 11, color: 'var(--app-danger-text)' }}
+                  >
                     -{team.penalty} pen
                   </div>
                 ) : null}
@@ -297,9 +314,9 @@ function BestTeamsTable({ result }: { result?: GetBestTeamsResult }) {
       <div
         style={{
           padding: '6px 14px',
-          borderTop: '1px solid #e2e6ee',
+          borderTop: '1px solid var(--app-border)',
           fontSize: 12,
-          color: '#666',
+          color: 'var(--app-muted)',
         }}
       >
         ⭐ captain · ⭐⭐ mega captain · green = required by filter
@@ -313,8 +330,8 @@ const cellHeader: React.CSSProperties = {
   fontWeight: 600,
   fontSize: 12,
   textTransform: 'uppercase',
-  color: '#666',
-  letterSpacing: 0.4,
+  color: 'var(--app-muted)',
+  letterSpacing: 0,
 };
 
 const cellBody: React.CSSProperties = {
@@ -332,7 +349,7 @@ export function useBestTeamsAction() {
     render: ({ status, result }) => {
       if (status === 'inProgress' || status === 'executing') {
         return (
-          <div style={{ padding: 10, color: '#666' }}>
+          <div style={{ padding: 10, color: 'var(--app-muted)' }}>
             Computing best teams…
           </div>
         );
@@ -341,7 +358,9 @@ export function useBestTeamsAction() {
       if (isToolErrorResult(parsed)) {
         return <ToolErrorFallback result={parsed} />;
       }
-      return <BestTeamsTable result={parsed as GetBestTeamsResult | undefined} />;
+      return (
+        <BestTeamsTable result={parsed as GetBestTeamsResult | undefined} />
+      );
     },
   });
 }

--- a/web/src/components/ClearHistoryButton.tsx
+++ b/web/src/components/ClearHistoryButton.tsx
@@ -24,9 +24,9 @@ export function ClearHistoryButton() {
         padding: '6px 12px',
         fontSize: 12,
         fontWeight: 600,
-        color: '#37404f',
-        background: '#f1f3f7',
-        border: '1px solid #d8dde6',
+        color: 'var(--app-control-text)',
+        background: 'var(--app-control-bg)',
+        border: '1px solid var(--app-control-border)',
         borderRadius: 6,
         cursor: 'pointer',
       }}

--- a/web/src/components/CurrentTeamCard.tsx
+++ b/web/src/components/CurrentTeamCard.tsx
@@ -39,16 +39,16 @@ function fmt(value: number | undefined | null, digits = 2): string {
 function CurrentTeamCard({ result }: { result?: CurrentTeamResult }) {
   if (!result || result.status === 'no_teams') {
     return (
-      <div style={{ padding: 12, color: '#555' }}>
-        You don't have a saved team yet. Upload a team screenshot or JSON in
-        the Telegram bot first.
+      <div style={{ padding: 12, color: 'var(--app-muted)' }}>
+        You don't have a saved team yet. Upload a team screenshot or JSON in the
+        Telegram bot first.
       </div>
     );
   }
 
   if (result.status === 'missing_cache') {
     return (
-      <div style={{ padding: 12, color: '#7a1f1f' }}>
+      <div style={{ padding: 12, color: 'var(--app-danger-text)' }}>
         Some of your team data isn't cached yet. Send drivers / constructors /
         current-team images or JSON in the Telegram bot first.
       </div>
@@ -57,7 +57,7 @@ function CurrentTeamCard({ result }: { result?: CurrentTeamResult }) {
 
   if (result.status === 'ambiguous_team') {
     return (
-      <div style={{ padding: 12, color: '#555' }}>
+      <div style={{ padding: 12, color: 'var(--app-muted)' }}>
         You have multiple teams ({result.teamIds?.join(', ') || '—'}). Tell me
         which one to show.
       </div>
@@ -66,7 +66,7 @@ function CurrentTeamCard({ result }: { result?: CurrentTeamResult }) {
 
   if (result.status === 'unknown_team') {
     return (
-      <div style={{ padding: 12, color: '#7a1f1f' }}>
+      <div style={{ padding: 12, color: 'var(--app-danger-text)' }}>
         Couldn't find that team. Available: {result.teamIds?.join(', ') || '—'}.
       </div>
     );
@@ -87,9 +87,9 @@ function CurrentTeamCard({ result }: { result?: CurrentTeamResult }) {
     <div
       style={{
         margin: '8px 0',
-        border: '1px solid #e2e6ee',
+        border: '1px solid var(--app-border)',
         borderRadius: 10,
-        background: '#fff',
+        background: 'var(--app-surface)',
         overflow: 'hidden',
         fontSize: 13,
       }}
@@ -97,8 +97,8 @@ function CurrentTeamCard({ result }: { result?: CurrentTeamResult }) {
       <div
         style={{
           padding: '12px 16px',
-          background: '#f8fafc',
-          borderBottom: '1px solid #e2e6ee',
+          background: 'var(--app-surface-muted)',
+          borderBottom: '1px solid var(--app-border)',
           display: 'flex',
           alignItems: 'baseline',
           flexWrap: 'wrap',
@@ -108,7 +108,7 @@ function CurrentTeamCard({ result }: { result?: CurrentTeamResult }) {
         <strong style={{ fontSize: 15 }}>
           {result.teamName || result.teamId}
         </strong>
-        <span style={{ color: '#7d8693', fontSize: 11 }}>
+        <span style={{ color: 'var(--app-subtle)', fontSize: 11 }}>
           id: <code>{result.teamId}</code>
         </span>
         {result.chip ? (
@@ -116,8 +116,8 @@ function CurrentTeamCard({ result }: { result?: CurrentTeamResult }) {
             style={{
               padding: '2px 8px',
               borderRadius: 999,
-              background: '#fff3c2',
-              color: '#7a5a00',
+              background: 'var(--app-warning-surface)',
+              color: 'var(--app-warning-text)',
               fontWeight: 700,
               fontSize: 11,
             }}
@@ -140,11 +140,15 @@ function CurrentTeamCard({ result }: { result?: CurrentTeamResult }) {
                   padding: '4px 10px',
                   borderRadius: 999,
                   background: isMega
-                    ? '#fff3c2'
+                    ? 'var(--app-warning-surface)'
                     : isCaptain
-                      ? '#eef4ff'
-                      : '#f1f3f7',
-                  color: isMega ? '#7a5a00' : isCaptain ? '#1c4f99' : '#37404f',
+                      ? 'var(--app-primary-surface)'
+                      : 'var(--app-control-bg)',
+                  color: isMega
+                    ? 'var(--app-warning-text)'
+                    : isCaptain
+                      ? 'var(--app-primary)'
+                      : 'var(--app-control-text)',
                   fontWeight: 700,
                   fontSize: 12,
                 }}
@@ -166,8 +170,8 @@ function CurrentTeamCard({ result }: { result?: CurrentTeamResult }) {
               style={{
                 padding: '4px 10px',
                 borderRadius: 999,
-                background: '#f1f3f7',
-                color: '#37404f',
+                background: 'var(--app-control-bg)',
+                color: 'var(--app-control-text)',
                 fontWeight: 700,
                 fontSize: 12,
               }}
@@ -181,7 +185,7 @@ function CurrentTeamCard({ result }: { result?: CurrentTeamResult }) {
       <div
         style={{
           padding: '12px 16px',
-          borderTop: '1px solid #eef0f5',
+          borderTop: '1px solid var(--app-border)',
           display: 'grid',
           gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
           gap: '10px 16px',
@@ -229,20 +233,26 @@ function Metric({
         style={{
           fontSize: 11,
           textTransform: 'uppercase',
-          color: '#7d8693',
-          letterSpacing: 0.4,
+          color: 'var(--app-subtle)',
+          letterSpacing: 0,
         }}
       >
         {label}
       </div>
-      <div style={{ fontSize: 16, fontWeight: 700, color: '#1c3d70' }}>
+      <div
+        style={{
+          fontSize: 16,
+          fontWeight: 700,
+          color: 'var(--app-primary-strong)',
+        }}
+      >
         {value}
         {unit ? (
           <span
             style={{
               fontSize: 11,
               marginLeft: 4,
-              color: '#7d8693',
+              color: 'var(--app-subtle)',
               fontWeight: 500,
             }}
           >
@@ -264,7 +274,7 @@ export function useCurrentTeamAction() {
     render: ({ status, result }) => {
       if (status === 'inProgress' || status === 'executing') {
         return (
-          <div style={{ padding: 10, color: '#666' }}>
+          <div style={{ padding: 10, color: 'var(--app-muted)' }}>
             Loading your current team…
           </div>
         );

--- a/web/src/components/DeadlineCountdown.tsx
+++ b/web/src/components/DeadlineCountdown.tsx
@@ -74,7 +74,7 @@ function DeadlineCountdown({ result }: { result?: DeadlineResult }) {
 
   if (!result || result.status === 'unavailable') {
     return (
-      <div style={{ padding: 12, color: '#555' }}>
+      <div style={{ padding: 12, color: 'var(--app-muted)' }}>
         Next deadline isn't available right now.
       </div>
     );
@@ -99,35 +99,38 @@ function DeadlineCountdown({ result }: { result?: DeadlineResult }) {
     <div
       style={{
         margin: '8px 0',
-        border: '1px solid #e2e6ee',
+        border: '1px solid var(--app-border)',
         borderRadius: 12,
-        background:
-          'linear-gradient(135deg, #fff 0%, #f3f7ff 60%, #e8efff 100%)',
+        background: 'var(--app-deadline-bg)',
         padding: '16px 18px',
         fontSize: 13,
       }}
     >
-      <div style={{ fontWeight: 700, fontSize: 14, color: '#1c3d70' }}>
+      <div
+        style={{
+          fontWeight: 700,
+          fontSize: 14,
+          color: 'var(--app-primary-strong)',
+        }}
+      >
         Teams lock deadline
       </div>
-      <div style={{ marginTop: 4, color: '#37404f' }}>
+      <div style={{ marginTop: 4, color: 'var(--app-control-text)' }}>
         Race: <strong>{result.raceName ?? '—'}</strong>
       </div>
-      <div style={{ color: '#37404f', marginBottom: 12 }}>
+      <div style={{ color: 'var(--app-control-text)', marginBottom: 12 }}>
         Locks at start of <strong>{sessionLabel}</strong>
-        {sessionStartsAt
-          ? ` · ${formatSessionStart(sessionStartsAt)}`
-          : ''}
+        {sessionStartsAt ? ` · ${formatSessionStart(sessionStartsAt)}` : ''}
       </div>
 
       {hasStarted ? (
         <div
           style={{
             padding: '12px 14px',
-            background: '#fff5f5',
-            border: '1px solid #f3c4c4',
+            background: 'var(--app-danger-surface)',
+            border: '1px solid var(--app-danger-border)',
             borderRadius: 8,
-            color: '#7a1f1f',
+            color: 'var(--app-danger-text)',
             fontWeight: 600,
           }}
         >
@@ -148,7 +151,7 @@ function DeadlineCountdown({ result }: { result?: DeadlineResult }) {
         </div>
       )}
 
-      <div style={{ marginTop: 10, color: '#5a6471', fontSize: 12 }}>
+      <div style={{ marginTop: 10, color: 'var(--app-muted)', fontSize: 12 }}>
         Don't forget to lock your team before then.
       </div>
     </div>
@@ -165,22 +168,28 @@ function CountdownCell({
   return (
     <div
       style={{
-        background: '#fff',
-        border: '1px solid #d6e0f0',
+        background: 'var(--app-surface)',
+        border: '1px solid var(--app-border)',
         borderRadius: 8,
         textAlign: 'center',
         padding: '10px 6px',
       }}
     >
-      <div style={{ fontSize: 24, fontWeight: 800, color: '#1c3d70' }}>
+      <div
+        style={{
+          fontSize: 24,
+          fontWeight: 800,
+          color: 'var(--app-primary-strong)',
+        }}
+      >
         {value}
       </div>
       <div
         style={{
           fontSize: 11,
-          color: '#5a6471',
+          color: 'var(--app-muted)',
           textTransform: 'uppercase',
-          letterSpacing: 0.6,
+          letterSpacing: 0,
           marginTop: 2,
         }}
       >
@@ -200,7 +209,9 @@ export function useDeadlineCountdownAction() {
     render: ({ status, result }) => {
       if (status === 'inProgress' || status === 'executing') {
         return (
-          <div style={{ padding: 10, color: '#666' }}>Loading deadline…</div>
+          <div style={{ padding: 10, color: 'var(--app-muted)' }}>
+            Loading deadline…
+          </div>
         );
       }
       const parsed = typeof result === 'string' ? safeParse(result) : result;

--- a/web/src/components/FollowedTeamsGrid.tsx
+++ b/web/src/components/FollowedTeamsGrid.tsx
@@ -23,16 +23,30 @@ function positionStyle(position: number | null): {
   background: string;
   color: string;
 } {
-  if (position === 1) return { background: '#fff3c2', color: '#7a5a00' };
+  if (position === 1)
+    return {
+      background: 'var(--app-warning-surface)',
+      color: 'var(--app-warning-text)',
+    };
   if (position && position <= 3)
-    return { background: '#e6f1ff', color: '#0b3e88' };
-  return { background: '#f1f3f7', color: '#37404f' };
+    return {
+      background: 'var(--app-primary-surface)',
+      color: 'var(--app-primary-strong)',
+    };
+  return {
+    background: 'var(--app-control-bg)',
+    color: 'var(--app-control-text)',
+  };
 }
 
 function FollowedTeamsGrid({ result }: { result?: ListFollowedTeamsResult }) {
-  if (result?.status === 'empty' || !result?.teams || result.teams.length === 0) {
+  if (
+    result?.status === 'empty' ||
+    !result?.teams ||
+    result.teams.length === 0
+  ) {
     return (
-      <div style={{ padding: 12, color: '#555' }}>
+      <div style={{ padding: 12, color: 'var(--app-muted)' }}>
         No tracked league teams yet. Run <code>/follow_league</code> +{' '}
         <code>/teams_tracker</code> in the Telegram bot first.
       </div>
@@ -52,10 +66,12 @@ function FollowedTeamsGrid({ result }: { result?: ListFollowedTeamsResult }) {
         <div
           key={team.teamId}
           style={{
-            border: team.isSelected ? '2px solid #2c6fd1' : '1px solid #e2e6ee',
+            border: team.isSelected
+              ? '2px solid var(--app-primary)'
+              : '1px solid var(--app-border)',
             borderRadius: 10,
             padding: '12px 14px',
-            background: '#fff',
+            background: 'var(--app-surface)',
             fontSize: 13,
           }}
         >
@@ -72,16 +88,18 @@ function FollowedTeamsGrid({ result }: { result?: ListFollowedTeamsResult }) {
               <span
                 style={{
                   fontSize: 11,
-                  color: '#1c4f99',
+                  color: 'var(--app-primary)',
                   fontWeight: 700,
-                  letterSpacing: 0.3,
+                  letterSpacing: 0,
                 }}
               >
                 ACTIVE
               </span>
             ) : null}
           </div>
-          <div style={{ color: '#7d8693', fontSize: 11, marginTop: 2 }}>
+          <div
+            style={{ color: 'var(--app-subtle)', fontSize: 11, marginTop: 2 }}
+          >
             id: <code>{team.teamId}</code>
           </div>
           <div
@@ -93,7 +111,7 @@ function FollowedTeamsGrid({ result }: { result?: ListFollowedTeamsResult }) {
             }}
           >
             {team.leagues.length === 0 ? (
-              <div style={{ color: '#888', fontSize: 12 }}>
+              <div style={{ color: 'var(--app-subtle)', fontSize: 12 }}>
                 (no leagues resolved for this team)
               </div>
             ) : (
@@ -110,7 +128,9 @@ function FollowedTeamsGrid({ result }: { result?: ListFollowedTeamsResult }) {
                       gap: 8,
                     }}
                   >
-                    <span style={{ color: '#37404f' }}>{row.leagueName}</span>
+                    <span style={{ color: 'var(--app-control-text)' }}>
+                      {row.leagueName}
+                    </span>
                     <span
                       style={{
                         padding: '2px 8px',
@@ -139,13 +159,13 @@ export function useFollowedTeamsAction() {
   useCopilotAction({
     name: 'list_followed_teams',
     description:
-      'List the user\'s followed F1 Fantasy teams enriched with each league they appear in and their current position.',
+      "List the user's followed F1 Fantasy teams enriched with each league they appear in and their current position.",
     parameters: [],
     available: 'frontend',
     render: ({ status, result }) => {
       if (status === 'inProgress' || status === 'executing') {
         return (
-          <div style={{ padding: 10, color: '#666' }}>
+          <div style={{ padding: 10, color: 'var(--app-muted)' }}>
             Loading your tracked teams…
           </div>
         );

--- a/web/src/components/LeaderboardTable.tsx
+++ b/web/src/components/LeaderboardTable.tsx
@@ -48,7 +48,7 @@ function LeaderboardTable({ result }: { result?: LeaderboardResult }) {
 
   if (result.status === 'not_followed') {
     return (
-      <div style={{ padding: 12, color: '#7a4a00' }}>
+      <div style={{ padding: 12, color: 'var(--app-warning-text)' }}>
         You don't follow league <code>{result.leagueCode}</code>. Run{' '}
         <code>/follow_league</code> in the Telegram bot first.
       </div>
@@ -57,7 +57,7 @@ function LeaderboardTable({ result }: { result?: LeaderboardResult }) {
 
   if (result.status === 'not_found') {
     return (
-      <div style={{ padding: 12, color: '#7a4a00' }}>
+      <div style={{ padding: 12, color: 'var(--app-warning-text)' }}>
         No standings available yet for league <code>{result.leagueCode}</code>.
         Try again after the next scrape.
       </div>
@@ -66,7 +66,7 @@ function LeaderboardTable({ result }: { result?: LeaderboardResult }) {
 
   if (result.status === 'invalid_input') {
     return (
-      <div style={{ padding: 12, color: '#a32020' }}>
+      <div style={{ padding: 12, color: 'var(--app-danger-text)' }}>
         Invalid league code.
       </div>
     );
@@ -75,7 +75,7 @@ function LeaderboardTable({ result }: { result?: LeaderboardResult }) {
   const rows = result.standings ?? [];
   if (rows.length === 0) {
     return (
-      <div style={{ padding: 12, color: '#555' }}>
+      <div style={{ padding: 12, color: 'var(--app-muted)' }}>
         No teams in <strong>{result.leagueName}</strong> yet.
       </div>
     );
@@ -87,23 +87,25 @@ function LeaderboardTable({ result }: { result?: LeaderboardResult }) {
     <div
       style={{
         margin: '8px 0',
-        border: '1px solid #e2e6ee',
+        border: '1px solid var(--app-border)',
         borderRadius: 10,
-        background: '#fff',
+        background: 'var(--app-surface)',
         overflow: 'hidden',
       }}
     >
       <div
         style={{
           padding: '10px 14px',
-          background: '#f6f8fb',
-          borderBottom: '1px solid #e2e6ee',
+          background: 'var(--app-surface-muted)',
+          borderBottom: '1px solid var(--app-border)',
         }}
       >
-        <div style={{ fontWeight: 700, fontSize: 14, color: '#1f2937' }}>
+        <div
+          style={{ fontWeight: 700, fontSize: 14, color: 'var(--app-text)' }}
+        >
           🏆 {result.leagueName ?? result.leagueCode}
         </div>
-        <div style={{ color: '#7d8693', fontSize: 11, marginTop: 2 }}>
+        <div style={{ color: 'var(--app-subtle)', fontSize: 11, marginTop: 2 }}>
           {result.memberCount ?? rows.length} teams
           {fetchedAt ? ` · updated ${fetchedAt}` : ''}
         </div>
@@ -113,11 +115,16 @@ function LeaderboardTable({ result }: { result?: LeaderboardResult }) {
           width: '100%',
           borderCollapse: 'collapse',
           fontSize: 13,
-          color: '#1f2937',
+          color: 'var(--app-text)',
         }}
       >
         <thead>
-          <tr style={{ background: '#fafbfd', textAlign: 'left' }}>
+          <tr
+            style={{
+              background: 'var(--app-surface-subtle)',
+              textAlign: 'left',
+            }}
+          >
             <th style={{ padding: '6px 12px', width: 50 }}>#</th>
             <th style={{ padding: '6px 12px' }}>Team</th>
             <th style={{ padding: '6px 12px', textAlign: 'right', width: 90 }}>
@@ -135,12 +142,14 @@ function LeaderboardTable({ result }: { result?: LeaderboardResult }) {
               <tr
                 key={row.teamId ?? `${row.teamName}-${idx}`}
                 style={{
-                  background: highlight ? '#fff8d6' : 'transparent',
+                  background: highlight
+                    ? 'var(--app-highlight-surface)'
+                    : 'transparent',
                   fontWeight: highlight ? 700 : 400,
-                  borderTop: idx === 0 ? 'none' : '1px solid #f0f2f6',
+                  borderTop: idx === 0 ? 'none' : '1px solid var(--app-border)',
                 }}
               >
-                <td style={{ padding: '6px 12px', color: '#7d8693' }}>
+                <td style={{ padding: '6px 12px', color: 'var(--app-subtle)' }}>
                   {row.position ?? '—'}
                 </td>
                 <td style={{ padding: '6px 12px' }}>{row.teamName}</td>
@@ -157,7 +166,7 @@ function LeaderboardTable({ result }: { result?: LeaderboardResult }) {
                   style={{
                     padding: '6px 12px',
                     textAlign: 'right',
-                    color: '#7d8693',
+                    color: 'var(--app-subtle)',
                     fontVariantNumeric: 'tabular-nums',
                   }}
                 >
@@ -176,13 +185,13 @@ export function useLeaderboardAction() {
   useCopilotAction({
     name: 'get_leaderboard',
     description:
-      'Show the standings for one of the user\'s followed F1 Fantasy leagues.',
+      "Show the standings for one of the user's followed F1 Fantasy leagues.",
     parameters: [],
     available: 'frontend',
     render: ({ status, result }) => {
       if (status === 'inProgress' || status === 'executing') {
         return (
-          <div style={{ padding: 10, color: '#666' }}>
+          <div style={{ padding: 10, color: 'var(--app-muted)' }}>
             Loading league standings…
           </div>
         );

--- a/web/src/components/LiveScoreBreakdown.tsx
+++ b/web/src/components/LiveScoreBreakdown.tsx
@@ -109,10 +109,12 @@ function MemberCard({
   return (
     <div
       style={{
-        border: '1px solid #eef0f5',
+        border: '1px solid var(--app-border)',
         borderRadius: 8,
         padding: '10px 12px',
-        background: member.missing ? '#fff5f5' : '#fafbfd',
+        background: member.missing
+          ? 'var(--app-danger-surface)'
+          : 'var(--app-surface-subtle)',
       }}
     >
       <div
@@ -133,8 +135,8 @@ function MemberCard({
               fontSize: 11,
               padding: '1px 6px',
               borderRadius: 999,
-              background: '#fff3c2',
-              color: '#7a5a00',
+              background: 'var(--app-warning-surface)',
+              color: 'var(--app-warning-text)',
               fontWeight: 700,
             }}
           >
@@ -146,24 +148,36 @@ function MemberCard({
               fontSize: 11,
               padding: '1px 6px',
               borderRadius: 999,
-              background: '#eef4ff',
-              color: '#1c4f99',
+              background: 'var(--app-primary-surface)',
+              color: 'var(--app-primary)',
               fontWeight: 700,
             }}
           >
             x2
           </span>
         ) : null}
-        <span style={{ marginLeft: 'auto', fontWeight: 700, color: '#1c3d70' }}>
+        <span
+          style={{
+            marginLeft: 'auto',
+            fontWeight: 700,
+            color: 'var(--app-primary-strong)',
+          }}
+        >
           {formatNumber(effective)} pts
         </span>
       </div>
-      <div style={{ fontSize: 12, color: '#5a6471' }}>
+      <div style={{ fontSize: 12, color: 'var(--app-muted)' }}>
         Δ {formatSigned(member.priceChange)}
         {member.missing ? ' · ⚠️ no live data yet' : ''}
       </div>
       {sessionLines.length > 0 ? (
-        <div style={{ marginTop: 6, fontSize: 12, color: '#37404f' }}>
+        <div
+          style={{
+            marginTop: 6,
+            fontSize: 12,
+            color: 'var(--app-control-text)',
+          }}
+        >
           {sessionLines.map((s) => (
             <div key={s.label}>
               <strong>{s.label}:</strong> {s.metrics.join(', ')}
@@ -178,14 +192,14 @@ function MemberCard({
 function LiveScoreBreakdown({ result }: { result?: LiveScoreTeamResult }) {
   if (!result || result.status === 'invalid_input') {
     return (
-      <div style={{ padding: 12, color: '#555' }}>
+      <div style={{ padding: 12, color: 'var(--app-muted)' }}>
         Live-score request was missing data. Tell me which league.
       </div>
     );
   }
   if (result.status === 'not_followed') {
     return (
-      <div style={{ padding: 12, color: '#7a1f1f' }}>
+      <div style={{ padding: 12, color: 'var(--app-danger-text)' }}>
         You don't follow that league. Run <code>/follow_league</code> in
         Telegram first.
       </div>
@@ -193,15 +207,15 @@ function LiveScoreBreakdown({ result }: { result?: LiveScoreTeamResult }) {
   }
   if (result.status === 'not_found') {
     return (
-      <div style={{ padding: 12, color: '#555' }}>
-        No locked roster snapshot for this league yet. Wait for the next
-        session lock.
+      <div style={{ padding: 12, color: 'var(--app-muted)' }}>
+        No locked roster snapshot for this league yet. Wait for the next session
+        lock.
       </div>
     );
   }
   if (result.status === 'team_not_found') {
     return (
-      <div style={{ padding: 12, color: '#7a1f1f' }}>
+      <div style={{ padding: 12, color: 'var(--app-danger-text)' }}>
         Couldn't match that team. Try one of:{' '}
         {(result.availableTeams || [])
           .map((t) => t.teamName || t.userName)
@@ -221,9 +235,9 @@ function LiveScoreBreakdown({ result }: { result?: LiveScoreTeamResult }) {
     <div
       style={{
         margin: '8px 0',
-        border: '1px solid #e2e6ee',
+        border: '1px solid var(--app-border)',
         borderRadius: 10,
-        background: '#fff',
+        background: 'var(--app-surface)',
         overflow: 'hidden',
         fontSize: 13,
       }}
@@ -231,15 +245,15 @@ function LiveScoreBreakdown({ result }: { result?: LiveScoreTeamResult }) {
       <div
         style={{
           padding: '12px 16px',
-          background: '#f8fafc',
-          borderBottom: '1px solid #e2e6ee',
+          background: 'var(--app-surface-muted)',
+          borderBottom: '1px solid var(--app-border)',
         }}
       >
         <div style={{ fontWeight: 700, fontSize: 15 }}>
           🏎️ Live score — {result.leagueName ?? result.leagueCode} ·{' '}
           {result.teamName}
         </div>
-        <div style={{ color: '#5a6471', marginTop: 2, fontSize: 12 }}>
+        <div style={{ color: 'var(--app-muted)', marginTop: 2, fontSize: 12 }}>
           Matchday {result.matchdayId ?? '?'} · updated{' '}
           {formatExtractedAt(result.extractedAt)}
         </div>
@@ -252,17 +266,23 @@ function LiveScoreBreakdown({ result }: { result?: LiveScoreTeamResult }) {
               style={{
                 fontSize: 11,
                 textTransform: 'uppercase',
-                color: '#7d8693',
+                color: 'var(--app-subtle)',
               }}
             >
               Total live points
             </div>
-            <div style={{ fontSize: 26, fontWeight: 800, color: '#1c3d70' }}>
+            <div
+              style={{
+                fontSize: 26,
+                fontWeight: 800,
+                color: 'var(--app-primary-strong)',
+              }}
+            >
               {formatNumber(breakdown.totalPoints)}
             </div>
             {typeof breakdown.transferPenalty === 'number' &&
             breakdown.transferPenalty > 0 ? (
-              <div style={{ fontSize: 12, color: '#7a1f1f' }}>
+              <div style={{ fontSize: 12, color: 'var(--app-danger-text)' }}>
                 Transfer penalty: -{breakdown.transferPenalty.toFixed(2)} (
                 pre-penalty {formatNumber(breakdown.pointsBeforePenalty)})
               </div>
@@ -273,12 +293,18 @@ function LiveScoreBreakdown({ result }: { result?: LiveScoreTeamResult }) {
               style={{
                 fontSize: 11,
                 textTransform: 'uppercase',
-                color: '#7d8693',
+                color: 'var(--app-subtle)',
               }}
             >
               Live price Δ
             </div>
-            <div style={{ fontSize: 18, fontWeight: 700, color: '#1c3d70' }}>
+            <div
+              style={{
+                fontSize: 18,
+                fontWeight: 700,
+                color: 'var(--app-primary-strong)',
+              }}
+            >
               {formatSigned(breakdown.totalPriceChange)}
             </div>
           </div>
@@ -287,8 +313,8 @@ function LiveScoreBreakdown({ result }: { result?: LiveScoreTeamResult }) {
               style={{
                 padding: '4px 10px',
                 borderRadius: 999,
-                background: '#eef4ff',
-                color: '#1c4f99',
+                background: 'var(--app-primary-surface)',
+                color: 'var(--app-primary)',
                 fontWeight: 700,
                 fontSize: 12,
                 alignSelf: 'center',
@@ -340,10 +366,10 @@ function LiveScoreBreakdown({ result }: { result?: LiveScoreTeamResult }) {
         <div
           style={{
             padding: '8px 16px',
-            background: '#fff5f5',
-            color: '#7a1f1f',
+            background: 'var(--app-danger-surface)',
+            color: 'var(--app-danger-text)',
             fontSize: 12,
-            borderTop: '1px solid #f3c4c4',
+            borderTop: '1px solid var(--app-danger-border)',
           }}
         >
           ⚠️ Missing live data: {breakdown.missingMembers.join(', ')}
@@ -362,7 +388,7 @@ export function useLiveScoreBreakdownAction() {
     render: ({ status, result }) => {
       if (status === 'inProgress' || status === 'executing') {
         return (
-          <div style={{ padding: 10, color: '#666' }}>
+          <div style={{ padding: 10, color: 'var(--app-muted)' }}>
             Loading live score…
           </div>
         );

--- a/web/src/components/LiveScoreLeaderboard.tsx
+++ b/web/src/components/LiveScoreLeaderboard.tsx
@@ -49,14 +49,14 @@ function LiveScoreLeaderboard({
 }) {
   if (!result || result.status === 'invalid_input') {
     return (
-      <div style={{ padding: 12, color: '#555' }}>
+      <div style={{ padding: 12, color: 'var(--app-muted)' }}>
         Live-score request was missing data. Tell me which league.
       </div>
     );
   }
   if (result.status === 'not_followed') {
     return (
-      <div style={{ padding: 12, color: '#7a1f1f' }}>
+      <div style={{ padding: 12, color: 'var(--app-danger-text)' }}>
         You don't follow that league. Run <code>/follow_league</code> in
         Telegram first.
       </div>
@@ -64,9 +64,9 @@ function LiveScoreLeaderboard({
   }
   if (result.status === 'not_found') {
     return (
-      <div style={{ padding: 12, color: '#555' }}>
-        No locked roster snapshot for this league yet. Wait for the next
-        session lock.
+      <div style={{ padding: 12, color: 'var(--app-muted)' }}>
+        No locked roster snapshot for this league yet. Wait for the next session
+        lock.
       </div>
     );
   }
@@ -81,9 +81,9 @@ function LiveScoreLeaderboard({
     <div
       style={{
         margin: '8px 0',
-        border: '1px solid #e2e6ee',
+        border: '1px solid var(--app-border)',
         borderRadius: 10,
-        background: '#fff',
+        background: 'var(--app-surface)',
         overflow: 'hidden',
         fontSize: 13,
       }}
@@ -91,14 +91,14 @@ function LiveScoreLeaderboard({
       <div
         style={{
           padding: '12px 16px',
-          background: '#f8fafc',
-          borderBottom: '1px solid #e2e6ee',
+          background: 'var(--app-surface-muted)',
+          borderBottom: '1px solid var(--app-border)',
         }}
       >
         <div style={{ fontWeight: 700, fontSize: 15 }}>
           🏎️ Live leaderboard — {result.leagueName ?? result.leagueCode}
         </div>
-        <div style={{ color: '#5a6471', marginTop: 2, fontSize: 12 }}>
+        <div style={{ color: 'var(--app-muted)', marginTop: 2, fontSize: 12 }}>
           Matchday {result.matchdayId ?? '?'} · updated{' '}
           {formatExtractedAt(result.extractedAt)} · {rows.length} team
           {rows.length === 1 ? '' : 's'}
@@ -106,13 +106,18 @@ function LiveScoreLeaderboard({
       </div>
 
       {rows.length === 0 ? (
-        <div style={{ padding: 12, color: '#555' }}>
+        <div style={{ padding: 12, color: 'var(--app-muted)' }}>
           No teams in this league yet.
         </div>
       ) : (
         <table style={{ width: '100%', borderCollapse: 'collapse' }}>
           <thead>
-            <tr style={{ background: '#fafbfd', textAlign: 'left' }}>
+            <tr
+              style={{
+                background: 'var(--app-surface-subtle)',
+                textAlign: 'left',
+              }}
+            >
               <th style={cellHeader}>#</th>
               <th style={cellHeader}>Team</th>
               <th style={{ ...cellHeader, textAlign: 'right' }}>Live pts</th>
@@ -124,8 +129,10 @@ function LiveScoreLeaderboard({
               <tr
                 key={row.teamId || `${row.userName}-${row.teamNo}`}
                 style={{
-                  borderTop: '1px solid #f0f2f7',
-                  background: row.isSelected ? '#eef4ff' : 'transparent',
+                  borderTop: '1px solid var(--app-border)',
+                  background: row.isSelected
+                    ? 'var(--app-primary-surface)'
+                    : 'transparent',
                   fontWeight: row.isSelected ? 700 : 500,
                 }}
               >
@@ -136,7 +143,7 @@ function LiveScoreLeaderboard({
                   row.transferPenalty > 0 ? (
                     <span
                       title={`Transfer penalty: -${row.transferPenalty}`}
-                      style={{ color: '#7a1f1f', marginLeft: 4 }}
+                      style={{ color: 'var(--app-danger-text)', marginLeft: 4 }}
                     >
                       †
                     </span>
@@ -146,8 +153,8 @@ function LiveScoreLeaderboard({
                       style={{
                         marginLeft: 6,
                         fontSize: 10,
-                        color: '#1c4f99',
-                        letterSpacing: 0.4,
+                        color: 'var(--app-primary)',
+                        letterSpacing: 0,
                       }}
                     >
                       YOU
@@ -159,7 +166,13 @@ function LiveScoreLeaderboard({
                     ? row.totalPoints.toFixed(2)
                     : '—'}
                 </td>
-                <td style={{ ...cellBody, textAlign: 'right', color: '#5a6471' }}>
+                <td
+                  style={{
+                    ...cellBody,
+                    textAlign: 'right',
+                    color: 'var(--app-muted)',
+                  }}
+                >
                   {formatSigned(row.totalPriceChange)}
                 </td>
               </tr>
@@ -172,9 +185,9 @@ function LiveScoreLeaderboard({
         <div
           style={{
             padding: '8px 16px',
-            color: '#5a6471',
+            color: 'var(--app-muted)',
             fontStyle: 'italic',
-            borderTop: '1px solid #eef0f5',
+            borderTop: '1px solid var(--app-border)',
             fontSize: 12,
           }}
         >
@@ -190,8 +203,8 @@ const cellHeader: React.CSSProperties = {
   fontWeight: 600,
   fontSize: 11,
   textTransform: 'uppercase',
-  color: '#666',
-  letterSpacing: 0.4,
+  color: 'var(--app-muted)',
+  letterSpacing: 0,
 };
 
 const cellBody: React.CSSProperties = {
@@ -208,7 +221,7 @@ export function useLiveScoreLeaderboardAction() {
     render: ({ status, result }) => {
       if (status === 'inProgress' || status === 'executing') {
         return (
-          <div style={{ padding: 10, color: '#666' }}>
+          <div style={{ padding: 10, color: 'var(--app-muted)' }}>
             Loading live leaderboard…
           </div>
         );

--- a/web/src/components/LoginScreen.tsx
+++ b/web/src/components/LoginScreen.tsx
@@ -6,6 +6,8 @@
 
 import { GoogleLogin } from '@react-oauth/google';
 import { useAuth } from '../auth/AuthContext';
+import { ThemeToggle } from './ThemeToggle';
+import type { ThemeMode } from '../theme';
 
 const REJECTION_MESSAGES: Record<string, string> = {
   email_not_allowlisted:
@@ -30,7 +32,13 @@ function formatRejection(rejection: {
   return base;
 }
 
-export function LoginScreen() {
+export function LoginScreen({
+  theme,
+  onToggleTheme,
+}: {
+  theme?: ThemeMode;
+  onToggleTheme?: () => void;
+}) {
   const { signIn, rejection, setRejection } = useAuth();
 
   return (
@@ -41,18 +49,24 @@ export function LoginScreen() {
         alignItems: 'center',
         justifyContent: 'center',
         minHeight: '60vh',
+        position: 'relative',
         gap: 24,
         padding: '32px 16px',
         textAlign: 'center',
       }}
     >
+      {theme && onToggleTheme ? (
+        <div className="login-theme-control">
+          <ThemeToggle theme={theme} onToggle={onToggleTheme} />
+        </div>
+      ) : null}
       <div style={{ maxWidth: 420 }}>
         <h1
           style={{
             margin: '0 0 12px',
             fontSize: 28,
             fontWeight: 700,
-            color: '#1a1a1a',
+            color: 'var(--app-text)',
           }}
         >
           🏎️ F1 Fantasy Agent
@@ -61,12 +75,12 @@ export function LoginScreen() {
           style={{
             margin: 0,
             fontSize: 15,
-            color: '#444',
+            color: 'var(--app-muted)',
             lineHeight: 1.45,
           }}
         >
-          Sign in with Google to chat with the agent. Access is invitation
-          only — ask the admin on Telegram if you'd like to be allowlisted.
+          Sign in with Google to chat with the agent. Access is invitation only
+          — ask the admin on Telegram if you'd like to be allowlisted.
         </p>
       </div>
 
@@ -76,10 +90,10 @@ export function LoginScreen() {
           style={{
             maxWidth: 420,
             padding: '12px 16px',
-            background: '#fff4f4',
-            border: '1px solid #f5c2c2',
+            background: 'var(--app-danger-surface)',
+            border: '1px solid var(--app-danger-border)',
             borderRadius: 8,
-            color: '#7a1f1f',
+            color: 'var(--app-danger-text)',
             fontSize: 13,
             lineHeight: 1.45,
           }}
@@ -91,9 +105,10 @@ export function LoginScreen() {
       <div
         style={{
           padding: 24,
-          background: '#fff',
+          background: 'var(--app-surface)',
+          border: '1px solid var(--app-border)',
           borderRadius: 12,
-          boxShadow: '0 2px 8px rgba(0,0,0,0.06)',
+          boxShadow: 'var(--app-shadow)',
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',

--- a/web/src/components/NextRacesTable.tsx
+++ b/web/src/components/NextRacesTable.tsx
@@ -42,7 +42,7 @@ function formatRaceDate(race: Race): string {
 function NextRacesTable({ result }: { result?: NextRacesResult }) {
   if (!result || !result.races || result.races.length === 0) {
     return (
-      <div style={{ padding: 12, color: '#555' }}>
+      <div style={{ padding: 12, color: 'var(--app-muted)' }}>
         No upcoming races found.
       </div>
     );
@@ -54,25 +54,32 @@ function NextRacesTable({ result }: { result?: NextRacesResult }) {
     <div
       style={{
         margin: '8px 0',
-        border: '1px solid #e2e6ee',
+        border: '1px solid var(--app-border)',
         borderRadius: 8,
-        background: '#fff',
+        background: 'var(--app-surface)',
         overflow: 'hidden',
       }}
     >
       <div
         style={{
           padding: '10px 14px',
-          borderBottom: '1px solid #e2e6ee',
-          background: '#f8fafc',
+          borderBottom: '1px solid var(--app-border)',
+          background: 'var(--app-surface-muted)',
           fontWeight: 600,
         }}
       >
         Upcoming Races{season ? ` — ${season}` : ''}
       </div>
-      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
+      <table
+        style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}
+      >
         <thead>
-          <tr style={{ background: '#fafbfd', textAlign: 'left' }}>
+          <tr
+            style={{
+              background: 'var(--app-surface-subtle)',
+              textAlign: 'left',
+            }}
+          >
             <th style={cellHeader}>Rd</th>
             <th style={cellHeader}>Race</th>
             <th style={cellHeader}>Country</th>
@@ -87,7 +94,10 @@ function NextRacesTable({ result }: { result?: NextRacesResult }) {
             const circuit = race.Circuit?.circuitName ?? '';
             const isSprint = Boolean(race.Sprint);
             return (
-              <tr key={race.round} style={{ borderTop: '1px solid #f0f2f7' }}>
+              <tr
+                key={race.round}
+                style={{ borderTop: '1px solid var(--app-border)' }}
+              >
                 <td style={cellBody}>{race.round}</td>
                 <td style={cellBody}>{race.raceName}</td>
                 <td style={cellBody}>{country || '—'}</td>
@@ -105,9 +115,9 @@ function NextRacesTable({ result }: { result?: NextRacesResult }) {
         <div
           style={{
             padding: '8px 14px',
-            borderTop: '1px solid #e2e6ee',
+            borderTop: '1px solid var(--app-border)',
             fontSize: 13,
-            color: '#555',
+            color: 'var(--app-muted)',
           }}
         >
           {counts.total ?? races.length} race
@@ -126,8 +136,8 @@ const cellHeader: React.CSSProperties = {
   fontWeight: 600,
   fontSize: 12,
   textTransform: 'uppercase',
-  color: '#666',
-  letterSpacing: 0.4,
+  color: 'var(--app-muted)',
+  letterSpacing: 0,
 };
 
 const cellBody: React.CSSProperties = {
@@ -153,7 +163,7 @@ export function useNextRacesAction() {
     render: ({ status, result }) => {
       if (status === 'inProgress' || status === 'executing') {
         return (
-          <div style={{ padding: 10, color: '#666' }}>
+          <div style={{ padding: 10, color: 'var(--app-muted)' }}>
             Loading upcoming races…
           </div>
         );

--- a/web/src/components/RaceInfoCard.tsx
+++ b/web/src/components/RaceInfoCard.tsx
@@ -87,14 +87,14 @@ function WeatherChip({
         gap: 4,
         padding: '4px 8px',
         borderRadius: 999,
-        background: '#eef4ff',
-        color: '#1c3d70',
+        background: 'var(--app-primary-surface)',
+        color: 'var(--app-primary-strong)',
         fontSize: 12,
         fontWeight: 600,
       }}
     >
       <span>{label}</span>
-      <span style={{ color: '#3b5d8e' }}>·</span>
+      <span style={{ color: 'var(--app-primary)' }}>·</span>
       <span>🌡 {entry.temperature}°C</span>
       <span>🌧 {entry.precipitation ?? 0}%</span>
       <span>💨 {entry.wind ?? 0} km/h</span>
@@ -105,7 +105,7 @@ function WeatherChip({
 function RaceInfoCard({ result }: { result?: RaceInfoResult }) {
   if (!result || result.status === 'unavailable') {
     return (
-      <div style={{ padding: 12, color: '#555' }}>
+      <div style={{ padding: 12, color: 'var(--app-muted)' }}>
         Race information isn't available right now. Try again in a moment.
       </div>
     );
@@ -123,9 +123,9 @@ function RaceInfoCard({ result }: { result?: RaceInfoResult }) {
     <div
       style={{
         margin: '8px 0',
-        border: '1px solid #e2e6ee',
+        border: '1px solid var(--app-border)',
         borderRadius: 10,
-        background: '#fff',
+        background: 'var(--app-surface)',
         overflow: 'hidden',
         fontSize: 13,
       }}
@@ -133,12 +133,12 @@ function RaceInfoCard({ result }: { result?: RaceInfoResult }) {
       <div
         style={{
           padding: '12px 16px',
-          background: '#f8fafc',
-          borderBottom: '1px solid #e2e6ee',
+          background: 'var(--app-surface-muted)',
+          borderBottom: '1px solid var(--app-border)',
         }}
       >
         <div style={{ fontWeight: 700, fontSize: 16 }}>{result.raceName}</div>
-        <div style={{ color: '#5a6471', marginTop: 2 }}>
+        <div style={{ color: 'var(--app-muted)', marginTop: 2 }}>
           {result.circuitName}
           {result.location
             ? ` · ${result.location.locality}, ${result.location.country}`
@@ -159,7 +159,7 @@ function RaceInfoCard({ result }: { result?: RaceInfoResult }) {
               maxHeight: 260,
               objectFit: 'contain',
               borderRadius: 6,
-              border: '1px solid #eef0f5',
+              border: '1px solid var(--app-border)',
             }}
           />
         </div>
@@ -176,19 +176,19 @@ function RaceInfoCard({ result }: { result?: RaceInfoResult }) {
         >
           {isSprint && sessions.sprintQualifying ? (
             <>
-              <div style={{ color: '#5a6471' }}>Sprint Qualifying</div>
+              <div style={{ color: 'var(--app-muted)' }}>Sprint Qualifying</div>
               <div>{formatIso(sessions.sprintQualifying)}</div>
             </>
           ) : null}
           {isSprint && sessions.sprint ? (
             <>
-              <div style={{ color: '#5a6471' }}>Sprint</div>
+              <div style={{ color: 'var(--app-muted)' }}>Sprint</div>
               <div>{formatIso(sessions.sprint)}</div>
             </>
           ) : null}
-          <div style={{ color: '#5a6471' }}>Qualifying</div>
+          <div style={{ color: 'var(--app-muted)' }}>Qualifying</div>
           <div>{formatIso(sessions.qualifying)}</div>
-          <div style={{ color: '#5a6471' }}>Race</div>
+          <div style={{ color: 'var(--app-muted)' }}>Race</div>
           <div>{formatIso(sessions.race)}</div>
         </div>
         {/* TODO: surface FP1/FP2/FP3 once nextRaceInfoCache tracks them. */}
@@ -228,28 +228,31 @@ function RaceInfoCard({ result }: { result?: RaceInfoResult }) {
             }}
           >
             <thead>
-              <tr style={{ background: '#fafbfd', textAlign: 'left' }}>
+              <tr
+                style={{
+                  background: 'var(--app-surface-subtle)',
+                  textAlign: 'left',
+                }}
+              >
                 <th style={cellHeader}>Year</th>
                 <th style={cellHeader}>Pole</th>
                 <th style={cellHeader}>Winner</th>
                 <th style={cellHeader}>2nd</th>
                 <th style={cellHeader}>3rd</th>
-                <th style={{ ...cellHeader, textAlign: 'center' }}>
-                  Finished
-                </th>
+                <th style={{ ...cellHeader, textAlign: 'center' }}>Finished</th>
               </tr>
             </thead>
             <tbody>
               {stats.map((row) => (
                 <tr
                   key={String(row.season)}
-                  style={{ borderTop: '1px solid #f0f2f7' }}
+                  style={{ borderTop: '1px solid var(--app-border)' }}
                 >
                   <td style={cellBody}>{row.season ?? '—'}</td>
                   <td style={cellBody}>
                     {row.polePosition ?? '—'}
                     {row.poleConstructor ? (
-                      <span style={{ color: '#7d8693' }}>
+                      <span style={{ color: 'var(--app-subtle)' }}>
                         {' '}
                         ({row.poleConstructor})
                       </span>
@@ -258,7 +261,7 @@ function RaceInfoCard({ result }: { result?: RaceInfoResult }) {
                   <td style={cellBody}>
                     {row.winner ?? '—'}
                     {row.constructor ? (
-                      <span style={{ color: '#7d8693' }}>
+                      <span style={{ color: 'var(--app-subtle)' }}>
                         {' '}
                         ({row.constructor})
                       </span>
@@ -280,9 +283,9 @@ function RaceInfoCard({ result }: { result?: RaceInfoResult }) {
         <div
           style={{
             padding: '12px 16px',
-            background: '#fafbfd',
-            borderTop: '1px solid #eef0f5',
-            color: '#444',
+            background: 'var(--app-surface-subtle)',
+            borderTop: '1px solid var(--app-border)',
+            color: 'var(--app-muted)',
             whiteSpace: 'pre-wrap',
           }}
         >
@@ -290,7 +293,7 @@ function RaceInfoCard({ result }: { result?: RaceInfoResult }) {
             style={{
               fontWeight: 700,
               marginBottom: 6,
-              color: '#222',
+              color: 'var(--app-text)',
             }}
           >
             Track history
@@ -307,8 +310,8 @@ const cellHeader: React.CSSProperties = {
   fontWeight: 600,
   fontSize: 11,
   textTransform: 'uppercase',
-  color: '#666',
-  letterSpacing: 0.4,
+  color: 'var(--app-muted)',
+  letterSpacing: 0,
 };
 
 const cellBody: React.CSSProperties = {
@@ -326,7 +329,7 @@ export function useRaceInfoAction() {
     render: ({ status, result }) => {
       if (status === 'inProgress' || status === 'executing') {
         return (
-          <div style={{ padding: 10, color: '#666' }}>
+          <div style={{ padding: 10, color: 'var(--app-muted)' }}>
             Loading next race info…
           </div>
         );

--- a/web/src/components/SignedInBadge.tsx
+++ b/web/src/components/SignedInBadge.tsx
@@ -30,7 +30,7 @@ export function SignedInBadge() {
         alignItems: 'center',
         gap: 10,
         fontSize: 13,
-        color: '#37404f',
+        color: 'var(--app-control-text)',
       }}
     >
       {claims.picture ? (
@@ -51,9 +51,9 @@ export function SignedInBadge() {
           padding: '6px 10px',
           fontSize: 12,
           fontWeight: 600,
-          color: '#37404f',
-          background: '#f1f3f7',
-          border: '1px solid #d8dde6',
+          color: 'var(--app-control-text)',
+          background: 'var(--app-control-bg)',
+          border: '1px solid var(--app-control-border)',
           borderRadius: 6,
           cursor: 'pointer',
         }}

--- a/web/src/components/ThemeToggle.tsx
+++ b/web/src/components/ThemeToggle.tsx
@@ -1,0 +1,24 @@
+import type { ThemeMode } from '../theme';
+
+export function ThemeToggle({
+  theme,
+  onToggle,
+}: {
+  theme: ThemeMode;
+  onToggle: () => void;
+}) {
+  const isDark = theme === 'dark';
+
+  return (
+    <button
+      type="button"
+      className="theme-toggle"
+      onClick={onToggle}
+      aria-label={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
+      aria-pressed={isDark}
+      title={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
+    >
+      <span className="theme-toggle__icon" aria-hidden="true" />
+    </button>
+  );
+}

--- a/web/src/components/ToolErrorFallback.tsx
+++ b/web/src/components/ToolErrorFallback.tsx
@@ -39,10 +39,10 @@ export function ToolErrorFallback({ result }: { result: ToolErrorResult }) {
       role="alert"
       style={{
         padding: '12px 14px',
-        background: '#fff1f1',
-        border: '1px solid #f3c2c2',
+        background: 'var(--app-danger-surface)',
+        border: '1px solid var(--app-danger-border)',
         borderRadius: 8,
-        color: '#7a1f1f',
+        color: 'var(--app-danger-text)',
         margin: '6px 0',
       }}
     >
@@ -51,7 +51,13 @@ export function ToolErrorFallback({ result }: { result: ToolErrorResult }) {
       </div>
       <div style={{ fontSize: 13, lineHeight: 1.4 }}>{message}</div>
       {(result.tool || result.errorId) && (
-        <details style={{ marginTop: 8, fontSize: 11, color: '#a04545' }}>
+        <details
+          style={{
+            marginTop: 8,
+            fontSize: 11,
+            color: 'var(--app-danger-text)',
+          }}
+        >
           <summary style={{ cursor: 'pointer', userSelect: 'none' }}>
             Support details
           </summary>

--- a/web/src/components/UserTeamsList.tsx
+++ b/web/src/components/UserTeamsList.tsx
@@ -28,8 +28,8 @@ function chipBadge(chip: string | null) {
         borderRadius: 999,
         fontSize: 11,
         fontWeight: 600,
-        background: '#fff4d6',
-        color: '#7a4a00',
+        background: 'var(--app-warning-surface)',
+        color: 'var(--app-warning-text)',
         marginLeft: 6,
       }}
     >
@@ -42,9 +42,9 @@ function UserTeamsList({ result }: { result?: ListUserTeamsResult }) {
   const teams = result?.teams ?? [];
   if (teams.length === 0) {
     return (
-      <div style={{ padding: 12, color: '#555' }}>
-        No tracked teams. Run <code>/follow_league</code> + <code>/teams_tracker</code> in the
-        Telegram bot first.
+      <div style={{ padding: 12, color: 'var(--app-muted)' }}>
+        No tracked teams. Run <code>/follow_league</code> +{' '}
+        <code>/teams_tracker</code> in the Telegram bot first.
       </div>
     );
   }
@@ -62,21 +62,25 @@ function UserTeamsList({ result }: { result?: ListUserTeamsResult }) {
         <div
           key={team.teamId}
           style={{
-            border: team.isSelected ? '2px solid #2c6fd1' : '1px solid #e2e6ee',
+            border: team.isSelected
+              ? '2px solid var(--app-primary)'
+              : '1px solid var(--app-border)',
             borderRadius: 8,
             padding: '10px 12px',
-            background: '#fff',
+            background: 'var(--app-surface)',
             fontSize: 13,
           }}
         >
-          <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
+          <div
+            style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}
+          >
             <strong style={{ fontSize: 15 }}>{team.teamName}</strong>
             {team.isSelected ? (
               <span
                 style={{
                   marginLeft: 6,
                   fontSize: 11,
-                  color: '#1c4f99',
+                  color: 'var(--app-primary)',
                   fontWeight: 600,
                 }}
               >
@@ -85,25 +89,39 @@ function UserTeamsList({ result }: { result?: ListUserTeamsResult }) {
             ) : null}
             {chipBadge(team.chip)}
           </div>
-          <div style={{ color: '#666', fontSize: 11, marginTop: 2 }}>
+          <div
+            style={{ color: 'var(--app-muted)', fontSize: 11, marginTop: 2 }}
+          >
             id: <code>{team.teamId}</code>
             {team.isLeague ? ' · league' : ' · screenshot'}
           </div>
-          <div style={{ marginTop: 6, color: '#444' }}>
+          <div style={{ marginTop: 6, color: 'var(--app-muted)' }}>
             <div>
-              <span style={{ color: '#888', fontSize: 11 }}>Drivers: </span>
+              <span style={{ color: 'var(--app-subtle)', fontSize: 11 }}>
+                Drivers:{' '}
+              </span>
               {team.drivers.length > 0 ? team.drivers.join(', ') : '—'}
             </div>
             <div>
-              <span style={{ color: '#888', fontSize: 11 }}>Constructors: </span>
-              {team.constructors.length > 0 ? team.constructors.join(', ') : '—'}
+              <span style={{ color: 'var(--app-subtle)', fontSize: 11 }}>
+                Constructors:{' '}
+              </span>
+              {team.constructors.length > 0
+                ? team.constructors.join(', ')
+                : '—'}
             </div>
             <div>
-              <span style={{ color: '#888', fontSize: 11 }}>Boost: </span>
+              <span style={{ color: 'var(--app-subtle)', fontSize: 11 }}>
+                Boost:{' '}
+              </span>
               {team.boost ?? '—'}
             </div>
-            <div style={{ color: '#666', fontSize: 12, marginTop: 4 }}>
-              {team.freeTransfers != null ? `${team.freeTransfers} free transfers` : ''}
+            <div
+              style={{ color: 'var(--app-muted)', fontSize: 12, marginTop: 4 }}
+            >
+              {team.freeTransfers != null
+                ? `${team.freeTransfers} free transfers`
+                : ''}
               {team.costCapRemaining != null
                 ? ` · ${team.costCapRemaining.toFixed?.(1) ?? team.costCapRemaining} cap left`
                 : ''}
@@ -125,7 +143,7 @@ export function useUserTeamsAction() {
     render: ({ status, result }) => {
       if (status === 'inProgress' || status === 'executing') {
         return (
-          <div style={{ padding: 10, color: '#666' }}>
+          <div style={{ padding: 10, color: 'var(--app-muted)' }}>
             Loading your teams…
           </div>
         );
@@ -134,7 +152,9 @@ export function useUserTeamsAction() {
       if (isToolErrorResult(parsed)) {
         return <ToolErrorFallback result={parsed} />;
       }
-      return <UserTeamsList result={parsed as ListUserTeamsResult | undefined} />;
+      return (
+        <UserTeamsList result={parsed as ListUserTeamsResult | undefined} />
+      );
     },
   });
 }

--- a/web/src/components/WeatherForecast.tsx
+++ b/web/src/components/WeatherForecast.tsx
@@ -60,7 +60,7 @@ function rainEmoji(precipitation?: number): string {
 function WeatherForecast({ result }: { result?: WeatherResult }) {
   if (!result || result.status === 'unavailable') {
     return (
-      <div style={{ padding: 12, color: '#555' }}>
+      <div style={{ padding: 12, color: 'var(--app-muted)' }}>
         Weather forecast isn't available right now.
       </div>
     );
@@ -70,7 +70,7 @@ function WeatherForecast({ result }: { result?: WeatherResult }) {
 
   if (sessions.length === 0) {
     return (
-      <div style={{ padding: 12, color: '#555' }}>
+      <div style={{ padding: 12, color: 'var(--app-muted)' }}>
         No upcoming sessions to forecast.
       </div>
     );
@@ -80,9 +80,9 @@ function WeatherForecast({ result }: { result?: WeatherResult }) {
     <div
       style={{
         margin: '8px 0',
-        border: '1px solid #e2e6ee',
+        border: '1px solid var(--app-border)',
         borderRadius: 10,
-        background: '#fff',
+        background: 'var(--app-surface)',
         overflow: 'hidden',
         fontSize: 13,
       }}
@@ -90,15 +90,15 @@ function WeatherForecast({ result }: { result?: WeatherResult }) {
       <div
         style={{
           padding: '12px 16px',
-          background: '#f8fafc',
-          borderBottom: '1px solid #e2e6ee',
+          background: 'var(--app-surface-muted)',
+          borderBottom: '1px solid var(--app-border)',
         }}
       >
         <div style={{ fontWeight: 700, fontSize: 15 }}>
           Weather forecast — {result.raceName ?? 'Next race'}
         </div>
         {result.location ? (
-          <div style={{ color: '#5a6471', marginTop: 2 }}>
+          <div style={{ color: 'var(--app-muted)', marginTop: 2 }}>
             {result.location.locality}, {result.location.country}
             {result.circuitName ? ` · ${result.circuitName}` : ''}
           </div>
@@ -110,7 +110,7 @@ function WeatherForecast({ result }: { result?: WeatherResult }) {
           key={session.key}
           style={{
             padding: '12px 16px',
-            borderTop: '1px solid #f0f2f7',
+            borderTop: '1px solid var(--app-border)',
           }}
         >
           <div
@@ -124,12 +124,18 @@ function WeatherForecast({ result }: { result?: WeatherResult }) {
             }}
           >
             <span>{session.label}</span>
-            <span style={{ fontSize: 12, color: '#5a6471', fontWeight: 500 }}>
+            <span
+              style={{
+                fontSize: 12,
+                color: 'var(--app-muted)',
+                fontWeight: 500,
+              }}
+            >
               {formatSessionStart(session.startsAt)}
             </span>
           </div>
           {session.hours.length === 0 ? (
-            <div style={{ color: '#888' }}>(already underway)</div>
+            <div style={{ color: 'var(--app-subtle)' }}>(already underway)</div>
           ) : (
             <div
               style={{
@@ -144,16 +150,16 @@ function WeatherForecast({ result }: { result?: WeatherResult }) {
                   <div
                     key={hour}
                     style={{
-                      border: '1px solid #eef0f5',
+                      border: '1px solid var(--app-border)',
                       borderRadius: 8,
                       padding: '8px 10px',
-                      background: '#fafbfd',
+                      background: 'var(--app-surface-subtle)',
                     }}
                   >
                     <div
                       style={{
                         fontSize: 12,
-                        color: '#5a6471',
+                        color: 'var(--app-muted)',
                         marginBottom: 4,
                       }}
                     >
@@ -165,16 +171,16 @@ function WeatherForecast({ result }: { result?: WeatherResult }) {
                     <div style={{ fontWeight: 700 }}>
                       {f.temperature ?? '—'}°C
                     </div>
-                    <div style={{ color: '#5a6471', fontSize: 12 }}>
+                    <div style={{ color: 'var(--app-muted)', fontSize: 12 }}>
                       🌧 {f.precipitation ?? 0}%
                       {typeof f.precipitation_mm === 'number'
                         ? ` (${f.precipitation_mm}mm)`
                         : ''}
                     </div>
-                    <div style={{ color: '#5a6471', fontSize: 12 }}>
+                    <div style={{ color: 'var(--app-muted)', fontSize: 12 }}>
                       💨 {f.wind ?? '—'} km/h
                     </div>
-                    <div style={{ color: '#5a6471', fontSize: 12 }}>
+                    <div style={{ color: 'var(--app-muted)', fontSize: 12 }}>
                       💧 {f.humidity ?? '—'}% · ☁️ {f.cloudCover ?? '—'}%
                     </div>
                   </div>
@@ -198,7 +204,7 @@ export function useWeatherForecastAction() {
     render: ({ status, result }) => {
       if (status === 'inProgress' || status === 'executing') {
         return (
-          <div style={{ padding: 10, color: '#666' }}>
+          <div style={{ padding: 10, color: 'var(--app-muted)' }}>
             Fetching weather forecast…
           </div>
         );

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,8 +1,86 @@
 :root {
-  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  font-family:
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
   line-height: 1.5;
-  color: #1a1a1a;
-  background: #f6f7fb;
+  color: var(--app-text);
+  background: var(--app-bg);
+
+  --app-bg: #f6f7fb;
+  --app-surface: #ffffff;
+  --app-surface-muted: #f8fafc;
+  --app-surface-subtle: #fafbfd;
+  --app-text: #1a1a1a;
+  --app-muted: #555;
+  --app-subtle: #7d8693;
+  --app-border: #e2e6ee;
+  --app-control-bg: #f1f3f7;
+  --app-control-text: #37404f;
+  --app-control-border: #d8dde6;
+  --app-primary: #1c4f99;
+  --app-primary-strong: #1c3d70;
+  --app-primary-contrast: #ffffff;
+  --app-primary-surface: #eef4ff;
+  --app-danger-surface: #fff4f4;
+  --app-danger-border: #f5c2c2;
+  --app-danger-text: #7a1f1f;
+  --app-warning-surface: #fff3c2;
+  --app-warning-text: #7a5a00;
+  --app-success-surface: #e6f4ea;
+  --app-success-text: #1e4d2b;
+  --app-highlight-surface: #fff8d6;
+  --app-deadline-bg: linear-gradient(
+    135deg,
+    #ffffff 0%,
+    #f3f7ff 60%,
+    #e8efff 100%
+  );
+  --app-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 4px 16px rgba(0, 0, 0, 0.04);
+}
+
+html[data-theme='dark'] {
+  --app-bg: #101318;
+  --app-surface: #171b22;
+  --app-surface-muted: #1e2430;
+  --app-surface-subtle: #202633;
+  --app-text: #f4f7fb;
+  --app-muted: #c7cfdb;
+  --app-subtle: #9aa6b8;
+  --app-border: #303847;
+  --app-control-bg: #222938;
+  --app-control-text: #edf2f9;
+  --app-control-border: #3a4557;
+  --app-primary: #8db8ff;
+  --app-primary-strong: #b7d2ff;
+  --app-primary-contrast: #101318;
+  --app-primary-surface: #1c3357;
+  --app-danger-surface: #3a1e24;
+  --app-danger-border: #81414a;
+  --app-danger-text: #ffb8bf;
+  --app-warning-surface: #3f3420;
+  --app-warning-text: #f4d178;
+  --app-success-surface: #193425;
+  --app-success-text: #9ee7b2;
+  --app-highlight-surface: #3d3520;
+  --app-deadline-bg: linear-gradient(
+    135deg,
+    #171b22 0%,
+    #1b2940 60%,
+    #20365e 100%
+  );
+  --app-shadow: 0 1px 3px rgba(0, 0, 0, 0.35), 0 10px 28px rgba(0, 0, 0, 0.3);
+
+  --copilot-kit-primary-color: #f4f7fb;
+  --copilot-kit-contrast-color: #101318;
+  --copilot-kit-background-color: #171b22;
+  --copilot-kit-input-background-color: #222938;
+  --copilot-kit-secondary-color: #171b22;
+  --copilot-kit-secondary-contrast-color: #f4f7fb;
+  --copilot-kit-separator-color: #303847;
+  --copilot-kit-muted-color: #3a4557;
 }
 
 * {
@@ -13,6 +91,7 @@ body {
   margin: 0;
   padding: 0;
   min-height: 100vh;
+  background: var(--app-bg);
 }
 
 #root {
@@ -35,12 +114,85 @@ body {
   margin: 0 0 16px;
   font-size: 22px;
   font-weight: 600;
+  color: var(--app-text);
 }
 
 .app-subheader {
   margin: 0 0 24px;
   font-size: 14px;
-  color: #555;
+  color: var(--app-muted);
+}
+
+.app-titlebar {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.app-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.theme-toggle {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid var(--app-control-border);
+  border-radius: 999px;
+  background: var(--app-control-bg);
+  color: var(--app-control-text);
+  cursor: pointer;
+  display: inline-grid;
+  place-items: center;
+  flex: 0 0 auto;
+}
+
+.theme-toggle:hover {
+  border-color: var(--app-primary);
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--app-primary);
+  outline-offset: 2px;
+}
+
+.theme-toggle__icon {
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  background: currentColor;
+  box-shadow: 0 0 0 2px currentColor;
+  transform: scale(0.68);
+}
+
+html[data-theme='light'] .theme-toggle__icon {
+  box-shadow:
+    0 -8px 0 -5px currentColor,
+    0 8px 0 -5px currentColor,
+    8px 0 0 -5px currentColor,
+    -8px 0 0 -5px currentColor,
+    6px 6px 0 -5px currentColor,
+    -6px -6px 0 -5px currentColor,
+    6px -6px 0 -5px currentColor,
+    -6px 6px 0 -5px currentColor;
+  transform: scale(0.86);
+}
+
+html[data-theme='dark'] .theme-toggle__icon {
+  background: transparent;
+  box-shadow: inset -4px -2px 0 0 currentColor;
+  transform: scale(1);
+}
+
+.login-theme-control {
+  position: absolute;
+  top: 24px;
+  right: 16px;
 }
 
 .chat-wrapper {
@@ -48,10 +200,22 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 0;
-  background: #ffffff;
+  background: var(--app-surface);
   border-radius: 12px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 4px 16px rgba(0, 0, 0, 0.04);
+  border: 1px solid var(--app-border);
+  box-shadow: var(--app-shadow);
   overflow: hidden;
+}
+
+@media (max-width: 640px) {
+  .app-titlebar {
+    flex-direction: column;
+  }
+
+  .app-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
 }
 
 .chat-wrapper .copilotKitMessage,
@@ -60,20 +224,28 @@ body {
   unicode-bidi: plaintext;
 }
 
-.chat-wrapper .copilotKitMessage[data-text-direction='rtl'] ul.copilotKitMarkdownElement,
-.chat-wrapper .copilotKitMessage[data-text-direction='rtl'] ol.copilotKitMarkdownElement {
+.chat-wrapper
+  .copilotKitMessage[data-text-direction='rtl']
+  ul.copilotKitMarkdownElement,
+.chat-wrapper
+  .copilotKitMessage[data-text-direction='rtl']
+  ol.copilotKitMarkdownElement {
   padding-left: 0;
   padding-right: 20px;
 }
 
-.chat-wrapper .copilotKitMessage[data-text-direction='rtl'] blockquote.copilotKitMarkdownElement {
+.chat-wrapper
+  .copilotKitMessage[data-text-direction='rtl']
+  blockquote.copilotKitMarkdownElement {
   border-left: 0;
   border-right: 2px solid rgb(142, 142, 160);
   padding-left: 0;
   padding-right: 10px;
 }
 
-.chat-wrapper .copilotKitMessage[data-text-direction='rtl'] .copilotKitMessageControls {
+.chat-wrapper
+  .copilotKitMessage[data-text-direction='rtl']
+  .copilotKitMessageControls {
   left: auto;
   right: 0;
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,7 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import { applyTheme, resolveInitialTheme } from './theme';
 import './index.css';
+
+applyTheme(resolveInitialTheme());
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/web/src/theme.test.ts
+++ b/web/src/theme.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import {
+  THEME_STORAGE_KEY,
+  applyTheme,
+  persistTheme,
+  resolveInitialTheme,
+} from './theme';
+
+afterEach(() => {
+  window.localStorage.clear();
+  document.documentElement.removeAttribute('data-theme');
+  document.body.removeAttribute('data-theme');
+  document.documentElement.classList.remove('dark');
+  document.body.classList.remove('dark');
+  document.documentElement.style.colorScheme = '';
+  vi.restoreAllMocks();
+});
+
+describe('theme preferences', () => {
+  test('uses stored theme before system preference', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+    vi.spyOn(window, 'matchMedia').mockReturnValue({
+      matches: false,
+    } as MediaQueryList);
+
+    expect(resolveInitialTheme()).toBe('dark');
+  });
+
+  test('applies dark theme to document roots', () => {
+    applyTheme('dark');
+
+    expect(document.documentElement.dataset.theme).toBe('dark');
+    expect(document.body.dataset.theme).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.body.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.style.colorScheme).toBe('dark');
+  });
+
+  test('persists explicit theme preference', () => {
+    persistTheme('light');
+
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('light');
+  });
+});

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -1,0 +1,44 @@
+export type ThemeMode = 'light' | 'dark';
+
+export const THEME_STORAGE_KEY = 'f1-fantazy-agent-theme';
+
+function isThemeMode(value: string | null): value is ThemeMode {
+  return value === 'light' || value === 'dark';
+}
+
+export function resolveInitialTheme(): ThemeMode {
+  if (typeof window === 'undefined') return 'light';
+
+  try {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+    if (isThemeMode(stored)) return stored;
+  } catch {
+    // Ignore storage failures; system preference is a safe fallback.
+  }
+
+  return window.matchMedia?.('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
+}
+
+export function persistTheme(theme: ThemeMode): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch {
+    // Theme persistence is non-critical.
+  }
+}
+
+export function applyTheme(theme: ThemeMode): void {
+  if (typeof document === 'undefined') return;
+
+  const targets = [document.documentElement, document.body].filter(Boolean);
+  for (const target of targets) {
+    target.dataset.theme = theme;
+    target.classList.toggle('dark', theme === 'dark');
+  }
+
+  document.documentElement.style.colorScheme = theme;
+}


### PR DESCRIPTION
## Summary

Adds dark theme support to the Vite/React web chat app.

- Adds persisted theme detection and application using `localStorage` plus system color-scheme preference fallback.
- Adds an accessible icon-only theme toggle in authenticated, unauthenticated, and login states.
- Introduces shared light/dark CSS tokens and CopilotKit variable overrides.
- Converts web chat tool cards, tables, auth screens, and controls from fixed light colors to theme variables.
- Adds unit coverage for theme resolution, persistence, and document application.

## Impact

Users can switch between light and dark themes, and the app preserves their choice across reloads. Tool-rendered UI now follows the selected theme instead of staying light inside the chat surface.

## Validation

- `npm test -- --run` in `web/`: 20 tests passed.
- `npm run build` in `web/`: passed.
- Commit hook: root lint completed with existing warnings only, and Jest coverage passed: 91 suites / 963 tests.
- Chrome CDP validation against local Vite app verified light/dark DOM state, persistence, toggle ARIA attributes, and computed theme colors.